### PR TITLE
Replace magic numbers with named constants and bump version to 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-01-10
+
+### Changed
+- Extract default timing values and sentinel configuration into named constants
+
 ## [0.12.0] - 2026-01-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.0**
+Current version: **0.12.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.0) implements:
+The current version (v0.12.1) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -81,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.1.jar`.
 
 ## Running the Simulation
 
@@ -94,7 +94,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.1.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -110,7 +110,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.0</version>
+    <version>0.12.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/SimulationEngine.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationEngine.java
@@ -9,6 +9,11 @@ import com.liftsimulator.domain.LiftStatus;
  * The engine owns time and coordinates state updates.
  */
 public class SimulationEngine {
+    private static final int DEFAULT_TRAVEL_TICKS_PER_FLOOR = 1;
+    private static final int DEFAULT_DOOR_TRANSITION_TICKS = 2;
+    private static final int DEFAULT_DOOR_DWELL_TICKS = 3;
+    private static final int DEFAULT_DOOR_REOPEN_WINDOW_MAX_TICKS = 2;
+    private static final int SENTINEL_USE_DEFAULT = -1;
     private final SimulationClock clock;
     private LiftState currentState;
     private final LiftController controller;
@@ -36,10 +41,10 @@ public class SimulationEngine {
         private final int minFloor;
         private final int maxFloor;
         private int initialFloor;
-        private int travelTicksPerFloor = 1;
-        private int doorTransitionTicks = 2;
-        private int doorDwellTicks = 3;
-        private int doorReopenWindowTicks = -1;
+        private int travelTicksPerFloor = DEFAULT_TRAVEL_TICKS_PER_FLOOR;
+        private int doorTransitionTicks = DEFAULT_DOOR_TRANSITION_TICKS;
+        private int doorDwellTicks = DEFAULT_DOOR_DWELL_TICKS;
+        private int doorReopenWindowTicks = SENTINEL_USE_DEFAULT;
 
         public Builder(LiftController controller, int minFloor, int maxFloor) {
             this.controller = controller;
@@ -90,9 +95,9 @@ public class SimulationEngine {
         }
 
         int configuredDoorReopenWindowTicks = builder.doorReopenWindowTicks;
-        // Use -1 as sentinel for "use default": min(2, doorTransitionTicks) for backward compatibility
-        if (configuredDoorReopenWindowTicks == -1) {
-            configuredDoorReopenWindowTicks = Math.min(2, builder.doorTransitionTicks);
+        // Use sentinel for "use default": min(DEFAULT_DOOR_REOPEN_WINDOW_MAX_TICKS, doorTransitionTicks)
+        if (configuredDoorReopenWindowTicks == SENTINEL_USE_DEFAULT) {
+            configuredDoorReopenWindowTicks = Math.min(DEFAULT_DOOR_REOPEN_WINDOW_MAX_TICKS, builder.doorTransitionTicks);
         }
 
         if (configuredDoorReopenWindowTicks < 0) {


### PR DESCRIPTION
### Motivation
- Replace hard-coded timing values and sentinel literals with named constants to improve readability and maintainability.
- Preserve existing backward-compatible behavior for the door reopen window while making the default value explicit.
- Centralize default timing configuration so `SimulationEngine` defaults are easier to find and adjust.
- Update project metadata to reflect the small, non-breaking change with a patch version bump to `0.12.1`.

### Description
- Add named constants (`DEFAULT_TRAVEL_TICKS_PER_FLOOR`, `DEFAULT_DOOR_TRANSITION_TICKS`, `DEFAULT_DOOR_DWELL_TICKS`, `DEFAULT_DOOR_REOPEN_WINDOW_MAX_TICKS`, `SENTINEL_USE_DEFAULT`) to `SimulationEngine` and use them for builder defaults and internal logic.
- Replace the `-1` magic sentinel with `SENTINEL_USE_DEFAULT` and compute the default reopen window as `Math.min(DEFAULT_DOOR_REOPEN_WINDOW_MAX_TICKS, doorTransitionTicks)` when the sentinel is used.
- Update the `Builder` default fields to reference the new constants instead of literal values.
- Bump project version in `pom.xml` to `0.12.1`, update `README.md` references and JAR paths, and add an entry to `CHANGELOG.md` describing the change.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f881aacb883259c25adc2a4c73cf5)