### PR TITLE
Clean stale Flyway migration artifacts during build and bump to 0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.2] - 2026-01-09
+
+### Fixed
+- Remove stale Flyway migration resources during build so older `V1__init.sql` artifacts cannot collide with `V1__init_schema.sql`.
+- Bump project version to 0.23.2 to reflect the migration cleanup fix.
+
 ## [0.23.1] - 2026-01-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.23.1**
+Current version: **0.23.2**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.23.1.jar
+java -jar target/lift-simulator-0.23.2.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -139,11 +139,11 @@ Future migrations will extend lift configuration metadata, simulation runs, and 
 **Migration errors:**
 - Check Flyway history: `SELECT * FROM flyway_schema_history;`
 - For development, you can reset the database: `DROP DATABASE lift_simulator; CREATE DATABASE lift_simulator;`
-- If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` or delete `target/classes/db/migration/V1__init.sql` so only `V1__init_schema.sql` remains.
+- If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` once to clear stale build artifacts; the build now removes old migration resources automatically.
 
 ## Features
 
-The current version (v0.23.1) implements:
+The current version (v0.23.2) implements:
 - **Selectable controller strategy**: Choose between different controller algorithms (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN) via enum-based configuration
 - **Directional scan controller**: Implements a SCAN-style algorithm that continues in the current direction until all requests are serviced
 - **Hall-call direction filtering**: Opposite-direction hall calls are deferred until after the directional scan reverses, with reversal occurring at the furthest pending stop in the current travel direction

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.23.1</version>
+    <version>0.23.2</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -88,6 +88,25 @@
             </resource>
         </resources>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>clean-stale-migrations</id>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <target>
+                                <delete dir="${project.build.outputDirectory}/db/migration" quiet="true"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>


### PR DESCRIPTION
### Motivation
- Fix a Spring/Flyway startup failure caused by duplicate version-1 migrations left behind as stale build artifacts.
- Ensure the build removes old migration resources so only the canonical `V1__init_schema.sql` is applied at runtime.
- Bump the project version to `0.23.2` to reflect the migration cleanup fix.
- Update user-facing documentation so troubleshooting guidance and JAR references match the new behavior.

### Description
- Add a `maven-antrun-plugin` execution `clean-stale-migrations` to `pom.xml` bound to the `process-resources` phase that deletes `${project.build.outputDirectory}/db/migration`.
- Update the project `<version>` in `pom.xml` from `0.23.1` to `0.23.2`.
- Update `README.md` to bump the displayed version and JAR name and to revise the Flyway troubleshooting note to reflect automatic cleanup.
- Add a `0.23.2` entry to `CHANGELOG.md` documenting the migration cleanup and version bump.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fc5d1a788325b123113697d93c78)