### PR TITLE
Maintain active/completed request sets in NaiveLiftController and bump version to 0.12.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.13] - 2026-01-21
+
+### Changed
+- Keep dedicated active/completed request collections in the naive controller to avoid rebuilding active sets during scheduling
+
 ## [0.12.12] - 2026-01-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.12**
+Current version: **0.12.13**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.12) implements:
+The current version (v0.12.13) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -83,7 +83,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.12.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.13.jar`.
 
 ## Running Tests
 
@@ -133,7 +133,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.12.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.13.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -149,7 +149,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.12.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.13.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.12</version>
+    <version>0.12.13</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Avoid repeatedly rebuilding a new active-request collection/stream on every scheduler call to reduce allocations and improve scheduling/cancellation performance.
- Preserve a clear separation between active and terminal (completed/cancelled) requests to simplify lifecycle handling.
- Ensure request archival is centralized so cancellation, completion, and out-of-service flows consistently remove requests from the active set.
- Publish the change as a patch release and update documentation to reflect the new behavior.

### Description
- Add a dedicated `completedRequests` set and `archiveRequest(LiftRequest)` helper in `NaiveLiftController` to move terminal requests out of the active set and into an archival collection.
- Replace on-the-fly set construction with an unmodifiable view returned by `getActiveRequests()` via `Collections.unmodifiableSet(activeRequests)` to avoid allocations when reading active requests.
- Update request lifecycle flows to call `archiveRequest(...)` from `cancelRequest(...)`, `completeRequestsForFloor(...)`, and `takeOutOfService()` so terminal requests are consistently archived and removed from the lookup map.
- Bump project version to `0.12.13` and update `CHANGELOG.md` and `README.md` to reflect the release and changes.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb1f9c2748325b6212f3ced03fb1e)