### PR TITLE
Normalize movement status and fix out-of-service door flow; bump version to v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-01-08
+
+### Fixed
+- Normalize movement status before controller decisions so doors can open immediately after arriving at a requested floor
+- Avoid reopening doors during out-of-service shutdown when doors are already open or opening
+
 ## [0.9.0] - 2026-01-08
 
 ### Added
@@ -255,6 +261,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Immutable state objects to avoid bugs from shared mutable state
 - Separated controller logic from simulation engine for flexibility
 
+[0.9.1]: https://github.com/manoj-bhaskaran/lift-simulator/compare/v0.9.0...v0.9.1
 [0.6.0]: https://github.com/manoj-bhaskaran/lift-simulator/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/manoj-bhaskaran/lift-simulator/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/manoj-bhaskaran/lift-simulator/releases/tag/v0.4.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.9.0**
+Current version: **0.9.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.9.0) implements:
+The current version (v0.9.1) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -80,7 +80,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.9.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.9.1.jar`.
 
 ## Running the Simulation
 
@@ -93,7 +93,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.9.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.9.1.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.9.0</version>
+    <version>0.9.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/SimulationEngine.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationEngine.java
@@ -109,6 +109,12 @@ public class SimulationEngine {
             return;
         }
 
+        if (movementTicksRemaining == 0 &&
+            (currentState.getStatus() == LiftStatus.MOVING_UP ||
+             currentState.getStatus() == LiftStatus.MOVING_DOWN)) {
+            currentState = new LiftState(currentState.getFloor(), LiftStatus.IDLE);
+        }
+
         // Ask controller for next action
         Action action = controller.decideNextAction(currentState, clock.getCurrentTick());
 
@@ -287,7 +293,8 @@ public class SimulationEngine {
 
         // Set pending flag to initiate graceful shutdown sequence
         outOfServicePending = true;
-        outOfServiceDoorsOpened = false;
+        outOfServiceDoorsOpened = currentState.getStatus() == LiftStatus.DOORS_OPEN ||
+            currentState.getStatus() == LiftStatus.DOORS_OPENING;
 
         // Determine target floor for graceful shutdown
         // If moving, complete movement to the next floor in direction of travel


### PR DESCRIPTION
### Motivation
- Fix integration test timing where the controller observed `MOVING_*` after movement completed and didn’t open doors, causing `OutOfServiceTest` failures.
- Ensure the graceful out-of-service sequence does not attempt to reopen doors when they are already open or in the process of opening.
- Keep controller/engine behavior consistent so arriving at a floor allows immediate door actions.
- Release a small patch version for this behavioral fix and document it.

### Description
- In `SimulationEngine.tick()` normalize a finished movement to `IDLE` when `movementTicksRemaining == 0` and status is `MOVING_UP`/`MOVING_DOWN` so the controller can decide to open doors immediately.
- In `SimulationEngine.setOutOfService()` set `outOfServiceDoorsOpened` when the current status is `DOORS_OPEN` or `DOORS_OPENING` to avoid redundant reopen behavior during shutdown.
- Bumped project version to `0.9.1` and updated `pom.xml`, `README.md`, and `CHANGELOG.md` with a short entry describing the fix.
- Committed changes to `src/main/java/com/liftsimulator/engine/SimulationEngine.java`, `CHANGELOG.md`, `README.md`, and `pom.xml`.

### Testing
- Ran `mvn test` to execute the unit test suite against the changes but the run failed before tests could execute due to a Maven plugin resolution error (403 from `repo.maven.apache.org`).
- No unit test failures were observed locally because the test run did not complete; the changes are focused and limited to the engine behavior covered by `OutOfServiceTest` and related state-transition tests.
- Recommend re-running `mvn test` in an environment with access to Maven Central (or with the necessary plugin artifacts cached) to validate all tests pass.
- Manual inspection and targeted reasoning were used to ensure the state normalization and out-of-service flagging align with the existing state machine and `StateTransitionValidator` constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f486633848325bbf308a6a420d2b6)