### PR TITLE
Validate scenario tick parsing and finalize 0.12.4 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.4] - 2026-01-12
+
 ### Added
 - Add JaCoCo coverage reporting and enforce an 80% line coverage minimum in Maven builds
 - Add integration tests covering scenario parsing, execution, and invalid scenario handling
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend the move-down test sequence to cover all downward ticks
 
 ### Fixed
+- Validate scenario event ticks to reject negative or malformed values with clear error messages
 - Return explicit action results and log invalid action attempts in the simulation engine to avoid silent failures
 
 ## [0.12.3] - 2026-01-11

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.3**
+Current version: **0.12.4**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.3) implements:
+The current version (v0.12.4) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -82,7 +82,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.3.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.4.jar`.
 
 ## Running Tests
 
@@ -106,7 +106,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.3.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.4.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -122,7 +122,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.1</version>
+    <version>0.12.4</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
@@ -117,7 +117,7 @@ public class ScenarioParser {
                     throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "Invalid event line: " + line));
                 }
 
-                long tick = Long.parseLong(tokens[0]);
+                long tick = parseTick(tokens[0], sourceName, lineNumber);
                 String action = tokens[1].toLowerCase();
                 Integer floorValue = extractFloorValue(action, tokens);
                 if (floorValue != null) {
@@ -224,6 +224,21 @@ public class ScenarioParser {
 
     private String errorMessage(String sourceName, int lineNumber, String message) {
         return String.format("%s (line %d): %s", sourceName, lineNumber, message);
+    }
+
+    private long parseTick(String token, String sourceName, int lineNumber) {
+        try {
+            long tick = Long.parseLong(token);
+            if (tick < 0) {
+                throw new IllegalArgumentException(errorMessage(sourceName, lineNumber, "Tick must be non-negative"));
+            }
+            return tick;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    errorMessage(sourceName, lineNumber, "Invalid tick value: " + token),
+                    e
+            );
+        }
     }
 
     private Integer parseIntValue(String trimmed, String prefix) {


### PR DESCRIPTION
### Motivation

- Ensure scenario event ticks are validated to prevent negative or malformed tick values from causing uncaught exceptions. 
- Centralize tick validation to provide clearer, contextual error messages for scenario parsing errors. 
- Finalize release metadata and documentation to reflect shipped changes for version `0.12.4`.
- Move previously `Unreleased` changelog entries into the `0.12.4` release section to keep history consistent.

### Description

- Added `parseTick(String token, String sourceName, int lineNumber)` in `src/main/java/com/liftsimulator/scenario/ScenarioParser.java` to validate numeric ticks and reject negative values, and replaced the direct `Long.parseLong(tokens[0])` call with `parseTick(...)`.
- Updated project version in `pom.xml` to `0.12.4` and updated references in `README.md` to use `0.12.4` (version string, packaged JAR path, and example classpath invocations).
- Moved notes from the `Unreleased` section into the `0.12.4` section in `CHANGELOG.md` and adjusted entries to reflect added, changed, and fixed items for the release.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9d970c9883259271dfe1dd68fe21)