### PR TITLE
Fix Flyway PostgreSQL dependency version resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.1] - 2026-01-09
+
+### Fixed
+- Add an explicit Flyway PostgreSQL artifact version in the Maven POM to restore dependency resolution.
+- Bump project version to 0.22.1 to reflect the build fix.
+
 ## [0.22.0] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.22.0**
+Current version: **0.22.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.22.0.jar
+java -jar target/lift-simulator-0.22.1.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -140,7 +140,7 @@ Future migrations will add tables for lift configurations, simulation runs, and 
 
 ## Features
 
-The current version (v0.22.0) implements:
+The current version (v0.22.1) implements:
 - **Selectable controller strategy**: Choose between different controller algorithms (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN) via enum-based configuration
 - **Directional scan controller**: Implements a SCAN-style algorithm that continues in the current direction until all requests are serviced
 - **Hall-call direction filtering**: Opposite-direction hall calls are deferred until after the directional scan reverses, with reversal occurring at the furthest pending stop in the current travel direction
@@ -219,7 +219,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.22.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.22.1.jar`.
 
 ## Running Tests
 
@@ -269,7 +269,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -278,16 +278,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -307,7 +307,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -316,13 +316,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.21.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.22.0</version>
+    <version>0.22.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -62,6 +62,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-database-postgresql</artifactId>
+            <version>${flyway.version}</version>
         </dependency>
 
         <!-- Spring Boot Test Starter -->


### PR DESCRIPTION
### Motivation
- Resolve a Maven build error caused by a missing `dependencies.dependency.version` for the Flyway PostgreSQL artifact. 
- Produce a small patch release to ensure downstream builds pick up the fix by bumping the project version to `0.22.1`.

### Description
- Bumped project version from `0.22.0` to `0.22.1` in `pom.xml` to indicate a patch release. 
- Pin the Flyway PostgreSQL artifact by setting the `flyway-database-postgresql` dependency version to the managed `
`${flyway.version}`` in `pom.xml` to restore dependency resolution. 
- Updated `CHANGELOG.md` with a `0.22.1` entry describing the fix. 
- Updated `README.md` references and packaged JAR examples to `0.22.1`.

### Testing
- No automated tests were executed as part of this change.
- No CI/build result is included in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960eb5e84608325b6dc0d2fb7cee82b)