### PR TITLE
Remove controller/idle-parking CLI overrides (help-only CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.15.0] - 2026-01-09
 
 ### Added
-- Command-line configuration options for the demo (`Main.java`)
-  - `--controller` / `-c` flag to select controller strategy (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN)
-  - `--idle-parking` / `-p` flag to select idle parking mode (STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR)
-  - `--help` / `-h` flag to display usage information
-  - Configuration display in demo output showing selected controller strategy and idle parking mode
-- Command-line configuration options for the scenario runner (`ScenarioRunnerMain.java`)
-  - `--controller` / `-c` flag to override scenario file controller strategy
-  - `--idle-parking` / `-p` flag to override scenario file idle parking mode
-  - `--help` / `-h` flag to display usage information
-  - Configuration display in scenario runner output showing active settings and whether they were overridden
 - Explicit `idle_parking_mode` configuration in `demo.scenario` with inline documentation
 - Comments in `demo.scenario` documenting available controller configuration options
 - Comprehensive README documentation for command-line usage of both demo and scenario runner
@@ -27,13 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Demo and scenario runner now display selected controller strategy and idle parking mode at startup
 - Demo.scenario now explicitly shows both controller_strategy and idle_parking_mode with comments
-
-### Design Decisions
-- Command-line arguments use long form (`--controller`) and short form (`-c`) for usability
-- Command-line overrides take precedence over scenario file settings for flexibility
-- Invalid argument values provide clear error messages with valid options
-- Sensible defaults match current behavior (NEAREST_REQUEST_ROUTING, PARK_TO_HOME_FLOOR)
-- Configuration is visible and unambiguous in demo output
+- Demo and scenario runner only expose `--help` on the command line; controller strategy and idle parking mode are configured via scenario files or defaults
 
 ## [0.14.0] - 2026-01-09
 

--- a/README.md
+++ b/README.md
@@ -150,27 +150,17 @@ java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.Main
 
 ### Configuring the Demo
 
-The demo supports command-line options to select controller strategy and idle parking mode:
+The demo runs with a fixed configuration (NEAREST_REQUEST_ROUTING controller, PARK_TO_HOME_FLOOR idle parking). The only command-line option is the help flag:
 
 ```bash
 # Show help
 java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.Main --help
 
-# Run with default configuration (NEAREST_REQUEST_ROUTING controller, PARK_TO_HOME_FLOOR parking)
+# Run with the default demo configuration
 java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.Main
-
-# Use STAY_AT_CURRENT_FLOOR parking mode
-java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.Main --idle-parking STAY_AT_CURRENT_FLOOR
-
-# Specify both controller and parking mode
-java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.Main -c NEAREST_REQUEST_ROUTING -p PARK_TO_HOME_FLOOR
 ```
 
 **Available Options:**
-- `-c, --controller STRATEGY`: Controller strategy (`NEAREST_REQUEST_ROUTING`, `DIRECTIONAL_SCAN`)
-  - Default: `NEAREST_REQUEST_ROUTING`
-- `-p, --idle-parking MODE`: Idle parking mode (`STAY_AT_CURRENT_FLOOR`, `PARK_TO_HOME_FLOOR`)
-  - Default: `PARK_TO_HOME_FLOOR`
 - `-h, --help`: Show help message
 
 The demo runs a pre-configured scenario with several lift requests and displays the simulation state at each tick.
@@ -191,7 +181,7 @@ java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.scenario.ScenarioRun
 
 ### Configuring Scenario Runner
 
-The scenario runner supports command-line options to override scenario file settings:
+The scenario runner relies on scenario file settings for controller strategy and idle parking mode. The only command-line option is the help flag:
 
 ```bash
 # Show help
@@ -200,19 +190,14 @@ java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.scenario.ScenarioRun
 # Run with default demo scenario
 java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
-# Override idle parking mode for the demo scenario
-java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --idle-parking STAY_AT_CURRENT_FLOOR
-
-# Run custom scenario with overridden settings
-java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.scenario.ScenarioRunnerMain -c NEAREST_REQUEST_ROUTING -p PARK_TO_HOME_FLOOR custom.scenario
+# Run a custom scenario
+java -cp target/lift-simulator-0.15.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**
-- `-c, --controller STRATEGY`: Controller strategy (overrides scenario file)
-- `-p, --idle-parking MODE`: Idle parking mode (overrides scenario file)
 - `-h, --help`: Show help message
 
-Command-line options take precedence over scenario file settings, which take precedence over defaults.
+Scenario file settings take precedence over defaults.
 
 Scenario files are plain text with metadata and event lines. Scenario parsing enforces limits of 1,000,000 ticks and 10,000 events per file:
 

--- a/src/main/java/com/liftsimulator/Main.java
+++ b/src/main/java/com/liftsimulator/Main.java
@@ -32,30 +32,12 @@ public class Main {
         ControllerStrategy controllerStrategy = DEFAULT_CONTROLLER_STRATEGY;
         IdleParkingMode idleParkingMode = DEFAULT_IDLE_PARKING_MODE;
 
-        for (int i = 0; i < args.length; i++) {
-            if ((args[i].equals("--controller") || args[i].equals("-c")) && i + 1 < args.length) {
-                try {
-                    controllerStrategy = ControllerStrategy.valueOf(args[i + 1]);
-                    i++;
-                } catch (IllegalArgumentException e) {
-                    System.err.println("Invalid controller strategy: " + args[i + 1]);
-                    System.err.println("Valid options: NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN");
-                    System.exit(1);
-                }
-            } else if ((args[i].equals("--idle-parking") || args[i].equals("-p")) && i + 1 < args.length) {
-                try {
-                    idleParkingMode = IdleParkingMode.valueOf(args[i + 1]);
-                    i++;
-                } catch (IllegalArgumentException e) {
-                    System.err.println("Invalid idle parking mode: " + args[i + 1]);
-                    System.err.println("Valid options: STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR");
-                    System.exit(1);
-                }
-            } else if (args[i].equals("--help") || args[i].equals("-h")) {
+        for (String arg : args) {
+            if (arg.equals("--help") || arg.equals("-h")) {
                 printUsage();
                 System.exit(0);
             } else {
-                System.err.println("Unknown argument: " + args[i]);
+                System.err.println("Unknown argument: " + arg);
                 printUsage();
                 System.exit(1);
             }
@@ -208,19 +190,11 @@ public class Main {
         System.out.println("Usage: java -jar lift-simulator.jar [OPTIONS]");
         System.out.println();
         System.out.println("Options:");
-        System.out.println("  -c, --controller STRATEGY       Controller strategy to use");
-        System.out.println("                                  (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN)");
-        System.out.println("                                  Default: NEAREST_REQUEST_ROUTING");
-        System.out.println("  -p, --idle-parking MODE         Idle parking mode");
-        System.out.println("                                  (STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR)");
-        System.out.println("                                  Default: PARK_TO_HOME_FLOOR");
         System.out.println("  -h, --help                      Show this help message");
         System.out.println();
         System.out.println("Examples:");
         System.out.println("  java -jar lift-simulator.jar");
-        System.out.println("  java -jar lift-simulator.jar --controller NEAREST_REQUEST_ROUTING");
-        System.out.println("  java -jar lift-simulator.jar --idle-parking STAY_AT_CURRENT_FLOOR");
-        System.out.println("  java -jar lift-simulator.jar -c NEAREST_REQUEST_ROUTING -p PARK_TO_HOME_FLOOR");
+        System.out.println("  java -jar lift-simulator.jar --help");
     }
 
     private static String resolveVersion() {

--- a/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
+++ b/src/main/java/com/liftsimulator/scenario/ScenarioRunnerMain.java
@@ -27,36 +27,16 @@ public class ScenarioRunnerMain {
     public static void main(String[] args) throws IOException {
         // Parse command-line arguments.
         String scenarioPath = null;
-        ControllerStrategy controllerStrategyOverride = null;
-        IdleParkingMode idleParkingModeOverride = null;
 
-        for (int i = 0; i < args.length; i++) {
-            if (args[i].equals("--help") || args[i].equals("-h")) {
+        for (String arg : args) {
+            if (arg.equals("--help") || arg.equals("-h")) {
                 printUsage();
                 System.exit(0);
-            } else if ((args[i].equals("--controller") || args[i].equals("-c")) && i + 1 < args.length) {
-                try {
-                    controllerStrategyOverride = ControllerStrategy.valueOf(args[i + 1]);
-                    i++;
-                } catch (IllegalArgumentException e) {
-                    System.err.println("Invalid controller strategy: " + args[i + 1]);
-                    System.err.println("Valid options: NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN");
-                    System.exit(1);
-                }
-            } else if ((args[i].equals("--idle-parking") || args[i].equals("-p")) && i + 1 < args.length) {
-                try {
-                    idleParkingModeOverride = IdleParkingMode.valueOf(args[i + 1]);
-                    i++;
-                } catch (IllegalArgumentException e) {
-                    System.err.println("Invalid idle parking mode: " + args[i + 1]);
-                    System.err.println("Valid options: STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR");
-                    System.exit(1);
-                }
-            } else if (!args[i].startsWith("-")) {
+            } else if (!arg.startsWith("-")) {
                 // This is the scenario file path.
-                scenarioPath = args[i];
+                scenarioPath = arg;
             } else {
-                System.err.println("Unknown argument: " + args[i]);
+                System.err.println("Unknown argument: " + arg);
                 printUsage();
                 System.exit(1);
             }
@@ -97,17 +77,12 @@ public class ScenarioRunnerMain {
         int idleTimeoutTicks = scenario.getIdleTimeoutTicks() != null
                 ? scenario.getIdleTimeoutTicks()
                 : DEFAULT_IDLE_TIMEOUT_TICKS;
-        // Apply command-line overrides if provided, otherwise use scenario or defaults.
-        IdleParkingMode idleParkingMode = idleParkingModeOverride != null
-                ? idleParkingModeOverride
-                : (scenario.getIdleParkingMode() != null
-                    ? scenario.getIdleParkingMode()
-                    : DEFAULT_IDLE_PARKING_MODE);
-        ControllerStrategy controllerStrategy = controllerStrategyOverride != null
-                ? controllerStrategyOverride
-                : (scenario.getControllerStrategy() != null
-                    ? scenario.getControllerStrategy()
-                    : DEFAULT_CONTROLLER_STRATEGY);
+        IdleParkingMode idleParkingMode = scenario.getIdleParkingMode() != null
+                ? scenario.getIdleParkingMode()
+                : DEFAULT_IDLE_PARKING_MODE;
+        ControllerStrategy controllerStrategy = scenario.getControllerStrategy() != null
+                ? scenario.getControllerStrategy()
+                : DEFAULT_CONTROLLER_STRATEGY;
 
         // Note: Scenarios currently require NaiveLiftController for request management.
         // If a non-NEAREST_REQUEST_ROUTING strategy is specified, we reject it for now.
@@ -121,10 +96,8 @@ public class ScenarioRunnerMain {
         // Print configuration.
         System.out.println("=== Lift Simulator - Scenario Runner ===");
         System.out.println("Scenario: " + (scenarioPath != null ? scenarioPath : DEFAULT_SCENARIO_RESOURCE));
-        System.out.println("Controller Strategy: " + controllerStrategy
-                + (controllerStrategyOverride != null ? " (overridden)" : ""));
-        System.out.println("Idle Parking Mode: " + idleParkingMode
-                + (idleParkingModeOverride != null ? " (overridden)" : ""));
+        System.out.println("Controller Strategy: " + controllerStrategy);
+        System.out.println("Idle Parking Mode: " + idleParkingMode);
         System.out.println();
 
         NaiveLiftController controller = (NaiveLiftController) ControllerFactory.createController(
@@ -152,16 +125,11 @@ public class ScenarioRunnerMain {
         System.out.println("  SCENARIO_FILE                   Path to scenario file (optional, uses demo.scenario if not provided)");
         System.out.println();
         System.out.println("Options:");
-        System.out.println("  -c, --controller STRATEGY       Controller strategy to use (overrides scenario file)");
-        System.out.println("                                  (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN)");
-        System.out.println("  -p, --idle-parking MODE         Idle parking mode (overrides scenario file)");
-        System.out.println("                                  (STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR)");
         System.out.println("  -h, --help                      Show this help message");
         System.out.println();
         System.out.println("Examples:");
         System.out.println("  java -cp lift-simulator.jar com.liftsimulator.scenario.ScenarioRunnerMain");
         System.out.println("  java -cp lift-simulator.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario");
-        System.out.println("  java -cp lift-simulator.jar com.liftsimulator.scenario.ScenarioRunnerMain --idle-parking STAY_AT_CURRENT_FLOOR");
-        System.out.println("  java -cp lift-simulator.jar com.liftsimulator.scenario.ScenarioRunnerMain -c NEAREST_REQUEST_ROUTING -p PARK_TO_HOME_FLOOR custom.scenario");
+        System.out.println("  java -cp lift-simulator.jar com.liftsimulator.scenario.ScenarioRunnerMain --help");
     }
 }


### PR DESCRIPTION
### Motivation
- Simplify the command-line surface by removing runtime overrides for controller strategy and idle parking so configuration comes from scenarios or built-in defaults. 
- Eliminate precedence and duplication confusion caused by CLI flags that could override scenario files. 
- Keep a single, discoverable configuration mechanism and preserve `--help` for usage information.

### Description
- Remove parsing and override handling of `--controller`/`-c` and `--idle-parking`/`-p` from `Main.java` and `ScenarioRunnerMain.java`, leaving only `--help`/`-h` as accepted CLI options. 
- Use scenario file values (or defaults) for `controller_strategy` and `idle_parking_mode` when running the scenario runner, and use built-in demo defaults in `Main`. 
- Update usage output in `printUsage()` implementations to reflect the reduced CLI surface and update `README.md` examples accordingly. 
- Update `CHANGELOG.md` entry for `0.15.0` to remove the Unreleased section and document the CLI simplification while retaining the same `0.15.0` version line.

### Testing
- No automated tests were run as part of this change. 
- Existing automated test suites were not executed for this PR. 
- Manual verification consisted of basic execution flows (not automated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960974b74688325bcfb821b74617006)