### PR TITLE
Support negative floors in scenario runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Expand scenario runner floor bounds to include requested negative floors while keeping the default range and starting floor
+
 ## [0.10.2] - 2026-01-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ ticks: 30
 ```
 
 Each event executes at the specified tick, and the output logs the tick, floor, lift state, and pending requests to help validate complex behavior.
+The scenario runner automatically expands the default floor range (0–10) to include any requested floors, so negative floors in scripted scenarios are supported without extra configuration.
 
 Note: If a `return_to_service` event is scheduled while the lift is still completing the out-of-service shutdown sequence, the return is deferred until the lift reaches the `OUT_OF_SERVICE` state.
 

--- a/src/main/java/com/liftsimulator/engine/SimulationEngine.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationEngine.java
@@ -28,7 +28,16 @@ public class SimulationEngine {
     private boolean returnToServicePending;
 
     public SimulationEngine(LiftController controller, int minFloor, int maxFloor) {
-        this(controller, minFloor, maxFloor, 1, 2, 3, -1);
+        this(controller, minFloor, maxFloor, minFloor, 1, 2, 3, -1);
+    }
+
+    public SimulationEngine(
+            LiftController controller,
+            int minFloor,
+            int maxFloor,
+            int initialFloor
+    ) {
+        this(controller, minFloor, maxFloor, initialFloor, 1, 2, 3, -1);
     }
 
     public SimulationEngine(
@@ -38,7 +47,7 @@ public class SimulationEngine {
             int travelTicksPerFloor,
             int doorTransitionTicks
     ) {
-        this(controller, minFloor, maxFloor, travelTicksPerFloor, doorTransitionTicks, 3, -1);
+        this(controller, minFloor, maxFloor, minFloor, travelTicksPerFloor, doorTransitionTicks, 3, -1);
     }
 
     public SimulationEngine(
@@ -49,13 +58,27 @@ public class SimulationEngine {
             int doorTransitionTicks,
             int doorDwellTicks
     ) {
-        this(controller, minFloor, maxFloor, travelTicksPerFloor, doorTransitionTicks, doorDwellTicks, -1);
+        this(controller, minFloor, maxFloor, minFloor, travelTicksPerFloor, doorTransitionTicks, doorDwellTicks, -1);
     }
 
     public SimulationEngine(
             LiftController controller,
             int minFloor,
             int maxFloor,
+            int travelTicksPerFloor,
+            int doorTransitionTicks,
+            int doorDwellTicks,
+            int doorReopenWindowTicks
+    ) {
+        this(controller, minFloor, maxFloor, minFloor, travelTicksPerFloor, doorTransitionTicks, doorDwellTicks,
+            doorReopenWindowTicks);
+    }
+
+    public SimulationEngine(
+            LiftController controller,
+            int minFloor,
+            int maxFloor,
+            int initialFloor,
             int travelTicksPerFloor,
             int doorTransitionTicks,
             int doorDwellTicks,
@@ -82,6 +105,9 @@ public class SimulationEngine {
         if (doorReopenWindowTicks > doorTransitionTicks) {
             throw new IllegalArgumentException("doorReopenWindowTicks cannot exceed doorTransitionTicks");
         }
+        if (initialFloor < minFloor || initialFloor > maxFloor) {
+            throw new IllegalArgumentException("initialFloor must be within minFloor and maxFloor");
+        }
         this.controller = controller;
         this.minFloor = minFloor;
         this.maxFloor = maxFloor;
@@ -94,8 +120,8 @@ public class SimulationEngine {
         this.doorTicksRemaining = 0;
         this.doorDwellTicksRemaining = 0;
         this.doorClosingTicksElapsed = 0;
-        // Initialize lift at minimum floor, idle status
-        this.currentState = new LiftState(minFloor, LiftStatus.IDLE);
+        // Initialize lift at the provided starting floor, idle status
+        this.currentState = new LiftState(initialFloor, LiftStatus.IDLE);
     }
 
     /**

--- a/src/main/java/com/liftsimulator/scenario/ScenarioDefinition.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioDefinition.java
@@ -7,14 +7,22 @@ public class ScenarioDefinition {
     private final String name;
     private final int totalTicks;
     private final List<ScenarioEvent> events;
+    private final Integer minFloor;
+    private final Integer maxFloor;
 
     public ScenarioDefinition(String name, int totalTicks, List<ScenarioEvent> events) {
+        this(name, totalTicks, events, null, null);
+    }
+
+    public ScenarioDefinition(String name, int totalTicks, List<ScenarioEvent> events, Integer minFloor, Integer maxFloor) {
         if (totalTicks <= 0) {
             throw new IllegalArgumentException("totalTicks must be > 0");
         }
         this.name = name;
         this.totalTicks = totalTicks;
         this.events = List.copyOf(events);
+        this.minFloor = minFloor;
+        this.maxFloor = maxFloor;
     }
 
     public String getName() {
@@ -27,5 +35,13 @@ public class ScenarioDefinition {
 
     public List<ScenarioEvent> getEvents() {
         return Collections.unmodifiableList(events);
+    }
+
+    public Integer getMinFloor() {
+        return minFloor;
+    }
+
+    public Integer getMaxFloor() {
+        return maxFloor;
     }
 }

--- a/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
@@ -34,6 +34,8 @@ public class ScenarioParser {
         String scenarioName = "Unnamed Scenario";
         Integer totalTicks = null;
         List<ScenarioEvent> events = new ArrayList<>();
+        Integer minFloor = null;
+        Integer maxFloor = null;
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             String line;
@@ -63,6 +65,11 @@ public class ScenarioParser {
 
                 long tick = Long.parseLong(tokens[0]);
                 String action = tokens[1].toLowerCase();
+                Integer floorValue = extractFloorValue(action, tokens);
+                if (floorValue != null) {
+                    minFloor = minFloor == null ? floorValue : Math.min(minFloor, floorValue);
+                    maxFloor = maxFloor == null ? floorValue : Math.max(maxFloor, floorValue);
+                }
                 ScenarioEvent event = parseEvent(tick, action, tokens, sourceName, lineNumber);
                 events.add(event);
             }
@@ -72,7 +79,17 @@ public class ScenarioParser {
             throw new IllegalArgumentException("Scenario must define ticks in " + sourceName);
         }
 
-        return new ScenarioDefinition(scenarioName, totalTicks, events);
+        return new ScenarioDefinition(scenarioName, totalTicks, events, minFloor, maxFloor);
+    }
+
+    private Integer extractFloorValue(String action, String[] tokens) {
+        if ("car_call".equals(action) && tokens.length >= 4) {
+            return Integer.parseInt(tokens[3]);
+        }
+        if ("hall_call".equals(action) && tokens.length >= 4) {
+            return Integer.parseInt(tokens[3]);
+        }
+        return null;
     }
 
     private ScenarioEvent parseEvent(long tick, String action, String[] tokens, String sourceName, int lineNumber) {

--- a/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
@@ -8,6 +8,9 @@ import java.nio.file.Path;
 
 public class ScenarioRunnerMain {
     private static final String DEFAULT_SCENARIO_RESOURCE = "/scenarios/demo.scenario";
+    private static final int DEFAULT_MIN_FLOOR = 0;
+    private static final int DEFAULT_MAX_FLOOR = 10;
+    private static final int DEFAULT_INITIAL_FLOOR = 0;
 
     public static void main(String[] args) throws IOException {
         ScenarioParser parser = new ScenarioParser();
@@ -20,7 +23,16 @@ public class ScenarioRunnerMain {
         }
 
         NaiveLiftController controller = new NaiveLiftController();
-        SimulationEngine engine = new SimulationEngine(controller, 0, 10);
+        int minFloor = DEFAULT_MIN_FLOOR;
+        int maxFloor = DEFAULT_MAX_FLOOR;
+        if (scenario.getMinFloor() != null) {
+            minFloor = Math.min(minFloor, scenario.getMinFloor());
+        }
+        if (scenario.getMaxFloor() != null) {
+            maxFloor = Math.max(maxFloor, scenario.getMaxFloor());
+        }
+        int initialFloor = Math.min(Math.max(DEFAULT_INITIAL_FLOOR, minFloor), maxFloor);
+        SimulationEngine engine = new SimulationEngine(controller, minFloor, maxFloor, initialFloor);
 
         ScenarioRunner runner = new ScenarioRunner(engine, controller);
         runner.run(scenario);


### PR DESCRIPTION
### Motivation
- Scenario scripts containing negative floor numbers were not supported because the engine always initialized at the minimum default floor (0) and the runner used a fixed floor range.
- Allow scripted scenarios to request arbitrary floors (including negative) without forcing callers to explicitly configure engine bounds.
- Preserve existing default behavior and backward compatibility for callers that rely on current constructors.

### Description
- Added an `initialFloor` parameter and overloads to `SimulationEngine` so the engine can start at a configurable floor while keeping existing constructors working, and validated `initialFloor` is within `[minFloor,maxFloor]`.
- Extended `ScenarioParser` to scan events and compute `minFloor`/`maxFloor` requested by the scenario and exposed those values on `ScenarioDefinition`.
- Updated `ScenarioRunnerMain` to expand the default floor range (0–10) to include any requested floors and to select a sensible `initialFloor` based on scenario bounds.
- Updated documentation (`README.md`) and changelog (`CHANGELOG.md`) to note the scenario runner now supports negative floors.

### Testing
- No automated tests were executed as part of this change.
- Changes were implemented to keep all existing public constructors and behavior unchanged unless an explicit `initialFloor` is provided.
- Manual scenario parsing and runner changes are localized to scenario code paths (`ScenarioParser`, `ScenarioDefinition`, `ScenarioRunnerMain`) and engine initialization (`SimulationEngine`).
- Recommend running `mvn package` and exercising custom scenario files (including negative floors) to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f79e546608325bbe15bada576a6f5)