### PR TITLE
Defer return-to-service until out-of-service shutdown completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-01-10
+
+### Fixed
+- Defer return-to-service events until the out-of-service shutdown sequence completes
+
 ## [0.10.0] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.10.0**
+Current version: **0.10.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.10.0) implements:
+The current version (v0.10.1) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -81,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.10.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.10.1.jar`.
 
 ## Running the Simulation
 
@@ -94,7 +94,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.10.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.10.1.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -110,7 +110,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.10.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.10.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:
@@ -129,6 +129,8 @@ ticks: 30
 ```
 
 Each event executes at the specified tick, and the output logs the tick, floor, lift state, and pending requests to help validate complex behavior.
+
+Note: If a `return_to_service` event is scheduled while the lift is still completing the out-of-service shutdown sequence, the return is deferred until the lift reaches the `OUT_OF_SERVICE` state.
 
 ## Configuring Tick Timing
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.10.0</version>
+    <version>0.10.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/SimulationEngine.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationEngine.java
@@ -25,6 +25,7 @@ public class SimulationEngine {
     private boolean outOfServicePending;
     private boolean outOfServiceDoorsOpened;
     private int outOfServiceTargetFloor;
+    private boolean returnToServicePending;
 
     public SimulationEngine(LiftController controller, int minFloor, int maxFloor) {
         this(controller, minFloor, maxFloor, 1, 2, 3, -1);
@@ -315,6 +316,11 @@ public class SimulationEngine {
      * @throws IllegalStateException if the lift is not currently out of service
      */
     public void returnToService() {
+        if (outOfServicePending) {
+            returnToServicePending = true;
+            return;
+        }
+
         if (currentState.getStatus() != LiftStatus.OUT_OF_SERVICE) {
             throw new IllegalStateException(
                 String.format("Cannot return to service from %s state (must be OUT_OF_SERVICE)",
@@ -329,6 +335,7 @@ public class SimulationEngine {
 
         // Transition to IDLE
         currentState = new LiftState(currentState.getFloor(), LiftStatus.IDLE);
+        returnToServicePending = false;
     }
 
     /**
@@ -399,6 +406,9 @@ public class SimulationEngine {
             doorTicksRemaining = 0;
             doorDwellTicksRemaining = 0;
             doorClosingTicksElapsed = 0;
+            if (returnToServicePending) {
+                returnToService();
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- A `return_to_service` event scheduled while the engine was still performing the out-of-service shutdown caused an `IllegalStateException` because the engine was not yet in `OUT_OF_SERVICE` when `returnToService()` was called.  
- The engine must finish its graceful shutdown sequence (stop, open doors, close doors) before accepting a return-to-service transition.  
- Allow controllers or scenario runners to request a return while the shutdown is running without causing an invalid transition.  

### Description
- Add a `returnToServicePending` flag to `SimulationEngine` and set it when `returnToService()` is invoked while `outOfServicePending` is true.  
- Modify `returnToService()` to defer the transition when `outOfServicePending` and to clear the pending flag when the transition is executed.  
- On completion of the out-of-service shutdown in `handleOutOfServiceTransition()`, call `returnToService()` if `returnToServicePending` is set so the engine immediately transitions to `IDLE`.  
- Update documentation and packaging: bump project version to `0.10.1` in `pom.xml`, add a `0.10.1` note to `CHANGELOG.md`, and document the deferred `return_to_service` behavior in `README.md`.  

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f712614988325aeae43b9fd9ace38)