### PR TITLE
Prevent moves during door closing and bump to 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2026-01-11
+
+### Fixed
+- Keep the naive controller idle while doors are closing to avoid invalid move attempts
+
+## [0.2.7] - 2026-01-11
+
+### Added
+- Print the running software version in the demo output
+
 ## [0.2.6] - 2026-01-11
 
 ### Fixed
@@ -108,6 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.2.8]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.8
+[0.2.7]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.7
 [0.2.6]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.6
 [0.2.5]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.5
 [0.2.4]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.2.6**
+Current version: **0.2.8**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.2.6) implements:
+The current version (v0.2.8) implements:
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state, all other properties are derived
 - **State transition validation** ensuring only valid state changes occur
@@ -69,7 +69,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.2.6.jar`.
+The packaged JAR will be in `target/lift-simulator-0.2.8.jar`.
 
 ## Running the Simulation
 
@@ -82,7 +82,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.2.6.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.2.8.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.2.6</version>
+    <version>0.2.8</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -37,6 +37,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/liftsimulator/Main.java
+++ b/src/main/java/com/liftsimulator/Main.java
@@ -7,6 +7,9 @@ import com.liftsimulator.domain.Direction;
 import com.liftsimulator.domain.DoorState;
 import com.liftsimulator.domain.HallCall;
 import com.liftsimulator.domain.LiftState;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 
 /**
  * Main entry point for the lift simulator.
@@ -15,6 +18,7 @@ import com.liftsimulator.domain.LiftState;
 public class Main {
     public static void main(String[] args) {
         System.out.println("=== Lift Simulator - NaiveLiftController Demo ===");
+        System.out.println("Version: " + resolveVersion());
         System.out.println("Starting simulation...\n");
 
         // Create naive controller and engine
@@ -67,5 +71,21 @@ public class Main {
 
         System.out.println("\nSimulation completed successfully!");
         System.out.println("All requests serviced using naive scheduling (nearest floor first).");
+    }
+
+    private static String resolveVersion() {
+        Properties properties = new Properties();
+        try (InputStream inputStream = Main.class.getResourceAsStream("/version.properties")) {
+            if (inputStream != null) {
+                properties.load(inputStream);
+                String version = properties.getProperty("version");
+                if (version != null && !version.isBlank()) {
+                    return version.trim();
+                }
+            }
+        } catch (IOException e) {
+            return "unknown";
+        }
+        return "unknown";
     }
 }

--- a/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
+++ b/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
@@ -112,6 +112,10 @@ public class NaiveLiftController implements LiftController {
             return Action.IDLE;
         }
 
+        if (currentStatus == LiftStatus.DOORS_CLOSING) {
+            return Action.IDLE;
+        }
+
         // If doors are open, manage dwell time
         if (doorState == DoorState.OPEN) {
             if (hasRequestForFloor(currentFloor)) {

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=@project.version@


### PR DESCRIPTION
### Motivation
- Prevent the controller from attempting to move the lift while doors are in the `DOORS_CLOSING` transitional state to avoid invalid state transitions and warnings. 
- Surface a single, build-filtered runtime version string in the demo output so packaged artifacts and demo agree. 
- Bump project metadata to follow SemVer for the fix and documentation updates. 

### Description
- Keep the naive controller idle while doors are closing by returning `Action.IDLE` when `currentStatus == LiftStatus.DOORS_CLOSING` in `NaiveLiftController.decideNextAction()`.
- Bump project version to `0.2.8` by updating `pom.xml` and propagate this change to `README.md` and `CHANGELOG.md`.
- Add runtime version support by enabling resource filtering in `pom.xml`, adding `src/main/resources/version.properties`, and adding `resolveVersion()` that reads `/version.properties` in `Main.java` to print the demo version.

### Testing
- No automated tests were executed as part of this change.
- Run `mvn test` locally or in CI to validate the build and unit tests if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc4e2563083258cae81dc44b5b282)