### PR TITLE
Fix out-of-service test stop tick expectations and bump version to 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.3] - 2026-01-08
+
+### Fixed
+- Align out-of-service integration test flow with the required stop tick before door opening
+
 ## [0.9.2] - 2026-01-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.9.2**
+Current version: **0.9.3**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.9.2) implements:
+The current version (v0.9.3) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -80,7 +80,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.9.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.9.3.jar`.
 
 ## Running the Simulation
 
@@ -93,7 +93,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.9.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.9.3.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.9.1</version>
+    <version>0.9.3</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/test/java/com/liftsimulator/engine/OutOfServiceTest.java
+++ b/src/test/java/com/liftsimulator/engine/OutOfServiceTest.java
@@ -380,9 +380,10 @@ public class OutOfServiceTest {
         engine.tick(); // Floor 1
         engine.tick(); // Floor 2
         engine.tick(); // Floor 3, stop
-        engine.tick(); // Open doors
-
         assertEquals(3, engine.getCurrentState().getFloor());
+        assertEquals(LiftStatus.IDLE, engine.getCurrentState().getStatus());
+
+        engine.tick(); // Open doors
         assertEquals(LiftStatus.DOORS_OPENING, engine.getCurrentState().getStatus());
 
         // Emergency: take out of service immediately


### PR DESCRIPTION
### Motivation
- Fix a failing out-of-service integration test by aligning the test flow with the engine requirement to stop at a floor before starting door open transitions.
- Ensure documentation and project metadata reflect the small behavioral fix with a patch version increment.
- Record the fix in the changelog so the change is discoverable and versioned.

### Description
- Adjusted `testIntegrationOutOfServiceScenario` in `src/test/java/com/liftsimulator/engine/OutOfServiceTest.java` to assert `LiftStatus.IDLE` immediately after arriving at the requested floor, then proceed to the door opening tick.
- Bumped the project version to `0.9.3` in `pom.xml` and updated `README.md` version and packaged JAR references to `0.9.3`.
- Added a `0.9.3` entry to `CHANGELOG.md` documenting the test flow fix.

### Testing
- No automated tests were executed as part of this change (no `mvn test` run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4d078eac83258ec1edbddfa96bd0)