### PR TITLE
Show lift status in demo output and bump version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-01-10
+
+### Fixed
+- Include lift status in the NaiveLiftController demo output so transitional states are visible
+
 ## [0.2.2] - 2026-01-10
 
 ### Fixed
@@ -87,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.2.3]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.3
 [0.2.2]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.2
 [0.2.1]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.1
 [0.2.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.2.2**
+Current version: **0.2.3**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.2.2) implements:
+The current version (v0.2.3) implements:
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state, all other properties are derived
 - **State transition validation** ensuring only valid state changes occur
@@ -69,7 +69,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.2.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.2.3.jar`.
 
 ## Running the Simulation
 
@@ -82,7 +82,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.2.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.2.3.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/Main.java
+++ b/src/main/java/com/liftsimulator/Main.java
@@ -34,8 +34,9 @@ public class Main {
 
         // Run simulation for 40 ticks
         int tickCount = 40;
-        System.out.println(String.format("%-6s %-8s %-12s %-10s %-15s", "Tick", "Floor", "Direction", "Door", "Notes"));
-        System.out.println("------------------------------------------------------------------------");
+        System.out.println(String.format("%-6s %-8s %-15s %-12s %-10s %-15s",
+                "Tick", "Floor", "Status", "Direction", "Door", "Notes"));
+        System.out.println("----------------------------------------------------------------------------------");
 
         for (int i = 0; i < tickCount; i++) {
             LiftState state = engine.getCurrentState();
@@ -53,9 +54,10 @@ public class Main {
                 notes = "(Servicing floor 7)";
             }
 
-            System.out.println(String.format("%-6d %-8d %-12s %-10s %-15s",
+            System.out.println(String.format("%-6d %-8d %-15s %-12s %-10s %-15s",
                     engine.getCurrentTick(),
                     state.getFloor(),
+                    state.getStatus(),
                     state.getDirection(),
                     state.getDoorState(),
                     notes));


### PR DESCRIPTION
### Motivation
- The console demo did not display the `LiftStatus` (transitional states like `DOORS_OPENING`, `DOORS_CLOSING`, `MOVING_UP`), making it hard to observe state machine behavior.
- Update project version metadata and documentation to reflect the change and a new patch release.

### Description
- Updated `Main.java` to include a `Status` column and print `state.getStatus()` in the demo table and adjusted column formatting and separator.
- Bumped project version from `0.2.2` to `0.2.3` in `pom.xml` and updated README references to the new version and packaged JAR path.
- Added a short changelog entry in `CHANGELOG.md` for `0.2.3` documenting the demo output fix.
- Minor formatting adjustments to the demo table header and separator line for clearer console output.

### Testing
- No automated tests were executed as part of this change.
- Recommend running `mvn test` and `mvn clean package` to validate compilation and unit tests before release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cb8d658308325a41c907bb76af662)