### PR TITLE
Use enum comparison for door state in demo and bump version to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2026-01-09
+
+### Fixed
+- Use enum comparison for door state checks in the demo output
+
 ## [0.1.2] - 2026-01-08
 
 ### Fixed
@@ -43,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.1.3]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.3
 [0.1.2]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.2
 [0.1.1]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.1
 [0.1.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.1.2**
+Current version: **0.1.3**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Iteration 1 Scope
 
-The current iteration (v0.1.2) implements:
+The current iteration (v0.1.3) implements:
 - **Single lift simulation** operating between configurable floor ranges
 - **Tick-based simulation engine** that advances time in discrete steps
 - **NaiveLiftController** - A simple controller that services the nearest pending request
@@ -64,7 +64,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.1.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.1.3.jar`.
 
 ## Running the Simulation
 
@@ -77,7 +77,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.1.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.1.3.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/src/main/java/com/liftsimulator/Main.java
+++ b/src/main/java/com/liftsimulator/Main.java
@@ -1,10 +1,10 @@
 package com.liftsimulator;
 
-import com.liftsimulator.engine.LiftController;
 import com.liftsimulator.engine.NaiveLiftController;
 import com.liftsimulator.engine.SimulationEngine;
 import com.liftsimulator.domain.CarCall;
 import com.liftsimulator.domain.Direction;
+import com.liftsimulator.domain.DoorState;
 import com.liftsimulator.domain.HallCall;
 import com.liftsimulator.domain.LiftState;
 
@@ -43,13 +43,13 @@ public class Main {
 
             // Add contextual notes
             if (i == 0) notes = "(Starting)";
-            if (state.getFloor() == 3 && state.getDoorState().toString().equals("OPEN")) {
+            if (state.getFloor() == 3 && state.getDoorState() == DoorState.OPEN) {
                 notes = "(Servicing floor 3)";
             }
-            if (state.getFloor() == 5 && state.getDoorState().toString().equals("OPEN")) {
+            if (state.getFloor() == 5 && state.getDoorState() == DoorState.OPEN) {
                 notes = "(Servicing floor 5)";
             }
-            if (state.getFloor() == 7 && state.getDoorState().toString().equals("OPEN")) {
+            if (state.getFloor() == 7 && state.getDoorState() == DoorState.OPEN) {
                 notes = "(Servicing floor 7)";
             }
 


### PR DESCRIPTION
### Motivation
- Replace fragile string-based door state checks with an enum comparison to improve type-safety and correctness in the demo output.
- Clean up imports and remove reliance on `toString()` for state checks.
- Follow the repository release process by updating `CHANGELOG.md` and `README.md` to reflect the fix and new version.

### Description
- Replace `state.getDoorState().toString().equals("OPEN")` with `state.getDoorState() == DoorState.OPEN` in `src/main/java/com/liftsimulator/Main.java` and add the `DoorState` import.
- Remove an unused import of `LiftController` from `Main.java` to keep imports clean.
- Add a new changelog entry for `0.1.3` documenting the fix in `CHANGELOG.md` and update release link reference accordingly.
- Bump version references and packaged JAR path from `0.1.2` to `0.1.3` in `README.md`.

### Testing
- No automated tests were executed as part of this change.
- `mvn compile` or `mvn test` were not run in this rollout, so compilation and test status are unverified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c9c2cbf7883258c96adb51ce8ba50)