### PR TITLE
Add JavaDoc for public APIs and bump version to 0.12.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.5] - 2026-01-13
+
+### Changed
+- Add JavaDoc coverage for public APIs in the lift engine and domain enums
+
 ## [0.12.4] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.4**
+Current version: **0.12.5**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.4) implements:
+The current version (v0.12.5) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -82,7 +82,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.4.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.5.jar`.
 
 ## Running Tests
 
@@ -106,7 +106,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.4.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.5.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -122,7 +122,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.4</version>
+    <version>0.12.5</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/domain/Direction.java
+++ b/src/main/java/com/liftsimulator/domain/Direction.java
@@ -4,7 +4,16 @@ package com.liftsimulator.domain;
  * Represents the direction of lift movement or a request.
  */
 public enum Direction {
+    /**
+     * Indicates upward movement or an upward request.
+     */
     UP,
+    /**
+     * Indicates downward movement or a downward request.
+     */
     DOWN,
+    /**
+     * Indicates no active movement.
+     */
     IDLE
 }

--- a/src/main/java/com/liftsimulator/domain/DoorState.java
+++ b/src/main/java/com/liftsimulator/domain/DoorState.java
@@ -4,6 +4,12 @@ package com.liftsimulator.domain;
  * Represents the state of the lift doors.
  */
 public enum DoorState {
+    /**
+     * Doors are fully open.
+     */
     OPEN,
+    /**
+     * Doors are fully closed.
+     */
     CLOSED
 }

--- a/src/main/java/com/liftsimulator/engine/SimulationClock.java
+++ b/src/main/java/com/liftsimulator/engine/SimulationClock.java
@@ -6,14 +6,25 @@ package com.liftsimulator.engine;
 public class SimulationClock {
     private long currentTick;
 
+    /**
+     * Creates a simulation clock starting at tick zero.
+     */
     public SimulationClock() {
         this.currentTick = 0;
     }
 
+    /**
+     * Advances the simulation clock by one tick.
+     */
     public void tick() {
         currentTick++;
     }
 
+    /**
+     * Returns the current tick value.
+     *
+     * @return the current tick
+     */
     public long getCurrentTick() {
         return currentTick;
     }

--- a/src/main/java/com/liftsimulator/engine/StateTransitionValidator.java
+++ b/src/main/java/com/liftsimulator/engine/StateTransitionValidator.java
@@ -77,11 +77,13 @@ public class StateTransitionValidator {
     }
 
     /**
-     * Determines the next status based on current status and action.
+     * Determines the next lift status based on the current status and requested action.
      *
-     * @param currentStatus The current lift status
-     * @param action The action being performed
-     * @return The next lift status after applying the action
+     * @param currentStatus the current lift status
+     * @param action the action being performed
+     * @return the next lift status after applying the action
+     * @see LiftStatus for the available lift states
+     * @see Action for the set of actions that drive transitions
      */
     public static LiftStatus getNextStatus(LiftStatus currentStatus, Action action) {
         return switch (action) {
@@ -106,11 +108,12 @@ public class StateTransitionValidator {
     }
 
     /**
-     * Validates if a transition from one status to another is valid.
+     * Validates whether a transition between lift statuses is allowed.
      *
-     * @param fromStatus The current status
-     * @param toStatus The target status
+     * @param fromStatus the current status
+     * @param toStatus the target status
      * @return true if the transition is valid, false otherwise
+     * @see LiftStatus for the complete lift state machine
      */
     public static boolean isValidTransition(LiftStatus fromStatus, LiftStatus toStatus) {
         Set<LiftStatus> validNextStates = VALID_TRANSITIONS.get(fromStatus);
@@ -132,11 +135,12 @@ public class StateTransitionValidator {
     }
 
     /**
-     * Validates if an action is allowed in the current status.
+     * Validates whether an action is allowed in the current status.
      *
-     * @param currentStatus The current lift status
-     * @param action The action to validate
+     * @param currentStatus the current lift status
+     * @param action the action to validate
      * @return true if the action is allowed, false otherwise
+     * @see Action for the action set validated by this method
      */
     public static boolean isActionAllowed(LiftStatus currentStatus, Action action) {
         LiftStatus nextStatus = getNextStatus(currentStatus, action);
@@ -146,8 +150,9 @@ public class StateTransitionValidator {
     /**
      * Gets the set of valid next states from the current status.
      *
-     * @param currentStatus The current status
-     * @return Set of valid next states
+     * @param currentStatus the current status
+     * @return set of valid next states
+     * @see LiftStatus for the defined states
      */
     public static Set<LiftStatus> getValidNextStates(LiftStatus currentStatus) {
         return VALID_TRANSITIONS.getOrDefault(currentStatus, EnumSet.noneOf(LiftStatus.class));


### PR DESCRIPTION
### Motivation

- Address missing JavaDoc on public APIs to improve API usability and maintainability.
- Document enum values to clarify domain semantics for `Direction` and `DoorState`.
- Provide basic JavaDoc on the simulation clock and state transition utilities for clearer developer guidance.
- Publish the change under a new SemVer patch release.

### Description

- Add JavaDoc comments to `StateTransitionValidator` public methods including `getNextStatus`, `isValidTransition`, `isActionAllowed`, and `getValidNextStates` to describe parameters, return values, and related types.
- Add JavaDoc for `SimulationClock` constructor, `tick()`, and `getCurrentTick()` to document behavior and return values.
- Add enum value documentation to `Direction` and `DoorState` describing `UP`, `DOWN`, `IDLE`, `OPEN`, and `CLOSED` semantics.
- Bump project version to `0.12.5` in `pom.xml`, update `README.md` references, and add a `CHANGELOG.md` entry for `0.12.5`.

### Testing

- No automated tests were run as part of this change.
- Existing test suite was not modified and will run normally via `mvn test` after merging.
- Changes are purely documentation and version metadata without behavioral changes to core logic.
- Static compilation should remain unaffected; run `mvn clean compile` to verify locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9ffea8d08325bc190bf16e55efe5)