### PR TITLE
Add package-level JavaDoc and bump version to 0.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.6] - 2026-01-14
+
+### Added
+- Add package-level documentation for the core lift simulator packages
+
 ## [0.12.5] - 2026-01-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.5**
+Current version: **0.12.6**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.5) implements:
+The current version (v0.12.6) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -82,7 +82,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.5.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.6.jar`.
 
 ## Running Tests
 
@@ -106,7 +106,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.5.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.6.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -122,7 +122,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.5</version>
+    <version>0.12.6</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/domain/package-info.java
+++ b/src/main/java/com/liftsimulator/domain/package-info.java
@@ -1,0 +1,13 @@
+/**
+ * Core domain models for the lift simulation system.
+ *
+ * <p>This package contains the fundamental types and value objects:
+ * <ul>
+ *   <li>{@link com.liftsimulator.domain.LiftState} - Immutable snapshot of lift state</li>
+ *   <li>{@link com.liftsimulator.domain.LiftStatus} - State machine enum with 7 states</li>
+ *   <li>{@link com.liftsimulator.domain.LiftRequest} - First-class request entity with lifecycle</li>
+ * </ul>
+ *
+ * @see com.liftsimulator.engine for simulation engine components
+ */
+package com.liftsimulator.domain;

--- a/src/main/java/com/liftsimulator/engine/package-info.java
+++ b/src/main/java/com/liftsimulator/engine/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Simulation engine and controller implementations for the lift system.
+ *
+ * <p>Classes in this package orchestrate time-based simulation, validate
+ * lift state transitions, and provide controller strategies for servicing
+ * requests.
+ *
+ * @see com.liftsimulator.domain for core domain types
+ */
+package com.liftsimulator.engine;

--- a/src/main/java/com/liftsimulator/package-info.java
+++ b/src/main/java/com/liftsimulator/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Entry points and shared interfaces for the lift simulation application.
+ *
+ * <p>The main executable demos and shared top-level utilities live here,
+ * while domain, engine, and scenario implementations reside in their
+ * respective subpackages.
+ */
+package com.liftsimulator;

--- a/src/main/java/com/liftsimulator/scenario/package-info.java
+++ b/src/main/java/com/liftsimulator/scenario/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Scenario parsing and execution for scripted lift simulations.
+ *
+ * <p>This package supports loading scenario definitions, scheduling
+ * events over discrete ticks, and running scripted simulations to
+ * validate controller behavior.
+ *
+ * @see com.liftsimulator.engine for simulation engine components
+ */
+package com.liftsimulator.scenario;


### PR DESCRIPTION
### Motivation
- Add package-level JavaDoc to improve code navigation and onboarding across the project.
- Provide descriptive package summaries for `com.liftsimulator`, `com.liftsimulator.domain`, `com.liftsimulator.engine`, and `com.liftsimulator.scenario` as recommended.
- Bump the project version following SemVer to reflect the documentation-only change with minimal impact.
- Record the change in `CHANGELOG.md` and update user-facing references in `README.md`.

### Description
- Added `package-info.java` files for the root and core packages at `src/main/java/com/liftsimulator/package-info.java`, `.../domain/package-info.java`, `.../engine/package-info.java`, and `.../scenario/package-info.java` with JavaDoc summaries.
- Updated the Maven project version in `pom.xml` from `0.12.5` to `0.12.6`.
- Updated `README.md` to reference the new version and adjusted the packaged JAR path to `target/lift-simulator-0.12.6.jar`.
- Added a `0.12.6` entry to `CHANGELOG.md` noting the package-level documentation addition.

### Testing
- No automated tests were run for this change.
- The `mvn test` command was not executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa10d2b1883259ef6676449b056d1)