### PR TITLE
Fix stop-tick timing for door operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-01-08
+
+### Fixed
+- Preserve MOVING_* status on arrival until controller decisions so door dwell timing and parking interruptions occur after a stop tick
+
 ## [0.9.1] - 2026-01-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.9.1**
+Current version: **0.9.2**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.9.1) implements:
+The current version (v0.9.2) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -80,7 +80,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.9.1.jar`.
+The packaged JAR will be in `target/lift-simulator-0.9.2.jar`.
 
 ## Running the Simulation
 
@@ -93,7 +93,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.9.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.9.2.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/src/main/java/com/liftsimulator/engine/SimulationEngine.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationEngine.java
@@ -109,12 +109,6 @@ public class SimulationEngine {
             return;
         }
 
-        if (movementTicksRemaining == 0 &&
-            (currentState.getStatus() == LiftStatus.MOVING_UP ||
-             currentState.getStatus() == LiftStatus.MOVING_DOWN)) {
-            currentState = new LiftState(currentState.getFloor(), LiftStatus.IDLE);
-        }
-
         // Ask controller for next action
         Action action = controller.decideNextAction(currentState, clock.getCurrentTick());
 


### PR DESCRIPTION
### Motivation
- Intermittent test failures showed the controller acted as if the lift was already stopped on arrival, which changed door timing and reopen/parking behavior.
- Preserve a distinct "stop" tick so door dwell, reopen-window logic, and parking interruptions occur after the lift actually stops.
- Record the behavioral fix in project documentation and bump the release version.

### Description
- Call `controller.decideNextAction` before normalizing MOVING_* to IDLE by removing the early status normalization in `SimulationEngine.tick` so controller decisions see the lift as MOVING on arrival.
- This change preserves a stop tick before door transitions, fixing timing-sensitive interactions like door reopen window and parking interruption.
- Update `CHANGELOG.md` and `README.md` to publish version `0.9.2` and document the fix.

### Testing
- Attempted an automated Maven build (`mvn -q -DskipTests package`) but plugin resolution failed with HTTP 403 from repo.maven.apache.org, so unit tests could not be executed.
- No automated test runs completed in this environment due to the repository/plugin resolution error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4a72df1c8325a8059db3b56f40d7)