### PR TITLE
Return action results and log invalid actions in SimulationEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor simulation engine tests to use a sequence-based controller helper to reduce boilerplate
 - Extend the move-down test sequence to cover all downward ticks
 
+### Fixed
+- Return explicit action results and log invalid action attempts in the simulation engine to avoid silent failures
+
 ## [0.12.3] - 2026-01-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The current version (v0.12.3) implements:
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state for the lift, all other properties are derived
 - **State transition validation** ensuring only valid state changes occur (for both lift and requests)
+- **Invalid action reporting** with explicit action results and warning logs that include tick and floor context
 - **Symmetric door behavior**: Both opening and closing are modeled as transitional states
 - **Door reopening window**: Configurable time window during which closing doors can be reopened for new requests at the current floor
 - **Idle parking**: Configurable home floor and idle timeout to park the lift when no requests are pending


### PR DESCRIPTION
### Motivation
- Prevent silent failures when invalid actions are attempted by returning explicit success/failure information instead of silently returning the unchanged state.
- Improve troubleshooting by adding contextual warning logs including tick and floor when invalid actions or invalid transitions occur.
- Ensure the engine stop-processing behavior on failed actions to avoid progressing idle tick work after invalid attempts.

### Description
- Change `SimulationEngine.startAction` to return an `ActionResult` record (`state`, `success`) instead of a raw `LiftState`, and update callers to respect the result. (see `src/main/java/com/liftsimulator/engine/SimulationEngine.java`)
- Add a `Logger` instance and `logInvalidAction` helper to emit warnings for invalid actions and expanded warnings for invalid transitions that include action, status, floor and tick context.
- Short-circuit idle tick processing when `startAction` reports failure so no movement/door progression occurs for invalid actions.
- Document the behavior in `CHANGELOG.md` and `README.md` under Unreleased/Features to note the explicit action results and invalid action reporting.

### Testing
- No automated tests were executed as part of this change.
- Existing test suite was not modified in this PR and should pass locally; consider adding a unit test to assert `ActionResult.success` is false and a log is emitted for disallowed actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9c08b6b883258055f3761cdcf0c9)