### PR TITLE
Add JaCoCo coverage reporting with 80% line coverage check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add JaCoCo coverage reporting and enforce an 80% line coverage minimum in Maven builds
+
 ## [0.12.3] - 2026-01-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -237,8 +237,10 @@ mvn test
 Run tests with coverage:
 
 ```bash
-mvn test jacoco:report
+mvn test jacoco:report jacoco:check
 ```
+
+The JaCoCo check enforces a minimum 80% line coverage threshold for the project.
 
 ## Request Types: Hall Calls vs. Car Calls
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,45 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.2</version>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>coverage-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Motivation
- Enable code coverage tracking to monitor test metrics and trends for the project.
- Enforce a minimum coverage gate to maintain code quality and prevent regressions.
- Make the coverage check easy to run from developer machines and CI by documenting the command.
- Record the tooling addition in the project changelog for visibility.

### Description
- Add the `org.jacoco:jacoco-maven-plugin` to `pom.xml` with `prepare-agent`, `report`, and `check` executions and a `LINE` coverage minimum of `0.80` for the `BUNDLE` element.
- Update `README.md` to recommend running `mvn test jacoco:report jacoco:check` and note the enforced 80% line coverage threshold.
- Update `CHANGELOG.md` under `Unreleased` to mention the addition of JaCoCo coverage reporting and the 80% line coverage enforcement.
- No project version bump was performed as part of this change.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9836b4048325bcf35848807e4f57)