### PR TITLE
Centralize request completion in LiftRequest and bump version to 0.12.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.17] - 2026-01-25
+
+### Changed
+- Centralize request completion transitions in `LiftRequest` to avoid duplicated lifecycle chains
+
 ## [0.12.16] - 2026-01-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.12.16**
+Current version: **0.12.17**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -20,11 +20,12 @@ The simulation is text-based and designed for clarity over visual appeal.
 
 ## Features
 
-The current version (v0.12.16) implements:
+The current version (v0.12.17) implements:
 - **Out-of-service functionality**: Take lifts out of service safely for maintenance or emergencies, automatically cancelling all pending requests
 - **Request lifecycle management**: Requests are first-class entities with explicit lifecycle states (CREATED → QUEUED → ASSIGNED → SERVING → COMPLETED/CANCELLED)
 - **Request cancellation**: Cancel hall and car calls by request ID at any point before completion
 - **Request state tracking**: Every request has a unique ID and progresses through validated state transitions
+- **Request completion helper**: Requests can complete by advancing through lifecycle states in a single call
 - **Indexed request tracking**: Active requests are indexed by ID for faster cancellation lookups
 - **Formal lift state machine** with 7 explicit states (IDLE, MOVING_UP, MOVING_DOWN, DOORS_OPENING, DOORS_OPEN, DOORS_CLOSING, OUT_OF_SERVICE)
 - **Single source of truth**: LiftStatus is the only stored state for the lift, all other properties are derived
@@ -93,7 +94,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.12.16.jar`.
+The packaged JAR will be in `target/lift-simulator-0.12.17.jar`.
 
 ## Running Tests
 
@@ -143,7 +144,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.12.16.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.12.17.jar com.liftsimulator.Main
 ```
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -159,7 +160,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.12.16.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.12.17.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and event lines. Scenario parsing enforces limits of 1,000,000 ticks and 10,000 events per file:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.12.16</version>
+    <version>0.12.17</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
+++ b/src/main/java/com/liftsimulator/engine/NaiveLiftController.java
@@ -146,16 +146,7 @@ public final class NaiveLiftController implements LiftController {
                 .collect(Collectors.toSet());
 
         for (LiftRequest request : requestsToComplete) {
-            if (request.getState() == RequestState.SERVING) {
-                request.transitionTo(RequestState.COMPLETED);
-            } else if (request.getState() == RequestState.ASSIGNED) {
-                request.transitionTo(RequestState.SERVING);
-                request.transitionTo(RequestState.COMPLETED);
-            } else if (request.getState() == RequestState.QUEUED) {
-                request.transitionTo(RequestState.ASSIGNED);
-                request.transitionTo(RequestState.SERVING);
-                request.transitionTo(RequestState.COMPLETED);
-            }
+            request.completeRequest();
         }
 
         // Remove completed requests.


### PR DESCRIPTION
### Motivation
- Remove duplicated multi-step state transitions used when servicing requests to reduce bugs and improve readability.
- Encapsulate request lifecycle completion logic inside the `LiftRequest` domain object so transition rules are validated in one place.
- Simplify `NaiveLiftController` by delegating request progression to the request itself.
- Publish a patch release and update documentation to reflect the behavioral change.

### Description
- Add `LiftRequest.completeRequest()` which advances a request through intermediate states using `transitionTo(...)` and a `nextCompletionState(...)` helper.
- Replace the explicit multi-line transition sequence in `NaiveLiftController.completeRequestsForFloor(...)` with a single call to `request.completeRequest()`.
- Update `CHANGELOG.md` with a `0.12.17` release entry noting the centralized request completion change and update `README.md` to reference `0.12.17` and mention the new completion helper.
- Bump the Maven project version in `pom.xml` to `0.12.17` and update packaged JAR references in the docs.

### Testing
- No automated tests were run for this change.
- It is recommended to run `mvn test` to validate the test suite after these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbbd348c88325a8f006626ffc243e)