### PR TITLE
Allow scenario metadata to configure simulation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-01-10
+
+### Added
+- Allow scenario files to configure controller and simulation timing parameters (including door dwell time) alongside scripted events
+
 ### Fixed
 - Expand scenario runner floor bounds to include requested negative floors while keeping the default range and starting floor
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.10.2**
+Current version: **0.11.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.10.2) implements:
+The current version (v0.11.0) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -81,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.10.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.11.0.jar`.
 
 ## Running the Simulation
 
@@ -94,7 +94,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.10.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.11.0.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -110,7 +110,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.10.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.11.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:
@@ -118,6 +118,15 @@ Scenario files are plain text with metadata and event lines:
 ```text
 name: Demo scenario - multiple events
 ticks: 30
+min_floor: 0
+max_floor: 10
+initial_floor: 0
+travel_ticks_per_floor: 1
+door_transition_ticks: 2
+door_dwell_ticks: 3
+door_reopen_window_ticks: 2
+home_floor: 0
+idle_timeout_ticks: 5
 
 0, car_call, req1, 3
 2, hall_call, req2, 7, UP
@@ -130,6 +139,18 @@ ticks: 30
 
 Each event executes at the specified tick, and the output logs the tick, floor, lift state, and pending requests to help validate complex behavior.
 The scenario runner automatically expands the default floor range (0–10) to include any requested floors, so negative floors in scripted scenarios are supported without extra configuration.
+If you set any of the scenario parameters (e.g., `door_dwell_ticks`), the scenario runner uses them to configure the controller and simulation engine.
+
+Scenario metadata keys:
+
+- **min_floor** / **max_floor**: floor bounds used for the simulation (still expanded to include requested floors)
+- **initial_floor**: starting floor for the lift (clamped to the final min/max range)
+- **travel_ticks_per_floor**: ticks required to travel one floor
+- **door_transition_ticks**: ticks required to open or close doors
+- **door_dwell_ticks**: ticks doors stay open before closing
+- **door_reopen_window_ticks**: ticks during door closing when doors can reopen (0 disables)
+- **home_floor**: idle parking floor for the naive controller
+- **idle_timeout_ticks**: idle ticks before the lift parks at the home floor
 
 Note: If a `return_to_service` event is scheduled while the lift is still completing the out-of-service shutdown sequence, the return is deferred until the lift reaches the `OUT_OF_SERVICE` state.
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.10.2</version>
+    <version>0.11.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/scenario/ScenarioDefinition.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioDefinition.java
@@ -9,12 +9,36 @@ public class ScenarioDefinition {
     private final List<ScenarioEvent> events;
     private final Integer minFloor;
     private final Integer maxFloor;
+    private final Integer configuredMinFloor;
+    private final Integer configuredMaxFloor;
+    private final Integer initialFloor;
+    private final Integer travelTicksPerFloor;
+    private final Integer doorTransitionTicks;
+    private final Integer doorDwellTicks;
+    private final Integer doorReopenWindowTicks;
+    private final Integer homeFloor;
+    private final Integer idleTimeoutTicks;
 
     public ScenarioDefinition(String name, int totalTicks, List<ScenarioEvent> events) {
-        this(name, totalTicks, events, null, null);
+        this(name, totalTicks, events, null, null, null, null, null, null, null, null, null, null, null);
     }
 
-    public ScenarioDefinition(String name, int totalTicks, List<ScenarioEvent> events, Integer minFloor, Integer maxFloor) {
+    public ScenarioDefinition(
+            String name,
+            int totalTicks,
+            List<ScenarioEvent> events,
+            Integer minFloor,
+            Integer maxFloor,
+            Integer configuredMinFloor,
+            Integer configuredMaxFloor,
+            Integer initialFloor,
+            Integer travelTicksPerFloor,
+            Integer doorTransitionTicks,
+            Integer doorDwellTicks,
+            Integer doorReopenWindowTicks,
+            Integer homeFloor,
+            Integer idleTimeoutTicks
+    ) {
         if (totalTicks <= 0) {
             throw new IllegalArgumentException("totalTicks must be > 0");
         }
@@ -23,6 +47,15 @@ public class ScenarioDefinition {
         this.events = List.copyOf(events);
         this.minFloor = minFloor;
         this.maxFloor = maxFloor;
+        this.configuredMinFloor = configuredMinFloor;
+        this.configuredMaxFloor = configuredMaxFloor;
+        this.initialFloor = initialFloor;
+        this.travelTicksPerFloor = travelTicksPerFloor;
+        this.doorTransitionTicks = doorTransitionTicks;
+        this.doorDwellTicks = doorDwellTicks;
+        this.doorReopenWindowTicks = doorReopenWindowTicks;
+        this.homeFloor = homeFloor;
+        this.idleTimeoutTicks = idleTimeoutTicks;
     }
 
     public String getName() {
@@ -43,5 +76,41 @@ public class ScenarioDefinition {
 
     public Integer getMaxFloor() {
         return maxFloor;
+    }
+
+    public Integer getConfiguredMinFloor() {
+        return configuredMinFloor;
+    }
+
+    public Integer getConfiguredMaxFloor() {
+        return configuredMaxFloor;
+    }
+
+    public Integer getInitialFloor() {
+        return initialFloor;
+    }
+
+    public Integer getTravelTicksPerFloor() {
+        return travelTicksPerFloor;
+    }
+
+    public Integer getDoorTransitionTicks() {
+        return doorTransitionTicks;
+    }
+
+    public Integer getDoorDwellTicks() {
+        return doorDwellTicks;
+    }
+
+    public Integer getDoorReopenWindowTicks() {
+        return doorReopenWindowTicks;
+    }
+
+    public Integer getHomeFloor() {
+        return homeFloor;
+    }
+
+    public Integer getIdleTimeoutTicks() {
+        return idleTimeoutTicks;
     }
 }

--- a/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
@@ -36,6 +36,15 @@ public class ScenarioParser {
         List<ScenarioEvent> events = new ArrayList<>();
         Integer minFloor = null;
         Integer maxFloor = null;
+        Integer configuredMinFloor = null;
+        Integer configuredMaxFloor = null;
+        Integer initialFloor = null;
+        Integer travelTicksPerFloor = null;
+        Integer doorTransitionTicks = null;
+        Integer doorDwellTicks = null;
+        Integer doorReopenWindowTicks = null;
+        Integer homeFloor = null;
+        Integer idleTimeoutTicks = null;
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
             String line;
@@ -55,6 +64,51 @@ public class ScenarioParser {
                 if (trimmed.startsWith("ticks:")) {
                     String value = trimmed.substring("ticks:".length()).trim();
                     totalTicks = Integer.parseInt(value);
+                    continue;
+                }
+
+                if (trimmed.startsWith("min_floor:")) {
+                    configuredMinFloor = parseIntValue(trimmed, "min_floor:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("max_floor:")) {
+                    configuredMaxFloor = parseIntValue(trimmed, "max_floor:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("initial_floor:")) {
+                    initialFloor = parseIntValue(trimmed, "initial_floor:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("travel_ticks_per_floor:")) {
+                    travelTicksPerFloor = parseIntValue(trimmed, "travel_ticks_per_floor:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("door_transition_ticks:")) {
+                    doorTransitionTicks = parseIntValue(trimmed, "door_transition_ticks:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("door_dwell_ticks:")) {
+                    doorDwellTicks = parseIntValue(trimmed, "door_dwell_ticks:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("door_reopen_window_ticks:")) {
+                    doorReopenWindowTicks = parseIntValue(trimmed, "door_reopen_window_ticks:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("home_floor:")) {
+                    homeFloor = parseIntValue(trimmed, "home_floor:");
+                    continue;
+                }
+
+                if (trimmed.startsWith("idle_timeout_ticks:")) {
+                    idleTimeoutTicks = parseIntValue(trimmed, "idle_timeout_ticks:");
                     continue;
                 }
 
@@ -79,7 +133,22 @@ public class ScenarioParser {
             throw new IllegalArgumentException("Scenario must define ticks in " + sourceName);
         }
 
-        return new ScenarioDefinition(scenarioName, totalTicks, events, minFloor, maxFloor);
+        return new ScenarioDefinition(
+                scenarioName,
+                totalTicks,
+                events,
+                minFloor,
+                maxFloor,
+                configuredMinFloor,
+                configuredMaxFloor,
+                initialFloor,
+                travelTicksPerFloor,
+                doorTransitionTicks,
+                doorDwellTicks,
+                doorReopenWindowTicks,
+                homeFloor,
+                idleTimeoutTicks
+        );
     }
 
     private Integer extractFloorValue(String action, String[] tokens) {
@@ -155,5 +224,10 @@ public class ScenarioParser {
 
     private String errorMessage(String sourceName, int lineNumber, String message) {
         return String.format("%s (line %d): %s", sourceName, lineNumber, message);
+    }
+
+    private Integer parseIntValue(String trimmed, String prefix) {
+        String value = trimmed.substring(prefix.length()).trim();
+        return Integer.parseInt(value);
     }
 }

--- a/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
@@ -11,6 +11,12 @@ public class ScenarioRunnerMain {
     private static final int DEFAULT_MIN_FLOOR = 0;
     private static final int DEFAULT_MAX_FLOOR = 10;
     private static final int DEFAULT_INITIAL_FLOOR = 0;
+    private static final int DEFAULT_TRAVEL_TICKS_PER_FLOOR = 1;
+    private static final int DEFAULT_DOOR_TRANSITION_TICKS = 2;
+    private static final int DEFAULT_DOOR_DWELL_TICKS = 3;
+    private static final int DEFAULT_DOOR_REOPEN_WINDOW_TICKS = -1;
+    private static final int DEFAULT_HOME_FLOOR = 0;
+    private static final int DEFAULT_IDLE_TIMEOUT_TICKS = 5;
 
     public static void main(String[] args) throws IOException {
         ScenarioParser parser = new ScenarioParser();
@@ -22,17 +28,44 @@ public class ScenarioRunnerMain {
             scenario = parser.parseResource(DEFAULT_SCENARIO_RESOURCE);
         }
 
-        NaiveLiftController controller = new NaiveLiftController();
-        int minFloor = DEFAULT_MIN_FLOOR;
-        int maxFloor = DEFAULT_MAX_FLOOR;
+        int minFloor = scenario.getConfiguredMinFloor() != null ? scenario.getConfiguredMinFloor() : DEFAULT_MIN_FLOOR;
+        int maxFloor = scenario.getConfiguredMaxFloor() != null ? scenario.getConfiguredMaxFloor() : DEFAULT_MAX_FLOOR;
         if (scenario.getMinFloor() != null) {
             minFloor = Math.min(minFloor, scenario.getMinFloor());
         }
         if (scenario.getMaxFloor() != null) {
             maxFloor = Math.max(maxFloor, scenario.getMaxFloor());
         }
-        int initialFloor = Math.min(Math.max(DEFAULT_INITIAL_FLOOR, minFloor), maxFloor);
-        SimulationEngine engine = new SimulationEngine(controller, minFloor, maxFloor, initialFloor);
+        int initialFloorValue = scenario.getInitialFloor() != null ? scenario.getInitialFloor() : DEFAULT_INITIAL_FLOOR;
+        int initialFloor = Math.min(Math.max(initialFloorValue, minFloor), maxFloor);
+        int travelTicksPerFloor = scenario.getTravelTicksPerFloor() != null
+                ? scenario.getTravelTicksPerFloor()
+                : DEFAULT_TRAVEL_TICKS_PER_FLOOR;
+        int doorTransitionTicks = scenario.getDoorTransitionTicks() != null
+                ? scenario.getDoorTransitionTicks()
+                : DEFAULT_DOOR_TRANSITION_TICKS;
+        int doorDwellTicks = scenario.getDoorDwellTicks() != null
+                ? scenario.getDoorDwellTicks()
+                : DEFAULT_DOOR_DWELL_TICKS;
+        int doorReopenWindowTicks = scenario.getDoorReopenWindowTicks() != null
+                ? scenario.getDoorReopenWindowTicks()
+                : DEFAULT_DOOR_REOPEN_WINDOW_TICKS;
+        int homeFloor = scenario.getHomeFloor() != null ? scenario.getHomeFloor() : DEFAULT_HOME_FLOOR;
+        int idleTimeoutTicks = scenario.getIdleTimeoutTicks() != null
+                ? scenario.getIdleTimeoutTicks()
+                : DEFAULT_IDLE_TIMEOUT_TICKS;
+
+        NaiveLiftController controller = new NaiveLiftController(homeFloor, idleTimeoutTicks);
+        SimulationEngine engine = new SimulationEngine(
+                controller,
+                minFloor,
+                maxFloor,
+                initialFloor,
+                travelTicksPerFloor,
+                doorTransitionTicks,
+                doorDwellTicks,
+                doorReopenWindowTicks
+        );
 
         ScenarioRunner runner = new ScenarioRunner(engine, controller);
         runner.run(scenario);

--- a/src/main/resources/scenarios/demo.scenario
+++ b/src/main/resources/scenarios/demo.scenario
@@ -1,6 +1,15 @@
 # Demo scenario showcasing multiple events and lifecycle changes
 name: Demo scenario - multiple events
 ticks: 30
+min_floor: 0
+max_floor: 10
+initial_floor: 0
+travel_ticks_per_floor: 1
+door_transition_ticks: 2
+door_dwell_ticks: 3
+door_reopen_window_ticks: 2
+home_floor: 0
+idle_timeout_ticks: 5
 
 # Format: tick, action, alias, args...
 # Actions: car_call, hall_call, cancel, out_of_service, return_to_service


### PR DESCRIPTION
### Motivation

- Provide a way for scenario files to tune simulation and controller timing (e.g. door dwell time) without changing code.
- Make the bundled demo configurable so users can experiment with timing and controller settings from the scenario file.
- Preserve existing behavior when metadata is not present by falling back to sensible defaults.

### Description

- Extended `ScenarioDefinition` to carry optional metadata fields such as `min_floor`, `max_floor`, `initial_floor`, `travel_ticks_per_floor`, `door_transition_ticks`, `door_dwell_ticks`, `door_reopen_window_ticks`, `home_floor`, and `idle_timeout_ticks`.
- Updated `ScenarioParser` to parse the new metadata keys from scenario files and populate `ScenarioDefinition` with the parsed values.
- Modified `ScenarioRunnerMain` to apply scenario-configured parameters (or fall back to defaults) when constructing `NaiveLiftController` and `SimulationEngine`, and updated the bundled `demo.scenario` accordingly.
- Bumped project version to `0.11.0`, updated `README.md` to document scenario metadata keys and adjusted `CHANGELOG.md` with the new release notes.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f7bb7617c832595989025cb004e61)