### PR TITLE
Introduce SimulationEngine Builder and migrate callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-01-10
+
+### Changed
+- Replace telescoping `SimulationEngine` constructors with a builder for configuration
+
 ## [0.11.0] - 2026-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.11.0**
+Current version: **0.12.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.11.0) implements:
+The current version (v0.12.0) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -81,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.11.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.0.jar`.
 
 ## Running the Simulation
 
@@ -94,7 +94,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.11.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.0.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -110,7 +110,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.11.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:
@@ -156,18 +156,15 @@ Note: If a `return_to_service` event is scheduled while the lift is still comple
 
 ## Configuring Tick Timing
 
-You can model travel and door timing by using the extended `SimulationEngine` constructor:
+You can model travel and door timing by using the `SimulationEngine` builder:
 
 ```java
-SimulationEngine engine = new SimulationEngine(
-    controller,
-    0,
-    10,
-    3, // travelTicksPerFloor
-    2, // doorTransitionTicks
-    3, // doorDwellTicks
-    2  // doorReopenWindowTicks
-);
+SimulationEngine engine = SimulationEngine.builder(controller, 0, 10)
+    .travelTicksPerFloor(3)
+    .doorTransitionTicks(2)
+    .doorDwellTicks(3)
+    .doorReopenWindowTicks(2)
+    .build();
 ```
 
 - **travelTicksPerFloor**: How many ticks it takes to move one floor

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.11.0</version>
+    <version>0.12.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/Main.java
+++ b/src/main/java/com/liftsimulator/Main.java
@@ -28,7 +28,7 @@ public class Main {
 
         // Create naive controller and engine
         NaiveLiftController controller = new NaiveLiftController();
-        SimulationEngine engine = new SimulationEngine(controller, 0, 10);
+        SimulationEngine engine = SimulationEngine.builder(controller, 0, 10).build();
 
         // Add some requests to simulate real usage
         System.out.println("Requests:");

--- a/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
@@ -56,16 +56,13 @@ public class ScenarioRunnerMain {
                 : DEFAULT_IDLE_TIMEOUT_TICKS;
 
         NaiveLiftController controller = new NaiveLiftController(homeFloor, idleTimeoutTicks);
-        SimulationEngine engine = new SimulationEngine(
-                controller,
-                minFloor,
-                maxFloor,
-                initialFloor,
-                travelTicksPerFloor,
-                doorTransitionTicks,
-                doorDwellTicks,
-                doorReopenWindowTicks
-        );
+        SimulationEngine engine = SimulationEngine.builder(controller, minFloor, maxFloor)
+                .initialFloor(initialFloor)
+                .travelTicksPerFloor(travelTicksPerFloor)
+                .doorTransitionTicks(doorTransitionTicks)
+                .doorDwellTicks(doorDwellTicks)
+                .doorReopenWindowTicks(doorReopenWindowTicks)
+                .build();
 
         ScenarioRunner runner = new ScenarioRunner(engine, controller);
         runner.run(scenario);

--- a/src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java
+++ b/src/test/java/com/liftsimulator/engine/NaiveLiftControllerTest.java
@@ -311,7 +311,12 @@ public class NaiveLiftControllerTest {
     @Test
     public void testIntegrationDoorReopenWithinWindow() {
         // Integration test: request arrives while doors closing, within reopen window
-        SimulationEngine engine = new SimulationEngine(controller, 0, 10, 1, 2, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(controller, 0, 10)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(2)
+                .doorReopenWindowTicks(2)
+                .build();
 
         // Add initial request to floor 5
         controller.addCarCall(new CarCall(5));
@@ -351,7 +356,12 @@ public class NaiveLiftControllerTest {
     @Test
     public void testIntegrationDoorDoesNotReopenOutsideWindow() {
         // Integration test: request arrives while doors closing, outside reopen window
-        SimulationEngine engine = new SimulationEngine(controller, 0, 10, 1, 4, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(controller, 0, 10)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(4)
+                .doorDwellTicks(2)
+                .doorReopenWindowTicks(2)
+                .build();
 
         // Add initial request to floor 5
         controller.addCarCall(new CarCall(5));
@@ -518,7 +528,7 @@ public class NaiveLiftControllerTest {
     @Test
     public void testParksAtHomeFloorAfterIdleTimeout() {
         NaiveLiftController parkingController = new NaiveLiftController(2, 3);
-        SimulationEngine engine = new SimulationEngine(parkingController, 0, 5);
+        SimulationEngine engine = SimulationEngine.builder(parkingController, 0, 5).build();
 
         engine.tick(); // tick 0
         engine.tick(); // tick 1
@@ -539,7 +549,7 @@ public class NaiveLiftControllerTest {
     @Test
     public void testParkingInterruptedByNewRequest() {
         NaiveLiftController parkingController = new NaiveLiftController(4, 1);
-        SimulationEngine engine = new SimulationEngine(parkingController, 0, 5);
+        SimulationEngine engine = SimulationEngine.builder(parkingController, 0, 5).build();
 
         engine.tick(); // tick 0
         engine.tick(); // tick 1 -> start parking to floor 4
@@ -637,7 +647,12 @@ public class NaiveLiftControllerTest {
     @Test
     public void testIntegrationCancelWhileMoving() {
         // Integration test: cancel request while lift is moving towards it
-        SimulationEngine engine = new SimulationEngine(controller, 0, 10, 1, 2, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(controller, 0, 10)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(2)
+                .doorReopenWindowTicks(2)
+                .build();
 
         // Add request to floor 5
         LiftRequest request = LiftRequest.carCall(5);

--- a/src/test/java/com/liftsimulator/engine/OutOfServiceTest.java
+++ b/src/test/java/com/liftsimulator/engine/OutOfServiceTest.java
@@ -18,7 +18,7 @@ public class OutOfServiceTest {
     @BeforeEach
     public void setUp() {
         controller = new NaiveLiftController();
-        engine = new SimulationEngine(controller, 0, 10);
+        engine = SimulationEngine.builder(controller, 0, 10).build();
     }
 
     @Test

--- a/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
+++ b/src/test/java/com/liftsimulator/engine/SimulationEngineTest.java
@@ -34,11 +34,11 @@ public class SimulationEngineTest {
 
     @Test
     public void testInitializesAtMinFloor() {
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.IDLE),
                 2,
                 6
-        );
+        ).build();
 
         assertEquals(2, engine.getCurrentState().getFloor());
         assertEquals(Direction.IDLE, engine.getCurrentState().getDirection());
@@ -48,11 +48,11 @@ public class SimulationEngineTest {
     @Test
     public void testMoveUpIncrementsFloorByOne() {
         // Given: lift at floor 0 with doors closed
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,  // minFloor
                 5   // maxFloor
-        );
+        ).build();
 
         // When: tick with MOVE_UP action
         engine.tick();
@@ -65,11 +65,11 @@ public class SimulationEngineTest {
     @Test
     public void testMoveUpDoesNotExceedTopFloor() {
         // Given: lift at top floor (5) with doors closed
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,
                 5
-        );
+        ).build();
 
         // Move to top floor
         for (int i = 0; i < 5; i++) {
@@ -88,11 +88,11 @@ public class SimulationEngineTest {
     @Test
     public void testMoveDownDecrementsFloorByOne() {
         // Given: lift at floor 3 with doors closed
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,
                 5
-        );
+        ).build();
 
         // Move up to floor 3
         for (int i = 0; i < 3; i++) {
@@ -101,36 +101,36 @@ public class SimulationEngineTest {
         assertEquals(3, engine.getCurrentState().getFloor());
 
         // Switch to MOVE_DOWN controller
-        engine = new SimulationEngine(
+        engine = SimulationEngine.builder(
                 new FixedActionController(Action.IDLE),
                 0,
                 5
-        );
+        ).build();
         // Manually advance to floor 3
         for (int i = 0; i < 3; i++) {
-            engine = new SimulationEngine(
+            engine = SimulationEngine.builder(
                     new FixedActionController(Action.MOVE_UP),
                     0,
                     5
-            );
+            ).build();
             for (int j = 0; j <= i; j++) {
                 engine.tick();
             }
         }
 
         // Create new engine at floor 3 going down
-        engine = new SimulationEngine(
+        engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_DOWN),
                 0,
                 5
-        );
+        ).build();
         // Move to floor 3 first
         for (int i = 0; i < 3; i++) {
-            engine = new SimulationEngine(
+            engine = SimulationEngine.builder(
                     new FixedActionController(Action.MOVE_UP),
                     0,
                     5
-            );
+            ).build();
             for (int j = 0; j < 3; j++) {
                 engine.tick();
             }
@@ -153,7 +153,7 @@ public class SimulationEngineTest {
             }
         };
 
-        engine = new SimulationEngine(moveToFloor3ThenDown, 0, 5);
+        engine = SimulationEngine.builder(moveToFloor3ThenDown, 0, 5).build();
 
         // Move up to floor 3
         for (int i = 0; i < 3; i++) {
@@ -177,11 +177,11 @@ public class SimulationEngineTest {
     @Test
     public void testMoveDownDoesNotGoBelowGroundFloor() {
         // Given: lift at ground floor (0) with doors closed
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_DOWN),
                 0,
                 5
-        );
+        ).build();
 
         // When: attempt to move down from ground floor
         engine.tick();
@@ -209,7 +209,7 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(moveUpThenDownPastMin, 0, 3);
+        SimulationEngine engine = SimulationEngine.builder(moveUpThenDownPastMin, 0, 3).build();
 
         // Move up to floor 1
         engine.tick();
@@ -251,7 +251,7 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(openDoorThenMoveUp, 0, 5);
+        SimulationEngine engine = SimulationEngine.builder(openDoorThenMoveUp, 0, 5).build();
 
         // Open the door (2 ticks)
         engine.tick();  // IDLE -> DOORS_OPENING
@@ -290,7 +290,7 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(moveUpTwiceThenOpenThenDown, 0, 5);
+        SimulationEngine engine = SimulationEngine.builder(moveUpTwiceThenOpenThenDown, 0, 5).build();
 
         // Move to floor 2
         engine.tick();
@@ -327,7 +327,11 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(openThenMoveUpDuringClose, 0, 5, 1, 2, 1);
+        SimulationEngine engine = SimulationEngine.builder(openThenMoveUpDuringClose, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(1)
+                .build();
 
         engine.tick(); // start opening
         engine.tick(); // doors open
@@ -359,7 +363,7 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(openThenIdle, 0, 5);
+        SimulationEngine engine = SimulationEngine.builder(openThenIdle, 0, 5).build();
         assertEquals(DoorState.CLOSED, engine.getCurrentState().getDoorState());
 
         // When: OPEN_DOOR action (starts opening)
@@ -389,7 +393,11 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(openThenIdle, 0, 5, 1, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(openThenIdle, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(2)
+                .build();
 
         // Open the door (2 ticks: OPEN_DOOR -> IDLE)
         engine.tick();  // IDLE -> DOORS_OPENING
@@ -411,11 +419,11 @@ public class SimulationEngineTest {
     @Test
     public void testMoveUpSequence() {
         // Test multiple moves up in sequence
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,
                 10
-        );
+        ).build();
 
         for (int expectedFloor = 1; expectedFloor <= 10; expectedFloor++) {
             engine.tick();
@@ -443,7 +451,7 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(moveUpThenDown, 0, 10);
+        SimulationEngine engine = SimulationEngine.builder(moveUpThenDown, 0, 10).build();
 
         // Move up to floor 5
         for (int i = 0; i < 5; i++) {
@@ -466,13 +474,14 @@ public class SimulationEngineTest {
 
     @Test
     public void testMoveUpHonorsTravelTicksPerFloor() {
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,
-                5,
-                3,
-                2
-        );
+                5
+        )
+                .travelTicksPerFloor(3)
+                .doorTransitionTicks(2)
+                .build();
 
         engine.tick();
         assertEquals(0, engine.getCurrentState().getFloor());
@@ -489,14 +498,15 @@ public class SimulationEngineTest {
 
     @Test
     public void testDoorTransitionConsumesConfiguredTicks() {
-        SimulationEngine engine = new SimulationEngine(
+        SimulationEngine engine = SimulationEngine.builder(
                 new FixedActionController(Action.OPEN_DOOR),
                 0,
-                5,
-                1,
-                3,
-                2
-        );
+                5
+        )
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(3)
+                .doorDwellTicks(2)
+                .build();
 
         engine.tick();
         assertEquals(LiftStatus.DOORS_OPENING, engine.getCurrentState().getStatus());
@@ -525,7 +535,11 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(openThenIdle, 0, 5, 1, 2, 3);
+        SimulationEngine engine = SimulationEngine.builder(openThenIdle, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(3)
+                .build();
 
         engine.tick(); // start opening
         engine.tick(); // open
@@ -547,21 +561,23 @@ public class SimulationEngineTest {
 
     @Test
     public void testDeterministicResultsForFixedInputs() {
-        SimulationEngine firstRun = new SimulationEngine(
+        SimulationEngine firstRun = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,
-                5,
-                2,
-                2
-        );
+                5
+        )
+                .travelTicksPerFloor(2)
+                .doorTransitionTicks(2)
+                .build();
 
-        SimulationEngine secondRun = new SimulationEngine(
+        SimulationEngine secondRun = SimulationEngine.builder(
                 new FixedActionController(Action.MOVE_UP),
                 0,
-                5,
-                2,
-                2
-        );
+                5
+        )
+                .travelTicksPerFloor(2)
+                .doorTransitionTicks(2)
+                .build();
 
         for (int i = 0; i < 6; i++) {
             assertEquals(firstRun.getCurrentTick(), secondRun.getCurrentTick());
@@ -594,7 +610,12 @@ public class SimulationEngineTest {
         };
 
         // doorTransitionTicks=2, doorDwellTicks=2, doorReopenWindowTicks=2
-        SimulationEngine engine = new SimulationEngine(doorReopenController, 0, 5, 1, 2, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(doorReopenController, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(2)
+                .doorReopenWindowTicks(2)
+                .build();
 
         engine.tick(); // tick 1: start opening
         engine.tick(); // tick 2: doors open
@@ -635,7 +656,12 @@ public class SimulationEngineTest {
         };
 
         // doorTransitionTicks=4, doorDwellTicks=2, doorReopenWindowTicks=2
-        SimulationEngine engine = new SimulationEngine(doorReopenController, 0, 5, 1, 4, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(doorReopenController, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(4)
+                .doorDwellTicks(2)
+                .doorReopenWindowTicks(2)
+                .build();
 
         engine.tick(); // tick 1: start opening
         engine.tick(); // tick 2: opening continues
@@ -680,7 +706,12 @@ public class SimulationEngineTest {
             }
         };
 
-        SimulationEngine engine = new SimulationEngine(doorReopenController, 0, 5, 1, 2, 2, 2);
+        SimulationEngine engine = SimulationEngine.builder(doorReopenController, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(2)
+                .doorReopenWindowTicks(2)
+                .build();
 
         engine.tick(); // start opening
         engine.tick(); // doors open
@@ -714,7 +745,12 @@ public class SimulationEngineTest {
         };
 
         // doorReopenWindowTicks=0 means no reopening allowed
-        SimulationEngine engine = new SimulationEngine(doorReopenController, 0, 5, 1, 2, 1, 0);
+        SimulationEngine engine = SimulationEngine.builder(doorReopenController, 0, 5)
+                .travelTicksPerFloor(1)
+                .doorTransitionTicks(2)
+                .doorDwellTicks(1)
+                .doorReopenWindowTicks(0)
+                .build();
 
         engine.tick(); // start opening
         engine.tick(); // doors open
@@ -731,21 +767,41 @@ public class SimulationEngineTest {
     public void testReopenWindowValidation() {
         // Test that doorReopenWindowTicks cannot exceed doorTransitionTicks
         assertThrows(IllegalArgumentException.class, () -> {
-            new SimulationEngine(new FixedActionController(Action.IDLE), 0, 5, 1, 2, 3, 3);
+            SimulationEngine.builder(new FixedActionController(Action.IDLE), 0, 5)
+                    .travelTicksPerFloor(1)
+                    .doorTransitionTicks(2)
+                    .doorDwellTicks(3)
+                    .doorReopenWindowTicks(3)
+                    .build();
         });
 
         // Test that doorReopenWindowTicks cannot be negative (except -1 which is sentinel for default)
         assertThrows(IllegalArgumentException.class, () -> {
-            new SimulationEngine(new FixedActionController(Action.IDLE), 0, 5, 1, 2, 3, -2);
+            SimulationEngine.builder(new FixedActionController(Action.IDLE), 0, 5)
+                    .travelTicksPerFloor(1)
+                    .doorTransitionTicks(2)
+                    .doorDwellTicks(3)
+                    .doorReopenWindowTicks(-2)
+                    .build();
         });
 
         // Test that valid values are accepted
         assertDoesNotThrow(() -> {
-            new SimulationEngine(new FixedActionController(Action.IDLE), 0, 5, 1, 2, 3, 2);
+            SimulationEngine.builder(new FixedActionController(Action.IDLE), 0, 5)
+                    .travelTicksPerFloor(1)
+                    .doorTransitionTicks(2)
+                    .doorDwellTicks(3)
+                    .doorReopenWindowTicks(2)
+                    .build();
         });
 
         assertDoesNotThrow(() -> {
-            new SimulationEngine(new FixedActionController(Action.IDLE), 0, 5, 1, 2, 3, 0);
+            SimulationEngine.builder(new FixedActionController(Action.IDLE), 0, 5)
+                    .travelTicksPerFloor(1)
+                    .doorTransitionTicks(2)
+                    .doorDwellTicks(3)
+                    .doorReopenWindowTicks(0)
+                    .build();
         });
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the telescoping `SimulationEngine` constructors with a clearer, maintainable construction API to improve usability and reduce constructor overload combinatorics.
- Centralize validation and defaulting logic so all configuration flows through a single initialization path while preserving prior defaults (e.g., `-1` sentinel for `doorReopenWindowTicks`).
- Make optional timing parameters explicit and discoverable via fluent setters to simplify usage in application code and tests.

### Description
- Add `SimulationEngine.Builder` with fluent setters `initialFloor`, `travelTicksPerFloor`, `doorTransitionTicks`, `doorDwellTicks`, `doorReopenWindowTicks`, and a `build()` method to create the engine instance.
- Replace the multiple public constructors with a single private `SimulationEngine(Builder)` constructor that performs validation and initialization using builder values and preserved sentinel/default semantics.
- Migrate all call sites to the new builder pattern, including `Main.java`, `ScenarioRunnerMain.java`, and test sources under `src/test/java/com/liftsimulator/engine`.
- Bump project version to `0.12.0`, update `README.md` to show builder usage, and add a `0.12.0` entry to `CHANGELOG.md`.

### Testing
- No automated tests were executed as part of this change.
- Existing unit and integration tests in `src/test/java` were updated to construct `SimulationEngine` via the builder and can be run with `mvn test` to validate behavior.
- Recommend running `mvn test` and `mvn package` to verify the build and test-suite pass after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f8604aae88325bcbb8b55551bcf9f)