### PR TITLE
Add OWASP Dependency-Check plugin and bump version to 0.12.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.11] - 2026-01-19
+
+### Added
+- Add OWASP Dependency-Check Maven plugin to scan for vulnerable dependencies during builds
+
 ## [0.12.10] - 2026-01-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.10**
+Current version: **0.12.11**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.10) implements:
+The current version (v0.12.11) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -82,7 +82,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.10.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.11.jar`.
 
 ## Running Tests
 
@@ -109,6 +109,12 @@ Run static analysis:
 mvn spotbugs:check
 ```
 
+Run dependency vulnerability checks:
+
+```bash
+mvn dependency-check:check
+```
+
 Generate coverage reports while running tests:
 
 ```bash
@@ -126,7 +132,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.10.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.11.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -142,7 +148,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.10.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.11.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.10</version>
+    <version>0.12.11</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -123,6 +123,18 @@
                                 </rule>
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>9.0.9</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### Motivation
- Add automated dependency vulnerability scanning to the build to detect known CVEs and improve supply-chain security.
- Bump the project version to reflect the new build/configuration change using Semantic Versioning.
- Document the new scan step and the release in the project README and `CHANGELOG.md` for discoverability.

### Description
- Add `org.owasp:dependency-check-maven:9.0.9` to `pom.xml` with a `check` execution to run vulnerability scans during the build.
- Bump the project version from `0.12.10` to `0.12.11` in `pom.xml` and update README references to the new version and packaged JAR name.
- Update `README.md` to include the `mvn dependency-check:check` command and updated artifact paths, and add a `0.12.11` entry to `CHANGELOG.md` noting the addition.
- Modified files: `pom.xml`, `README.md`, and `CHANGELOG.md`.

### Testing
- No automated tests were executed as part of this change.
- It is recommended to run `mvn test` and `mvn dependency-check:check` in CI to validate tests and scan results before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa8d47b508325b9e84f067dde88c8)