### PR TITLE
Refactor tick state handling and bump version to v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-01-10
+
+### Changed
+- Refactor tick processing into state-specific handlers for clearer maintenance
+
 ## [0.12.1] - 2026-01-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.1**
+Current version: **0.12.2**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.1) implements:
+The current version (v0.12.2) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -81,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.1.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.2.jar`.
 
 ## Running the Simulation
 
@@ -94,7 +94,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.2.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -110,7 +110,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:


### PR DESCRIPTION
### Motivation

- Reduce complexity and the potential for future state-transition race bugs by separating state-specific tick logic. 
- Implement the suggested state-behavior extraction so each `LiftStatus` has a single handler. 
- Improve maintainability and make `tick()` easier to reason about and extend. 
- Bump the project patch version to reflect the non-breaking refactor. 

### Description

- Add a `TickBehavior` functional interface and a `STATE_BEHAVIORS` map that dispatches `LiftStatus` to handler methods. 
- Replace the large branching logic in `SimulationEngine.tick()` with state-specific handlers: `handleMovementTick`, `handleDoorTransitionTick`, `handleDoorDwellTick`, and `handleIdleTick`. 
- Update `src/main/java/com/liftsimulator/engine/SimulationEngine.java` to use the behavior map and handlers, preserving existing transition rules and timing counters. 
- Update `CHANGELOG.md` and `README.md` and bump version references to `0.12.2` (including packaged JAR names). 

### Testing

- No automated tests were executed as part of this change. 
- Recommended automated checks to run locally: `mvn test` to run unit tests and `mvn package` to verify compilation and the JAR artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f8903dfb083258702daaf52c94d06)