### PR TITLE
Fix boundary direction handling and min-floor initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-01-07
+
+### Fixed
+- Initialize the simulation state at the configured minimum floor
+- Normalize direction to idle when movement is requested at top or bottom floors
+- Added tests for non-zero minimum floor initialization and boundary direction behavior
+
 ## [0.1.0] - 2026-01-06
 
 ### Added
@@ -30,4 +37,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.1.1]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.1
 [0.1.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.1.0**
+Current version: **0.1.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Iteration 1 Scope
 
-The current iteration (v0.1.0) implements:
+The current iteration (v0.1.1) implements:
 - **Single lift simulation** operating between configurable floor ranges
 - **Tick-based simulation engine** that advances time in discrete steps
 - **NaiveLiftController** - A simple controller that services the nearest pending request
@@ -64,7 +64,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.1.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.1.1.jar`.
 
 ## Running the Simulation
 
@@ -77,7 +77,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.1.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.1.1.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/SimulationEngine.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationEngine.java
@@ -21,8 +21,8 @@ public class SimulationEngine {
         this.minFloor = minFloor;
         this.maxFloor = maxFloor;
         this.currentTick = 0;
-        // Initialize lift at ground floor, idle, doors closed
-        this.currentState = new LiftState(0, Direction.IDLE, DoorState.CLOSED);
+        // Initialize lift at minimum floor, idle, doors closed
+        this.currentState = new LiftState(minFloor, Direction.IDLE, DoorState.CLOSED);
     }
 
     /**
@@ -50,15 +50,23 @@ public class SimulationEngine {
 
         switch (action) {
             case MOVE_UP:
-                if (state.getDoorState() == DoorState.CLOSED && newFloor < maxFloor) {
-                    newFloor++;
-                    newDirection = Direction.UP;
+                if (state.getDoorState() == DoorState.CLOSED) {
+                    if (newFloor < maxFloor) {
+                        newFloor++;
+                        newDirection = Direction.UP;
+                    } else if (newFloor == maxFloor) {
+                        newDirection = Direction.IDLE;
+                    }
                 }
                 break;
             case MOVE_DOWN:
-                if (state.getDoorState() == DoorState.CLOSED && newFloor > minFloor) {
-                    newFloor--;
-                    newDirection = Direction.DOWN;
+                if (state.getDoorState() == DoorState.CLOSED) {
+                    if (newFloor > minFloor) {
+                        newFloor--;
+                        newDirection = Direction.DOWN;
+                    } else if (newFloor == minFloor) {
+                        newDirection = Direction.IDLE;
+                    }
                 }
                 break;
             case OPEN_DOOR:

--- a/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
+++ b/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
@@ -32,6 +32,19 @@ public class SimulationEngineTest {
     }
 
     @Test
+    public void testInitializesAtMinFloor() {
+        SimulationEngine engine = new SimulationEngine(
+                new FixedActionController(Action.IDLE),
+                2,
+                6
+        );
+
+        assertEquals(2, engine.getCurrentState().getFloor());
+        assertEquals(Direction.IDLE, engine.getCurrentState().getDirection());
+        assertEquals(DoorState.CLOSED, engine.getCurrentState().getDoorState());
+    }
+
+    @Test
     public void testMoveUpIncrementsFloorByOne() {
         // Given: lift at floor 0 with doors closed
         SimulationEngine engine = new SimulationEngine(
@@ -68,6 +81,7 @@ public class SimulationEngineTest {
 
         // Then: floor should remain at top floor
         assertEquals(5, engine.getCurrentState().getFloor());
+        assertEquals(Direction.IDLE, engine.getCurrentState().getDirection());
     }
 
     @Test
@@ -165,6 +179,37 @@ public class SimulationEngineTest {
 
         // Then: floor should remain at ground floor
         assertEquals(0, engine.getCurrentState().getFloor());
+        assertEquals(Direction.IDLE, engine.getCurrentState().getDirection());
+    }
+
+    @Test
+    public void testMoveDownAtBottomFloorSetsDirectionIdle() {
+        LiftController moveUpThenDownPastMin = new LiftController() {
+            private int tickCount = 0;
+
+            @Override
+            public Action decideNextAction(LiftState state, long tick) {
+                if (tickCount == 0) {
+                    tickCount++;
+                    return Action.MOVE_UP;
+                }
+                return Action.MOVE_DOWN;
+            }
+        };
+
+        SimulationEngine engine = new SimulationEngine(moveUpThenDownPastMin, 0, 3);
+
+        engine.tick();
+        assertEquals(1, engine.getCurrentState().getFloor());
+        assertEquals(Direction.UP, engine.getCurrentState().getDirection());
+
+        engine.tick();
+        assertEquals(0, engine.getCurrentState().getFloor());
+        assertEquals(Direction.DOWN, engine.getCurrentState().getDirection());
+
+        engine.tick();
+        assertEquals(0, engine.getCurrentState().getFloor());
+        assertEquals(Direction.IDLE, engine.getCurrentState().getDirection());
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Ensure the engine starts the lift at the configured minimum floor rather than a hard-coded ground floor so non-zero floor ranges behave correctly.
- Prevent the lift from retaining an `UP` or `DOWN` direction when a movement is requested at the top or bottom boundary respectively by normalizing to `Direction.IDLE`.
- Add coverage for the corrected behaviors to avoid regressions.

### Description
- Initialize `currentState` with `minFloor` in `SimulationEngine` and update the comment to reflect the change.
- Normalize direction inside `applyAction` so `MOVE_UP` at `maxFloor` and `MOVE_DOWN` at `minFloor` set the direction to `Direction.IDLE` instead of leaving `UP`/`DOWN`.
- Add tests in `src/test/java/com/liftsimulator/engine/SimulationEngineTest.java` (`testInitializesAtMinFloor`, `testMoveDownAtBottomFloorSetsDirectionIdle`) and adjust assertions for boundary direction behavior.
- Bump project version to `0.1.1` and update `pom.xml`, `README.md`, and `CHANGELOG.md` with the new version and a short changelog entry.

### Testing
- Added unit tests in `SimulationEngineTest` covering non-zero `minFloor` initialization and boundary direction normalization (tests present in the tree).
- Attempted to run `mvn test`, but the build failed due to Maven plugin resolution being blocked with a 403 from `repo.maven.apache.org`, so automated tests could not be fully executed here.
- Local compilation and unit test execution should be possible once network access to Maven Central is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c94462a348325b0ca194a9178d67a)