### PR TITLE
Fix dev DB password for lift_admin and bump version to 0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.3] - 2026-01-09
+
+### Fixed
+- Correct the development database password for `lift_admin` in configuration and documentation.
+- Bump project version to 0.22.3 to reflect the credential update.
+
 ## [0.22.2] - 2026-01-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.22.2**
+Current version: **0.22.3**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.22.2.jar
+java -jar target/lift-simulator-0.22.3.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -83,7 +83,7 @@ The backend uses PostgreSQL with Flyway for schema migrations. Follow these step
 
    # Execute these commands in the psql prompt:
    CREATE DATABASE lift_simulator;
-   CREATE USER lift_admin WITH PASSWORD 'lift_password';
+   CREATE USER lift_admin WITH PASSWORD 'liftpassword';
    GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;
    \c lift_simulator
    GRANT ALL ON SCHEMA public TO lift_admin;
@@ -93,7 +93,7 @@ The backend uses PostgreSQL with Flyway for schema migrations. Follow these step
 3. **Verify Database Connection**:
    ```bash
    psql -h localhost -U lift_admin -d lift_simulator
-   # Password: lift_password
+   # Password: liftpassword
    ```
 
 4. **Run the Application**:
@@ -109,7 +109,7 @@ The application supports different profiles for different environments:
 - **dev** (default): Uses local PostgreSQL with connection pooling
   - Configuration: `src/main/resources/application-dev.yml`
   - Database: `localhost:5432/lift_simulator`
-  - User: `lift_admin` / `lift_password`
+  - User: `lift_admin` / `liftpassword`
 
 To use a different profile, set the `SPRING_PROFILES_ACTIVE` environment variable:
 ```bash
@@ -140,7 +140,7 @@ Future migrations will add tables for lift configurations, simulation runs, and 
 
 ## Features
 
-The current version (v0.22.2) implements:
+The current version (v0.22.3) implements:
 - **Selectable controller strategy**: Choose between different controller algorithms (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN) via enum-based configuration
 - **Directional scan controller**: Implements a SCAN-style algorithm that continues in the current direction until all requests are serviced
 - **Hall-call direction filtering**: Opposite-direction hall calls are deferred until after the directional scan reverses, with reversal occurring at the furthest pending stop in the current travel direction
@@ -219,7 +219,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.22.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.22.3.jar`.
 
 ## Running Tests
 
@@ -269,7 +269,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -278,16 +278,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -307,7 +307,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -316,13 +316,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.22.2.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.22.3.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/docs/decisions/0007-postgresql-flyway-integration.md
+++ b/docs/decisions/0007-postgresql-flyway-integration.md
@@ -333,7 +333,7 @@ sudo service postgresql start
 # Create database and user
 sudo -u postgres psql <<EOF
 CREATE DATABASE lift_simulator;
-CREATE USER lift_admin WITH PASSWORD 'lift_password';
+CREATE USER lift_admin WITH PASSWORD 'liftpassword';
 GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;
 \c lift_simulator
 GRANT ALL ON SCHEMA public TO lift_admin;

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.22.2</version>
+    <version>0.22.3</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,7 +3,7 @@ spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/lift_simulator
     username: lift_admin
-    password: lift_password
+    password: liftpassword
     driver-class-name: org.postgresql.Driver
     hikari:
       maximum-pool-size: 5


### PR DESCRIPTION
### Motivation
- Correct an incorrect development credential where the `lift_admin` password in configuration and docs used `lift_password` instead of the intended `liftpassword`.
- Ensure documentation, configuration and packaging references remain consistent with the runtime configuration.
- Bump the project version to reflect the change in the codebase and artifact names.

### Description
- Update `src/main/resources/application-dev.yml` to set `password: liftpassword` for the `lift_admin` datasource.
- Update documentation examples and instructions in `README.md` and `docs/decisions/0007-postgresql-flyway-integration.md` to reference `liftpassword` and the corrected create-user command.
- Bump the project version in `pom.xml` to `0.22.3` and update packaged JAR references in `README.md` accordingly.
- Add a `0.22.3` entry to `CHANGELOG.md` noting the credential correction and version bump.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960f4be25848325b7a10717f76b8339)