### PR TITLE
Fix cancel-while-moving test expectations and bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1] - 2026-01-06
+
+### Fixed
+- Align cancellation-while-moving integration test expectations with tick-per-floor movement behavior
+
 ## [0.7.0] - 2026-01-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.7.0**
+Current version: **0.7.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.7.0) implements:
+The current version (v0.7.1) implements:
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
 - **Request state tracking**: Every request has a unique ID and progresses through validated state transitions
@@ -78,7 +78,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.7.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.7.1.jar`.
 
 ## Running the Simulation
 
@@ -91,7 +91,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.7.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.7.1.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.7.0</version>
+    <version>0.7.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java
+++ b/src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java
@@ -603,12 +603,12 @@ public class NaiveLiftControllerTest {
         LiftRequest request = LiftRequest.carCall(5);
         controller.addRequest(request);
 
-        // Move 2 floors up
-        engine.tick(); // start moving
-        engine.tick(); // floor 1
+        // Move 3 floors up (movement completes in the same tick as MOVE_UP with ticksPerFloor=1)
+        engine.tick(); // start moving, reaches floor 1
         engine.tick(); // floor 2
+        engine.tick(); // floor 3
 
-        assertEquals(2, engine.getCurrentState().getFloor());
+        assertEquals(3, engine.getCurrentState().getFloor());
         assertEquals(LiftStatus.MOVING_UP, engine.getCurrentState().getStatus());
 
         // Cancel the request while lift is moving


### PR DESCRIPTION
### Motivation
- The cancel-while-moving integration test assumed movement completed one tick later, but with `travelTicksPerFloor=1` the lift advances a floor in the same tick as the `MOVE_UP` decision.  
- The test asserted the pre-cancellation floor incorrectly which caused a failing assertion.  
- Bump the project version and docs to reflect the small corrective change.  

### Description
- Adjusted `testIntegrationCancelWhileMoving` in `NaiveLiftControllerTest` to expect floor `3` after three `tick()` calls when `travelTicksPerFloor=1` and added a clarifying comment about same-tick movement.  
- Added a new `0.7.1` entry to `CHANGELOG.md` describing the fix.  
- Bumped the project version in `pom.xml` to `0.7.1` and updated `README.md` references and packaged JAR path to `0.7.1`.  

### Testing
- No automated tests were executed as part of this change.  
- The change is limited to test expectation and documentation/version metadata only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d4fbb62408325a0766cf56a61b173)