### PR TITLE
Format scenario limit constants without numeric separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.14] - 2026-01-22
+
+### Fixed
+- Enforce scenario tick and event limits to prevent resource exhaustion when parsing scenario files
+
 ## [0.12.13] - 2026-01-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.13**
+Current version: **0.12.14**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.13) implements:
+The current version (v0.12.14) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -83,7 +83,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.13.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.14.jar`.
 
 ## Running Tests
 
@@ -133,7 +133,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.13.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.14.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -149,10 +149,10 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.13.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.14.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
-Scenario files are plain text with metadata and event lines:
+Scenario files are plain text with metadata and event lines. Scenario parsing enforces limits of 1,000,000 ticks and 10,000 events per file:
 
 ```text
 name: Demo scenario - multiple events

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.13</version>
+    <version>0.12.14</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioParser.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Locale;
 
 public class ScenarioParser {
+    private static final int MAX_EVENTS = 10000;
+    private static final int MAX_TICKS = 1000000;
+
     public ScenarioDefinition parse(Path path) throws IOException {
         try (InputStream inputStream = Files.newInputStream(path)) {
             return parse(inputStream, path.toString());
@@ -65,6 +68,11 @@ public class ScenarioParser {
                 if (trimmed.startsWith("ticks:")) {
                     String value = trimmed.substring("ticks:".length()).trim();
                     totalTicks = Integer.parseInt(value);
+                    if (totalTicks > MAX_TICKS) {
+                        throw new IllegalArgumentException(
+                                "Scenario exceeds maximum tick limit: " + MAX_TICKS
+                        );
+                    }
                     continue;
                 }
 
@@ -127,6 +135,11 @@ public class ScenarioParser {
                 }
                 ScenarioEvent event = parseEvent(tick, action, tokens, sourceName, lineNumber);
                 events.add(event);
+                if (events.size() > MAX_EVENTS) {
+                    throw new IllegalArgumentException(
+                            "Scenario exceeds maximum event limit: " + MAX_EVENTS
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
### Motivation
- Prevent unbounded CPU/memory usage when parsing large or malicious scenario files by enforcing limits on ticks and event counts.  
- Publish the change as a patch release and keep documentation in sync by bumping the project version and updating `README.md` and `CHANGELOG.md`.  
- Address review feedback to remove numeric separators in integer literals for consistency in `ScenarioParser.java`.

### Description
- Add `MAX_EVENTS` and `MAX_TICKS` and validate `ticks:` and per-event counts during parsing in `ScenarioParser.java`.  
- Throw `IllegalArgumentException` when a scenario exceeds `MAX_TICKS` or `MAX_EVENTS`.  
- Bump version to `0.12.14` in `pom.xml` and update `README.md` and `CHANGELOG.md` to document the limits and new version.  
- Remove numeric separators from the constants in `ScenarioParser.java` and reformat the literals to `10000` and `1000000`.

### Testing
- No automated tests were executed as part of this change.  
- The change is limited to parsing guards and a small formatting tweak and should be covered by existing scenario integration tests when running `mvn test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb35618a48325a46c5b6ea5b1093d)