### PR TITLE
Add LiftRequest ID reset hook for test isolation; bump to v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-01-11
+
+### Added
+- Add a test reset hook for the lift request ID generator to improve test isolation
+
 ## [0.12.2] - 2026-01-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.2**
+Current version: **0.12.3**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.2) implements:
+The current version (v0.12.3) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -81,7 +81,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.3.jar`.
 
 ## Running the Simulation
 
@@ -94,7 +94,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.3.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -110,7 +110,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/src/main/java/com/liftsimulator/domain/LiftRequest.java
+++ b/src/main/java/com/liftsimulator/domain/LiftRequest.java
@@ -51,6 +51,13 @@ public class LiftRequest {
     }
 
     /**
+     * Resets the request ID generator for test isolation.
+     */
+    static void resetIdGenerator() {
+        ID_GENERATOR.set(0);
+    }
+
+    /**
      * Creates a car call request.
      *
      * @param destinationFloor The destination floor selected by the passenger


### PR DESCRIPTION
### Motivation
- The `ID_GENERATOR` in `LiftRequest` is a static `AtomicLong` that persisted across instances and could break test isolation and determinism.
- A test-only hook allows resetting request IDs between tests to make assertions predictable.
- The repository version and documentation need to reflect the small, backwards-compatible change.

### Description
- Added a package-private static method `resetIdGenerator()` to `com.liftsimulator.domain.LiftRequest` that sets the ID generator back to zero.
- Updated `CHANGELOG.md` with a new `0.12.3` entry describing the added test reset hook.
- Bumped README version references and example JAR names from `0.12.2` to `0.12.3`.

### Testing
- No automated tests were executed as part of this change.
- Manual verification included reviewing the updated `LiftRequest` source to ensure the `resetIdGenerator` method is present and properly resets `ID_GENERATOR`.
- Documentation updates were validated by inspecting `CHANGELOG.md` and `README.md` for correct version/entry text.
- Build was not performed as part of this PR description generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9739dee083258102ec9b352e6585)