### PR TITLE
Use Java 17 release flag and set resource encodings; bump version to 0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.9] - 2026-01-06
+
+### Fixed
+- Configure Maven to use Java release targeting to avoid module path warnings
+- Explicitly set the resources plugin encoding for filtered properties files
+
 ## [0.2.8] - 2026-01-11
 
 ### Fixed
@@ -118,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.2.9]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.9
 [0.2.8]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.8
 [0.2.7]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.7
 [0.2.6]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.6

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.2.8**
+Current version: **0.2.9**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.2.8) implements:
+The current version (v0.2.9) implements:
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state, all other properties are derived
 - **State transition validation** ensuring only valid state changes occur
@@ -69,7 +69,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.2.8.jar`.
+The packaged JAR will be in `target/lift-simulator-0.2.9.jar`.
 
 ## Running the Simulation
 
@@ -82,7 +82,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.2.8.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.2.9.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.2.8</version>
+    <version>0.2.9</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -15,8 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <junit.version>5.10.1</junit.version>
     </properties>
 
@@ -46,11 +45,19 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <release>${maven.compiler.release}</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Motivation
- Fix Maven compile warning about system modules when using `-source 17` by using the Java `--release` target instead. 
- Eliminate the resources plugin warning by explicitly setting encodings for filtered properties files. 
- Keep project metadata consistent by bumping the project version to `0.2.9`. 
- Update documentation to reflect the new version and packaging artifact name.

### Description
- Updated `pom.xml` to replace `maven.compiler.source`/`maven.compiler.target` with `maven.compiler.release` and configured the `maven-compiler-plugin` to use `<release>${maven.compiler.release}</release>` to produce JDK 17-compatible class files. 
- Added an explicit `maven-resources-plugin` declaration and set `encoding` and `propertiesEncoding` to `${project.build.sourceEncoding}` to ensure filtered properties files are copied with the correct encoding. 
- Bumped project `version` in `pom.xml` to `0.2.9`. 
- Updated `README.md` and `CHANGELOG.md` to reflect the new version and added a short changelog entry describing the fix.

### Testing
- No automated tests were run as part of this change. 
- Changes were committed and staged; no test execution was performed. 
- Suggested verification: run `mvn -X clean compile` on a JDK 17 environment to confirm the previous warnings are resolved. 
- Suggested follow-up: run `mvn test` and build pipelines to validate on CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc7c96d8c8325a88263b148bb5653)