### PR TITLE
Fix Flyway migration cleanup timing and bump version to 0.23.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.6] - 2026-01-09
+
+### Fixed
+- Ensure Flyway migrations are retained in build output by cleaning stale resources before the copy phase.
+- Bump project version to 0.23.6 to reflect the migration packaging fix.
+
 ## [0.23.5] - 2026-01-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.23.5**
+Current version: **0.23.6**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.23.5.jar
+java -jar target/lift-simulator-0.23.6.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -144,10 +144,11 @@ Future migrations will extend lift configuration metadata, simulation runs, and 
 - If `public.flyway_schema_history` exists from earlier runs, drop it and restart the app so Flyway recreates history in `lift_simulator`: `DROP TABLE public.flyway_schema_history;`
 - If a legacy `public.schema_metadata` table exists from older releases, it can be dropped; current migrations do not use it: `DROP TABLE public.schema_metadata;`
 - If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` once to clear stale build artifacts; the build now removes old migration resources automatically.
+- If Flyway reports "No migrations found", rebuild with `mvn clean package` to refresh the packaged `db/migration` resources.
 
 ## Features
 
-The current version (v0.23.5) implements:
+The current version (v0.23.6) implements:
 - **Selectable controller strategy**: Choose between different controller algorithms (NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN) via enum-based configuration
 - **Directional scan controller**: Implements a SCAN-style algorithm that continues in the current direction until all requests are serviced
 - **Hall-call direction filtering**: Opposite-direction hall calls are deferred until after the directional scan reverses, with reversal occurring at the furthest pending stop in the current travel direction
@@ -226,7 +227,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.23.5.jar`.
+The packaged JAR will be in `target/lift-simulator-0.23.6.jar`.
 
 ## Running Tests
 
@@ -276,7 +277,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -285,16 +286,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -314,7 +315,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -323,13 +324,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.23.5.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.23.6.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.23.5</version>
+    <version>0.23.6</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -95,7 +95,7 @@
                 <executions>
                     <execution>
                         <id>clean-stale-migrations</id>
-                        <phase>process-resources</phase>
+                        <phase>generate-resources</phase>
                         <configuration>
                             <target>
                                 <delete dir="${project.build.outputDirectory}/db/migration" quiet="true"/>


### PR DESCRIPTION
### Motivation

- Flyway migrations were being removed from the packaged artifact because stale-migration cleanup ran too late in the build lifecycle. 
- The build should remove old migration artifacts before resources are copied so `src/main/resources/db/migration` is retained in the JAR. 
- Update repository version and documentation to reflect the packaging fix and guide developers who encounter missing migrations. 

### Description

- Change the Maven `maven-antrun-plugin` execution phase for the `clean-stale-migrations` task from `process-resources` to `generate-resources` so stale `db/migration` artifacts are deleted earlier. 
- Bump project version from `0.23.5` to `0.23.6` in `pom.xml`. 
- Update `README.md` to reference `0.23.6`, refresh packaged JAR paths, and add a troubleshooting line recommending `mvn clean package` when Flyway reports "No migrations found". 
- Add a `0.23.6` entry to `CHANGELOG.md` describing the migration packaging fix. 

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961044674ec8325a1a1b5a2abfd00ee)