### PR TITLE
Add scenario runner for scripted simulations and bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-01-09
+
+### Added
+- Scenario runner for scripted simulations with tick-based event triggers
+- Plain-text scenario definitions with support for car calls, hall calls, cancellations, and service mode changes
+- Scenario output logging that includes tick, floor, lift state, and pending requests
+
 ## [0.9.4] - 2026-01-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.9.4**
+Current version: **0.10.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.9.4) implements:
+The current version (v0.10.0) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -39,6 +39,7 @@ The current version (v0.9.4) implements:
 - **NaiveLiftController** - A simple controller that services the nearest pending request
 - **Console output** displaying tick-by-tick lift state (floor, direction, door state, status, request lifecycle)
 - **Request lifecycle visibility** in demo output with compact status display (Q:n, A:n, S:n)
+- **Scenario runner** for scripted simulations with tick-based events and pending request logging
 - **Request types**: Car calls (from inside the lift) and hall calls (from a floor)
 - **Safety enforcement**: Lift cannot move with doors open, doors cannot open while moving
 - **Backward compatibility**: Existing CarCall/HallCall interfaces still work
@@ -80,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.9.4.jar`.
+The packaged JAR will be in `target/lift-simulator-0.10.0.jar`.
 
 ## Running the Simulation
 
@@ -93,10 +94,41 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.9.4.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.10.0.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
+
+## Running Scripted Scenarios
+
+Run the scenario runner with the bundled demo scenario:
+
+```bash
+mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
+```
+
+Or run a custom scenario file:
+
+```bash
+java -cp target/lift-simulator-0.10.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+```
+
+Scenario files are plain text with metadata and event lines:
+
+```text
+name: Demo scenario - multiple events
+ticks: 30
+
+0, car_call, req1, 3
+2, hall_call, req2, 7, UP
+4, car_call, req3, 5
+10, cancel, req3
+15, out_of_service
+20, return_to_service
+22, car_call, req4, 4
+```
+
+Each event executes at the specified tick, and the output logs the tick, floor, lift state, and pending requests to help validate complex behavior.
 
 ## Configuring Tick Timing
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.9.4</version>
+    <version>0.10.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/scenario/ScenarioCommand.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioCommand.java
@@ -1,0 +1,6 @@
+package com.liftsimulator.scenario;
+
+@FunctionalInterface
+public interface ScenarioCommand {
+    void apply(ScenarioContext context);
+}

--- a/src/main/java/com/liftsimulator/scenario/ScenarioContext.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioContext.java
@@ -1,0 +1,34 @@
+package com.liftsimulator.scenario;
+
+import com.liftsimulator.engine.NaiveLiftController;
+import com.liftsimulator.engine.SimulationEngine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ScenarioContext {
+    private final SimulationEngine engine;
+    private final NaiveLiftController controller;
+    private final Map<String, Long> requestAliases = new HashMap<>();
+
+    public ScenarioContext(SimulationEngine engine, NaiveLiftController controller) {
+        this.engine = engine;
+        this.controller = controller;
+    }
+
+    public SimulationEngine getEngine() {
+        return engine;
+    }
+
+    public NaiveLiftController getController() {
+        return controller;
+    }
+
+    public void registerAlias(String alias, long requestId) {
+        requestAliases.put(alias, requestId);
+    }
+
+    public Long resolveAlias(String alias) {
+        return requestAliases.get(alias);
+    }
+}

--- a/src/main/java/com/liftsimulator/scenario/ScenarioDefinition.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioDefinition.java
@@ -1,0 +1,31 @@
+package com.liftsimulator.scenario;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ScenarioDefinition {
+    private final String name;
+    private final int totalTicks;
+    private final List<ScenarioEvent> events;
+
+    public ScenarioDefinition(String name, int totalTicks, List<ScenarioEvent> events) {
+        if (totalTicks <= 0) {
+            throw new IllegalArgumentException("totalTicks must be > 0");
+        }
+        this.name = name;
+        this.totalTicks = totalTicks;
+        this.events = List.copyOf(events);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getTotalTicks() {
+        return totalTicks;
+    }
+
+    public List<ScenarioEvent> getEvents() {
+        return Collections.unmodifiableList(events);
+    }
+}

--- a/src/main/java/com/liftsimulator/scenario/ScenarioEvent.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioEvent.java
@@ -1,0 +1,4 @@
+package com.liftsimulator.scenario;
+
+public record ScenarioEvent(long tick, String description, ScenarioCommand command) {
+}

--- a/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
@@ -1,0 +1,142 @@
+package com.liftsimulator.scenario;
+
+import com.liftsimulator.domain.Direction;
+import com.liftsimulator.domain.LiftRequest;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ScenarioParser {
+    public ScenarioDefinition parse(Path path) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(path)) {
+            return parse(inputStream, path.toString());
+        }
+    }
+
+    public ScenarioDefinition parseResource(String resourcePath) throws IOException {
+        InputStream inputStream = ScenarioParser.class.getResourceAsStream(resourcePath);
+        if (inputStream == null) {
+            throw new IOException("Scenario resource not found: " + resourcePath);
+        }
+        try (InputStream stream = inputStream) {
+            return parse(stream, resourcePath);
+        }
+    }
+
+    private ScenarioDefinition parse(InputStream inputStream, String sourceName) throws IOException {
+        String scenarioName = "Unnamed Scenario";
+        Integer totalTicks = null;
+        List<ScenarioEvent> events = new ArrayList<>();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            int lineNumber = 0;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                String trimmed = line.trim();
+                if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                    continue;
+                }
+
+                if (trimmed.startsWith("name:")) {
+                    scenarioName = trimmed.substring("name:".length()).trim();
+                    continue;
+                }
+
+                if (trimmed.startsWith("ticks:")) {
+                    String value = trimmed.substring("ticks:".length()).trim();
+                    totalTicks = Integer.parseInt(value);
+                    continue;
+                }
+
+                String[] tokens = trimmed.split("\\s*,\\s*");
+                if (tokens.length < 2) {
+                    throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "Invalid event line: " + line));
+                }
+
+                long tick = Long.parseLong(tokens[0]);
+                String action = tokens[1].toLowerCase();
+                ScenarioEvent event = parseEvent(tick, action, tokens, sourceName, lineNumber);
+                events.add(event);
+            }
+        }
+
+        if (totalTicks == null) {
+            throw new IllegalArgumentException("Scenario must define ticks in " + sourceName);
+        }
+
+        return new ScenarioDefinition(scenarioName, totalTicks, events);
+    }
+
+    private ScenarioEvent parseEvent(long tick, String action, String[] tokens, String sourceName, int lineNumber) {
+        return switch (action) {
+            case "car_call" -> parseCarCall(tick, tokens, sourceName, lineNumber);
+            case "hall_call" -> parseHallCall(tick, tokens, sourceName, lineNumber);
+            case "cancel" -> parseCancel(tick, tokens, sourceName, lineNumber);
+            case "out_of_service" -> new ScenarioEvent(tick, "Out of service", context -> {
+                context.getController().takeOutOfService();
+                context.getEngine().setOutOfService();
+            });
+            case "return_to_service" -> new ScenarioEvent(tick, "Return to service", context -> {
+                context.getController().returnToService();
+                context.getEngine().returnToService();
+            });
+            default -> throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "Unknown action: " + action));
+        };
+    }
+
+    private ScenarioEvent parseCarCall(long tick, String[] tokens, String sourceName, int lineNumber) {
+        if (tokens.length != 4) {
+            throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "car_call requires tick, alias, destination"));
+        }
+        String alias = tokens[2];
+        int destination = Integer.parseInt(tokens[3]);
+        String description = String.format("Car call %s to %d", alias, destination);
+        return new ScenarioEvent(tick, description, context -> {
+            LiftRequest request = LiftRequest.carCall(destination);
+            context.getController().addRequest(request);
+            context.registerAlias(alias, request.getId());
+        });
+    }
+
+    private ScenarioEvent parseHallCall(long tick, String[] tokens, String sourceName, int lineNumber) {
+        if (tokens.length != 5) {
+            throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "hall_call requires tick, alias, floor, direction"));
+        }
+        String alias = tokens[2];
+        int floor = Integer.parseInt(tokens[3]);
+        Direction direction = Direction.valueOf(tokens[4].toUpperCase());
+        String description = String.format("Hall call %s at %d %s", alias, floor, direction);
+        return new ScenarioEvent(tick, description, context -> {
+            LiftRequest request = LiftRequest.hallCall(floor, direction);
+            context.getController().addRequest(request);
+            context.registerAlias(alias, request.getId());
+        });
+    }
+
+    private ScenarioEvent parseCancel(long tick, String[] tokens, String sourceName, int lineNumber) {
+        if (tokens.length != 3) {
+            throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "cancel requires tick and alias"));
+        }
+        String alias = tokens[2];
+        String description = String.format("Cancel %s", alias);
+        return new ScenarioEvent(tick, description, context -> {
+            Long requestId = context.resolveAlias(alias);
+            if (requestId == null) {
+                throw new IllegalArgumentException("Unknown request alias: " + alias);
+            }
+            context.getController().cancelRequest(requestId);
+        });
+    }
+
+    private String errorMessage(String sourceName, int lineNumber, String message) {
+        return String.format("%s (line %d): %s", sourceName, lineNumber, message);
+    }
+}

--- a/src/main/java/com/liftsimulator/scenario/ScenarioRunner.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioRunner.java
@@ -1,0 +1,109 @@
+package com.liftsimulator.scenario;
+
+import com.liftsimulator.domain.LiftRequest;
+import com.liftsimulator.domain.LiftState;
+import com.liftsimulator.domain.RequestState;
+import com.liftsimulator.engine.NaiveLiftController;
+import com.liftsimulator.engine.SimulationEngine;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+public class ScenarioRunner {
+    private final SimulationEngine engine;
+    private final NaiveLiftController controller;
+
+    public ScenarioRunner(SimulationEngine engine, NaiveLiftController controller) {
+        this.engine = engine;
+        this.controller = controller;
+    }
+
+    public void run(ScenarioDefinition scenario) {
+        ScenarioContext context = new ScenarioContext(engine, controller);
+        Map<Long, List<ScenarioEvent>> eventsByTick = scenario.getEvents().stream()
+                .collect(Collectors.groupingBy(ScenarioEvent::tick));
+
+        System.out.println("=== Scenario Runner ===");
+        System.out.println("Scenario: " + scenario.getName());
+        System.out.println("Total ticks: " + scenario.getTotalTicks());
+        System.out.println();
+        System.out.println(String.format("%-6s %-6s %-15s %-30s %-30s",
+                "Tick", "Floor", "State", "Pending Requests", "Events"));
+        System.out.println("-------------------------------------------------------------------------------------------");
+
+        for (int i = 0; i < scenario.getTotalTicks(); i++) {
+            List<ScenarioEvent> events = eventsByTick.getOrDefault(engine.getCurrentTick(), List.of());
+            String eventNotes = applyEvents(events, context);
+
+            LiftState state = engine.getCurrentState();
+            String pendingRequests = formatPendingRequests(controller);
+
+            System.out.println(String.format("%-6d %-6d %-15s %-30s %-30s",
+                    engine.getCurrentTick(),
+                    state.getFloor(),
+                    state.getStatus(),
+                    pendingRequests,
+                    eventNotes));
+
+            engine.tick();
+        }
+
+        System.out.println();
+        System.out.println("Scenario completed.");
+    }
+
+    private String applyEvents(List<ScenarioEvent> events, ScenarioContext context) {
+        if (events.isEmpty()) {
+            return "-";
+        }
+        StringJoiner joiner = new StringJoiner(" | ");
+        for (ScenarioEvent event : events) {
+            event.command().apply(context);
+            joiner.add(event.description());
+        }
+        return joiner.toString();
+    }
+
+    private String formatPendingRequests(NaiveLiftController controller) {
+        Set<LiftRequest> activeRequests = controller.getRequests().stream()
+                .filter(request -> !request.isTerminal())
+                .collect(Collectors.toSet());
+
+        if (activeRequests.isEmpty()) {
+            return "-";
+        }
+
+        Map<RequestState, Long> stateCounts = activeRequests.stream()
+                .collect(Collectors.groupingBy(LiftRequest::getState, Collectors.counting()));
+
+        StringBuilder sb = new StringBuilder();
+        appendCount(sb, "Q", stateCounts.get(RequestState.QUEUED));
+        appendCount(sb, "A", stateCounts.get(RequestState.ASSIGNED));
+        appendCount(sb, "S", stateCounts.get(RequestState.SERVING));
+
+        String floors = activeRequests.stream()
+                .map(LiftRequest::getTargetFloor)
+                .distinct()
+                .sorted()
+                .map(String::valueOf)
+                .collect(Collectors.joining(","));
+
+        if (!floors.isEmpty()) {
+            sb.append(" Floors:").append(floors);
+        }
+
+        return sb.toString().trim();
+    }
+
+    private void appendCount(StringBuilder sb, String label, Long count) {
+        if (count != null && count > 0) {
+            if (!sb.isEmpty()) {
+                sb.append(" ");
+            }
+            sb.append(label).append(":").append(count);
+        }
+    }
+}

--- a/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
@@ -1,0 +1,28 @@
+package com.liftsimulator.scenario;
+
+import com.liftsimulator.engine.NaiveLiftController;
+import com.liftsimulator.engine.SimulationEngine;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public class ScenarioRunnerMain {
+    private static final String DEFAULT_SCENARIO_RESOURCE = "/scenarios/demo.scenario";
+
+    public static void main(String[] args) throws IOException {
+        ScenarioParser parser = new ScenarioParser();
+        ScenarioDefinition scenario;
+
+        if (args.length > 0) {
+            scenario = parser.parse(Path.of(args[0]));
+        } else {
+            scenario = parser.parseResource(DEFAULT_SCENARIO_RESOURCE);
+        }
+
+        NaiveLiftController controller = new NaiveLiftController();
+        SimulationEngine engine = new SimulationEngine(controller, 0, 10);
+
+        ScenarioRunner runner = new ScenarioRunner(engine, controller);
+        runner.run(scenario);
+    }
+}

--- a/src/main/resources/scenarios/demo.scenario
+++ b/src/main/resources/scenarios/demo.scenario
@@ -1,0 +1,13 @@
+# Demo scenario showcasing multiple events and lifecycle changes
+name: Demo scenario - multiple events
+ticks: 30
+
+# Format: tick, action, alias, args...
+# Actions: car_call, hall_call, cancel, out_of_service, return_to_service
+0, car_call, req1, 3
+2, hall_call, req2, 7, UP
+4, car_call, req3, 5
+10, cancel, req3
+15, out_of_service
+20, return_to_service
+22, car_call, req4, 4


### PR DESCRIPTION
### Motivation

- Provide a replayable scenario runner to exercise scripted events at specific ticks for debugging and validation.
- Allow scenarios to trigger `car_call`, `hall_call`, `cancel`, `out_of_service`, and `return_to_service` actions at deterministic ticks.
- Emit per-tick logging that includes tick, floor, lift state, and pending requests to validate complex behavior.
- Document the feature and bump the project version using SemVer.

### Description

- Add a new `com.liftsimulator.scenario` package with `ScenarioParser`, `ScenarioRunner`, `ScenarioRunnerMain`, `ScenarioDefinition`, `ScenarioEvent`, `ScenarioContext`, and `ScenarioCommand` to parse and run plain-text scenarios.
- Include a bundled example scenario at `src/main/resources/scenarios/demo.scenario` demonstrating multiple events and lifecycle operations.
- Update documentation and metadata by bumping the project version in `pom.xml` to `0.10.0`, updating `README.md` with usage instructions for `ScenarioRunnerMain`, and adding an entry to `CHANGELOG.md`.
- Scenario output prints a compact per-tick table with `Tick`, `Floor`, `State`, `Pending Requests`, and `Events` to aid validation.

### Testing

- No automated tests were executed as part of this change (`mvn test` was not run).
- The new scenario runner can be exercised locally via `mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"` to run the bundled demo.
- The project version and README references were updated to `0.10.0` and should be validated by a normal build (`mvn clean package`).
- Manual inspection and local runs are recommended to validate scenario parsing and event semantics before adding automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f682bf3a083259378f53e650516c7)