### PR TITLE
Add SimulationClock, tick-based timing, docs, and deterministic regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-01-12
+
+### Added
+- Introduced a deterministic simulation clock to manage tick progression
+- Added configurable travel and door transition durations to model time per floor
+- Expanded unit tests to validate tick-based movement and door timing
+- Added a deterministic simulation regression test for fixed inputs
+
+### Changed
+- Movement and door transitions now consume configured ticks before completing
+
 ## [0.2.9] - 2026-01-06
 
 ### Fixed
@@ -124,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.3.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.3.0
 [0.2.9]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.9
 [0.2.8]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.8
 [0.2.7]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.2.7

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.2.9**
+Current version: **0.3.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,13 +20,15 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.2.9) implements:
+The current version (v0.3.0) implements:
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state, all other properties are derived
 - **State transition validation** ensuring only valid state changes occur
 - **Symmetric door behavior**: Both opening and closing are modeled as transitional states
 - **Single lift simulation** operating between configurable floor ranges
 - **Tick-based simulation engine** that advances time in discrete steps
+- **Simulation clock** powering deterministic tick progression
+- **Configurable travel and door transition durations** to model time per floor and door cycles
 - **NaiveLiftController** - A simple controller that services the nearest pending request
 - **Console output** displaying tick-by-tick lift state (floor, direction, door state, status)
 - **Basic request types**: Car calls (from inside the lift) and hall calls (from a floor)
@@ -69,7 +71,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.2.9.jar`.
+The packaged JAR will be in `target/lift-simulator-0.3.0.jar`.
 
 ## Running the Simulation
 
@@ -82,10 +84,26 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.2.9.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.3.0.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
+
+## Configuring Tick Timing
+
+You can model travel and door timing by using the extended `SimulationEngine` constructor:
+
+```java
+SimulationEngine engine = new SimulationEngine(
+    controller,
+    0,
+    10,
+    3, // travelTicksPerFloor
+    2  // doorTransitionTicks
+);
+```
+
+Travel ticks specify how many ticks it takes to move one floor. Door transition ticks apply to opening and closing.
 
 ## Running Tests
 
@@ -159,6 +177,7 @@ src/
 │       ├── LiftController.java            # Controller interface
 │       ├── NaiveLiftController.java       # Simple nearest-floor controller
 │       ├── SimpleLiftController.java      # Alternative basic controller
+│       ├── SimulationClock.java           # Deterministic simulation clock
 │       ├── SimulationEngine.java          # Tick-based simulation engine
 │       └── StateTransitionValidator.java  # State machine validator
 └── test/java/com/liftsimulator/

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.2.9</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/SimulationClock.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationClock.java
@@ -1,0 +1,20 @@
+package com.liftsimulator.engine;
+
+/**
+ * Simple simulation clock that advances in deterministic ticks.
+ */
+public class SimulationClock {
+    private long currentTick;
+
+    public SimulationClock() {
+        this.currentTick = 0;
+    }
+
+    public void tick() {
+        currentTick++;
+    }
+
+    public long getCurrentTick() {
+        return currentTick;
+    }
+}

--- a/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
+++ b/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
@@ -436,4 +436,76 @@ public class SimulationEngineTest {
             assertEquals(DoorState.CLOSED, engine.getCurrentState().getDoorState());
         }
     }
+
+    @Test
+    public void testMoveUpHonorsTravelTicksPerFloor() {
+        SimulationEngine engine = new SimulationEngine(
+                new FixedActionController(Action.MOVE_UP),
+                0,
+                5,
+                3,
+                2
+        );
+
+        engine.tick();
+        assertEquals(0, engine.getCurrentState().getFloor());
+        assertEquals(LiftStatus.MOVING_UP, engine.getCurrentState().getStatus());
+
+        engine.tick();
+        assertEquals(0, engine.getCurrentState().getFloor());
+        assertEquals(LiftStatus.MOVING_UP, engine.getCurrentState().getStatus());
+
+        engine.tick();
+        assertEquals(1, engine.getCurrentState().getFloor());
+        assertEquals(LiftStatus.MOVING_UP, engine.getCurrentState().getStatus());
+    }
+
+    @Test
+    public void testDoorTransitionConsumesConfiguredTicks() {
+        SimulationEngine engine = new SimulationEngine(
+                new FixedActionController(Action.OPEN_DOOR),
+                0,
+                5,
+                1,
+                3
+        );
+
+        engine.tick();
+        assertEquals(LiftStatus.DOORS_OPENING, engine.getCurrentState().getStatus());
+        assertEquals(DoorState.CLOSED, engine.getCurrentState().getDoorState());
+
+        engine.tick();
+        assertEquals(LiftStatus.DOORS_OPENING, engine.getCurrentState().getStatus());
+
+        engine.tick();
+        assertEquals(LiftStatus.DOORS_OPEN, engine.getCurrentState().getStatus());
+        assertEquals(DoorState.OPEN, engine.getCurrentState().getDoorState());
+    }
+
+    @Test
+    public void testDeterministicResultsForFixedInputs() {
+        SimulationEngine firstRun = new SimulationEngine(
+                new FixedActionController(Action.MOVE_UP),
+                0,
+                5,
+                2,
+                2
+        );
+
+        SimulationEngine secondRun = new SimulationEngine(
+                new FixedActionController(Action.MOVE_UP),
+                0,
+                5,
+                2,
+                2
+        );
+
+        for (int i = 0; i < 6; i++) {
+            assertEquals(firstRun.getCurrentTick(), secondRun.getCurrentTick());
+            assertEquals(firstRun.getCurrentState().getFloor(), secondRun.getCurrentState().getFloor());
+            assertEquals(firstRun.getCurrentState().getStatus(), secondRun.getCurrentState().getStatus());
+            firstRun.tick();
+            secondRun.tick();
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

- Make simulation timing explicit and deterministic by centralizing tick progression in a clock (`SimulationClock`).
- Model realistic time costs by allowing configurable ticks per floor and ticks for door transitions (`travelTicksPerFloor`, `doorTransitionTicks`).
- Ensure deterministic, reproducible behavior for unit tests and regression checking of controller outputs.
- Bump project metadata to reflect the backward-compatible addition of timing features (`0.3.0`).

### Description

- Introduced `SimulationClock` and refactored `SimulationEngine` to use the clock and expose `getCurrentTick()` via the clock rather than an internal counter.
- Extended `SimulationEngine` with new constructors and configurable `travelTicksPerFloor` and `doorTransitionTicks`, plus tick counters (`movementTicksRemaining`, `doorTicksRemaining`) and tick-aware progressors (`advanceMovement()`, `advanceDoorTransition()`).
- Added unit tests to `SimulationEngineTest.java` (`testMoveUpHonorsTravelTicksPerFloor`, `testDoorTransitionConsumesConfiguredTicks`, and `testDeterministicResultsForFixedInputs`) and documented usage in `README.md` along with a changelog entry in `CHANGELOG.md` and version bump in `pom.xml` to `0.3.0`.

### Testing

- Added and updated unit tests in `src/test/java/com/liftsimulator/engine/SimulationEngineTest.java` to cover multi-tick movement, door transitions, and deterministic regression; no test execution was performed in this update.
- Automated test execution (`mvn test`) was not run as part of this rollout, so there are no new test run results to report.
- A prior attempt to run tests (from an earlier change) failed to complete due to external Maven plugin resolution errors (403 Forbidden) when resolving `maven-resources-plugin`.
- All source edits compiled locally during development edits (no compilation errors reported during commit steps).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cc94b51a48325b64055fe0ba8167f)