### PR TITLE
Make nearest-floor selection deterministic with lower-floor tie-breaker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-01-08
+
+### Fixed
+- Make nearest-floor selection deterministic with a tie-breaker for equidistant requests
+- Added tests covering deterministic behavior for equidistant requests
+
 ## [0.1.1] - 2026-01-07
 
 ### Fixed
@@ -37,5 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.1.2]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.2
 [0.1.1]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.1
 [0.1.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.1.1**
+Current version: **0.1.2**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Iteration 1 Scope
 
-The current iteration (v0.1.1) implements:
+The current iteration (v0.1.2) implements:
 - **Single lift simulation** operating between configurable floor ranges
 - **Tick-based simulation engine** that advances time in discrete steps
 - **NaiveLiftController** - A simple controller that services the nearest pending request
@@ -64,7 +64,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.1.1.jar`.
+The packaged JAR will be in `target/lift-simulator-0.1.2.jar`.
 
 ## Running the Simulation
 
@@ -77,7 +77,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.1.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.1.2.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
+++ b/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
@@ -9,6 +9,7 @@ import com.liftsimulator.domain.LiftState;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * A naive lift controller that implements basic scheduling logic.
@@ -76,7 +77,7 @@ public class NaiveLiftController implements LiftController {
      * @return the nearest requested floor, or empty if no requests
      */
     private Optional<Integer> findNearestRequestedFloor(int currentFloor) {
-        Set<Integer> requestedFloors = new HashSet<>();
+        Set<Integer> requestedFloors = new TreeSet<>();
 
         // Collect all requested floors from car calls
         carCalls.forEach(call -> requestedFloors.add(call.destinationFloor()));
@@ -89,7 +90,10 @@ public class NaiveLiftController implements LiftController {
                 .min((f1, f2) -> {
                     int dist1 = Math.abs(f1 - currentFloor);
                     int dist2 = Math.abs(f2 - currentFloor);
-                    return Integer.compare(dist1, dist2);
+                    if (dist1 != dist2) {
+                        return Integer.compare(dist1, dist2);
+                    }
+                    return Integer.compare(f1, f2);
                 });
     }
 

--- a/src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java
+++ b/src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java
@@ -137,6 +137,34 @@ public class NaiveLiftControllerTest {
     }
 
     @Test
+    public void testTieBreakerPrefersLowerFloorForEquidistantCarCalls() {
+        // Add equidistant requests around the current floor
+        controller.addCarCall(new CarCall(1));
+        controller.addCarCall(new CarCall(5));
+
+        // Lift is at floor 3 with doors closed
+        LiftState state = new LiftState(3, Direction.IDLE, DoorState.CLOSED);
+
+        // Floors 1 and 5 are both distance 2; should prefer lower floor (1)
+        Action action = controller.decideNextAction(state, 0);
+        assertEquals(Action.MOVE_DOWN, action);
+    }
+
+    @Test
+    public void testTieBreakerPrefersLowerFloorForEquidistantMixedCalls() {
+        // Add equidistant mixed requests around the current floor
+        controller.addCarCall(new CarCall(2));
+        controller.addHallCall(new HallCall(6, Direction.UP));
+
+        // Lift is at floor 4 with doors closed
+        LiftState state = new LiftState(4, Direction.IDLE, DoorState.CLOSED);
+
+        // Floors 2 and 6 are both distance 2; should prefer lower floor (2)
+        Action action = controller.decideNextAction(state, 0);
+        assertEquals(Action.MOVE_DOWN, action);
+    }
+
+    @Test
     public void testRequestsClearedWhenServiced() {
         // Add a car call to floor 2
         controller.addCarCall(new CarCall(2));


### PR DESCRIPTION
### Motivation
- Replace nondeterministic set-based selection to ensure repeatable nearest-floor decisions when multiple requests are equidistant.
- Provide a clear tie-breaker to avoid flakiness in scheduling and tests.
- Bump project version and documentation to reflect the change.

### Description
- Change `findNearestRequestedFloor` to collect floors into a `TreeSet` and use an explicit comparator that prefers smaller distance and on ties prefers the lower floor (`TreeSet` / explicit compare logic). 
- Implemented tie-breaker by comparing distances and returning `Integer.compare(f1, f2)` when distances are equal in `NaiveLiftController#findNearestRequestedFloor`.
- Added deterministic unit tests in `src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java` covering equidistant car and mixed calls.
- Updated `pom.xml`, `CHANGELOG.md`, and `README.md` to bump version to `0.1.2` and document the fix.

### Testing
- Added unit tests: `testTieBreakerPrefersLowerFloorForEquidistantCarCalls` and `testTieBreakerPrefersLowerFloorForEquidistantMixedCalls` in `NaiveLiftControllerTest` (not yet validated by CI here).
- Ran `mvn test` locally as an automated verification step which failed during build setup due to Maven plugin download being blocked with a `403 Forbidden` from central, so tests did not complete successfully.
- No other automated test failures were observed prior to the plugin download issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9a0bee948325aa753702a45cf50f)