### PR TITLE
Fix missing `LiftStatus` import in tests and bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-01-10
+
+### Fixed
+- Add missing `LiftStatus` import in `SimulationEngineTest` to restore test compilation
+
 ## [0.2.0] - 2026-01-06
 
 ### Added
@@ -77,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.2.1]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.1
 [0.2.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.0
 [0.1.3]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.3
 [0.1.2]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.1.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.2.0**
+Current version: **0.2.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.2.0) implements:
+The current version (v0.2.1) implements:
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state, all other properties are derived
 - **State transition validation** ensuring only valid state changes occur
@@ -69,7 +69,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.2.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.2.1.jar`.
 
 ## Running the Simulation
 
@@ -82,7 +82,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.2.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.2.1.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
+++ b/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
@@ -4,6 +4,7 @@ import com.liftsimulator.domain.Action;
 import com.liftsimulator.domain.Direction;
 import com.liftsimulator.domain.DoorState;
 import com.liftsimulator.domain.LiftState;
+import com.liftsimulator.domain.LiftStatus;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
### Motivation
- A compilation failure in unit tests was caused by a missing `LiftStatus` import in `SimulationEngineTest`, preventing `mvn test` from completing.
- The change is a small patch-level fix and should be reflected in project metadata via a SemVer patch bump.

### Description
- Added the missing `import com.liftsimulator.domain.LiftStatus;` to `src/test/java/com/liftsimulator/engine/SimulationEngineTest.java` to restore test compilation.
- Bumped the project version from `0.2.0` to `0.2.1` in `pom.xml` and updated references in `README.md` and packaging paths.
- Recorded the fix in `CHANGELOG.md` under a new `0.2.1` entry describing the compilation/test fix.

### Testing
- No automated tests were executed as part of this change (no `mvn test` run was performed).
- The change addresses the previously observed compilation error where `SimulationEngineTest` failed with "cannot find symbol: LiftStatus" during test compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cb4c78ba883258ecec2aaf3a15a27)