### PR TITLE
Guard idle timeout tracking in NaiveLiftController; release 0.12.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.16] - 2026-01-24
+
+### Fixed
+- Guard idle timeout calculations in the naive controller against null idle tracking state
+
 ## [0.12.15] - 2026-01-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.15**
+Current version: **0.12.16**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,7 +20,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.15) implements:
+The current version (v0.12.16) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
@@ -33,6 +33,7 @@ The current version (v0.12.15) implements:
 - **Symmetric door behavior**: Both opening and closing are modeled as transitional states
 - **Door reopening window**: Configurable time window during which closing doors can be reopened for new requests at the current floor
 - **Idle parking**: Configurable home floor and idle timeout to park the lift when no requests are pending
+- **Defensive idle tracking**: Idle timeout calculations guard against unset idle tracking state
 - **Single lift simulation** operating between configurable floor ranges
 - **Tick-based simulation engine** that advances time in discrete steps
 - **Simulation clock** powering deterministic tick progression
@@ -92,7 +93,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.15.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.16.jar`.
 
 ## Running Tests
 
@@ -142,7 +143,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.15.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.16.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -158,7 +159,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.15.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.16.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines. Scenario parsing enforces limits of 1,000,000 ticks and 10,000 events per file:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.14</version>
+    <version>0.12.16</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
+++ b/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
@@ -345,10 +345,12 @@ public final class NaiveLiftController implements LiftController {
             }
 
             if (shouldTrackIdle(currentState)) {
-                if (idleStartTick == null) {
+                Long trackedIdleStartTick = idleStartTick;
+                if (trackedIdleStartTick == null) {
+                    trackedIdleStartTick = currentTick;
                     idleStartTick = currentTick;
                 }
-                long idleTicks = currentTick - idleStartTick;
+                long idleTicks = currentTick - trackedIdleStartTick;
                 if (idleTicks >= idleTimeoutTicks && currentFloor != homeFloor) {
                     parkingInProgress = true;
                     return moveTowardHome(currentFloor);


### PR DESCRIPTION
### Motivation
- Prevent a null or racey read of idle tracking state when computing idle duration in the naive controller.  
- Make idle timeout logic defensive so the controller does not depend on fragile null-check ordering.  
- Record the fix in project metadata and release notes so users get a concrete version containing the change.  

### Description
- Use a local `Long trackedIdleStartTick` in `NaiveLiftController` and compute `idleTicks` from that local value to avoid null/racey usage of `idleStartTick`.  
- Add a `0.12.16` entry to `CHANGELOG.md` describing the fix.  
- Bump the project version in `pom.xml` to `0.12.16` and update version/JAR references in `README.md`.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb93101688325b806eeec47cbc7c7)