### PR TITLE
Fix Flyway dependency resolution and bump version to 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2] - 2026-01-09
+
+### Fixed
+- Remove the unused Flyway PostgreSQL module dependency so Maven resolves Flyway from Spring Boot's managed version.
+- Bump project version to 0.22.2 to reflect the build fix.
+
 ## [0.22.1] - 2026-01-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.22.1**
+Current version: **0.22.2**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.22.1.jar
+java -jar target/lift-simulator-0.22.2.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -140,7 +140,7 @@ Future migrations will add tables for lift configurations, simulation runs, and 
 
 ## Features
 
-The current version (v0.22.1) implements:
+The current version (v0.22.2) implements:
 - **Selectable controller strategy**: Choose between different controller algorithms (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN) via enum-based configuration
 - **Directional scan controller**: Implements a SCAN-style algorithm that continues in the current direction until all requests are serviced
 - **Hall-call direction filtering**: Opposite-direction hall calls are deferred until after the directional scan reverses, with reversal occurring at the furthest pending stop in the current travel direction
@@ -219,7 +219,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.22.1.jar`.
+The packaged JAR will be in `target/lift-simulator-0.22.2.jar`.
 
 ## Running Tests
 
@@ -269,7 +269,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -278,16 +278,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -307,7 +307,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -316,13 +316,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.22.1.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.22.1</version>
+    <version>0.22.2</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -56,13 +56,6 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-        </dependency>
-
-        <!-- Flyway PostgreSQL support -->
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-database-postgresql</artifactId>
-            <version>${flyway.version}</version>
         </dependency>
 
         <!-- Spring Boot Test Starter -->


### PR DESCRIPTION
### Motivation
- Resolve a Maven build failure where `org.flywaydb:flyway-database-postgresql` could not be resolved from central.  
- Prefer using Spring Boot's managed Flyway artifacts rather than an explicit module dependency that caused resolution issues.  
- Reflect the build fix with a patch version bump following SemVer by moving to `0.22.2`.

### Description
- Remove the unused `flyway-database-postgresql` dependency from `pom.xml` and update the project `<version>` to `0.22.2` in `pom.xml`.  
- Update `README.md` to reference `0.22.2` and adjust example JAR/classpath usage accordingly.  
- Add a `0.22.2` entry to `CHANGELOG.md` documenting the dependency fix.

### Testing
- No automated tests were executed as part of this change.  
- Suggested verification commands to run locally are `mvn clean package` to validate the build and `mvn test` to run the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960ec1e0b788325898ee0ce6e4d5d42)