### PR TITLE
Implement Lift System Versioning APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2026-01-11
+
+### Added
+- **Lift System Versioning REST APIs**: Full REST API implementation for managing lift system versions
+  - `POST /api/lift-systems/{systemId}/versions` - Create new version with optional cloning from existing version
+  - `PUT /api/lift-systems/{systemId}/versions/{versionNumber}` - Update version configuration JSON
+  - `GET /api/lift-systems/{systemId}/versions` - List all versions for a lift system
+  - `GET /api/lift-systems/{systemId}/versions/{versionNumber}` - Get specific version by number
+- **Version Service Layer**: `LiftSystemVersionService` providing business logic for version operations
+  - Auto-incrementing version numbers per lift system
+  - Configuration cloning from existing versions
+  - Validation for lift system and version existence
+  - Transactional integrity for all write operations
+- **Version DTOs**: Type-safe API contracts for versioning
+  - `CreateVersionRequest` with validation (config required, optional cloneFromVersionNumber)
+  - `UpdateVersionConfigRequest` for config updates
+  - `VersionResponse` for consistent version API responses
+- **Comprehensive Test Coverage**: Unit and integration tests for versioning
+  - `LiftSystemVersionServiceTest`: 10 unit tests covering all service operations with mocks
+  - `LiftSystemVersionControllerTest`: 13 integration tests with full Spring context
+  - Tests for version creation, cloning, updating, listing, and retrieval
+  - Tests for version number auto-increment functionality
+  - Full coverage of success cases, error cases, and validation failures
+
+### Changed
+- Version bumped from 0.25.0 to 0.26.0
+- REST API now provides full version lifecycle management for lift system configurations
+- Version numbers automatically increment starting from 1 for each lift system
+
+### Documentation
+- Updated README with Version Management API documentation
+- Added API endpoint examples with request/response payloads for all versioning operations
+- Documented version cloning functionality and auto-increment behavior
+
 ## [0.25.0] - 2026-01-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.24.0**
+Current version: **0.26.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.25.0.jar
+java -jar target/lift-simulator-0.26.0.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -109,6 +109,86 @@ The backend will start on `http://localhost:8080`.
   - Deletes a lift system and all its versions (cascade delete)
   - Response (204 No Content): Success with no body
   - Error (404 Not Found): If lift system doesn't exist
+
+#### Version Management
+
+- **Create Version**: `POST /api/lift-systems/{systemId}/versions`
+  - Creates a new version for a lift system
+  - Optionally clones configuration from an existing version
+  - Request body (with new config):
+    ```json
+    {
+      "config": "{\"floors\": 10, \"lifts\": 2}",
+      "cloneFromVersionNumber": null
+    }
+    ```
+  - Request body (cloning from version):
+    ```json
+    {
+      "config": "{}",
+      "cloneFromVersionNumber": 1
+    }
+    ```
+  - Response (201 Created):
+    ```json
+    {
+      "id": 1,
+      "liftSystemId": 1,
+      "versionNumber": 1,
+      "status": "DRAFT",
+      "isPublished": false,
+      "publishedAt": null,
+      "config": "{\"floors\": 10, \"lifts\": 2}",
+      "createdAt": "2026-01-11T10:00:00Z",
+      "updatedAt": "2026-01-11T10:00:00Z"
+    }
+    ```
+  - Version numbers auto-increment per lift system
+
+- **Update Version Config**: `PUT /api/lift-systems/{systemId}/versions/{versionNumber}`
+  - Updates the configuration JSON for a specific version
+  - Request body:
+    ```json
+    {
+      "config": "{\"floors\": 15, \"lifts\": 3}"
+    }
+    ```
+  - Response (200 OK): Updated version details
+
+- **List Versions**: `GET /api/lift-systems/{systemId}/versions`
+  - Returns all versions for a lift system, ordered by version number descending
+  - Response (200 OK):
+    ```json
+    [
+      {
+        "id": 2,
+        "liftSystemId": 1,
+        "versionNumber": 2,
+        "status": "DRAFT",
+        "isPublished": false,
+        "publishedAt": null,
+        "config": "{\"floors\": 15}",
+        "createdAt": "2026-01-11T11:00:00Z",
+        "updatedAt": "2026-01-11T11:00:00Z"
+      },
+      {
+        "id": 1,
+        "liftSystemId": 1,
+        "versionNumber": 1,
+        "status": "DRAFT",
+        "isPublished": false,
+        "publishedAt": null,
+        "config": "{\"floors\": 10}",
+        "createdAt": "2026-01-11T10:00:00Z",
+        "updatedAt": "2026-01-11T10:00:00Z"
+      }
+    ]
+    ```
+
+- **Get Version**: `GET /api/lift-systems/{systemId}/versions/{versionNumber}`
+  - Returns a specific version by version number
+  - Response (200 OK): Version details
+  - Error (404 Not Found): If version doesn't exist
 
 #### Health & Monitoring
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.25.0</version>
+    <version>0.26.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/controller/LiftSystemVersionController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/LiftSystemVersionController.java
@@ -1,0 +1,89 @@
+package com.liftsimulator.admin.controller;
+
+import com.liftsimulator.admin.dto.CreateVersionRequest;
+import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
+import com.liftsimulator.admin.dto.VersionResponse;
+import com.liftsimulator.admin.service.LiftSystemVersionService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST controller for managing lift system versions.
+ */
+@RestController
+@RequestMapping("/api/lift-systems/{systemId}/versions")
+public class LiftSystemVersionController {
+
+    private final LiftSystemVersionService versionService;
+
+    public LiftSystemVersionController(LiftSystemVersionService versionService) {
+        this.versionService = versionService;
+    }
+
+    /**
+     * Creates a new version for a lift system.
+     * Optionally clones configuration from an existing version.
+     *
+     * @param systemId the lift system ID
+     * @param request the creation request
+     * @return the created version
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public VersionResponse createVersion(
+            @PathVariable Long systemId,
+            @Valid @RequestBody CreateVersionRequest request) {
+        return versionService.createVersion(systemId, request);
+    }
+
+    /**
+     * Updates the configuration of an existing version.
+     *
+     * @param systemId the lift system ID
+     * @param versionNumber the version number
+     * @param request the update request
+     * @return the updated version
+     */
+    @PutMapping("/{versionNumber}")
+    public VersionResponse updateVersionConfig(
+            @PathVariable Long systemId,
+            @PathVariable Integer versionNumber,
+            @Valid @RequestBody UpdateVersionConfigRequest request) {
+        return versionService.updateVersionConfig(systemId, versionNumber, request);
+    }
+
+    /**
+     * Lists all versions for a lift system.
+     *
+     * @param systemId the lift system ID
+     * @return list of versions ordered by version number descending
+     */
+    @GetMapping
+    public List<VersionResponse> listVersions(@PathVariable Long systemId) {
+        return versionService.listVersions(systemId);
+    }
+
+    /**
+     * Retrieves a specific version.
+     *
+     * @param systemId the lift system ID
+     * @param versionNumber the version number
+     * @return the version details
+     */
+    @GetMapping("/{versionNumber}")
+    public VersionResponse getVersion(
+            @PathVariable Long systemId,
+            @PathVariable Integer versionNumber) {
+        return versionService.getVersion(systemId, versionNumber);
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/dto/CreateVersionRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/CreateVersionRequest.java
@@ -1,0 +1,14 @@
+package com.liftsimulator.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request DTO for creating a new lift system version.
+ */
+public record CreateVersionRequest(
+    @NotBlank(message = "Config JSON is required")
+    String config,
+
+    Integer cloneFromVersionNumber
+) {
+}

--- a/src/main/java/com/liftsimulator/admin/dto/UpdateVersionConfigRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/UpdateVersionConfigRequest.java
@@ -1,0 +1,12 @@
+package com.liftsimulator.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request DTO for updating lift system version configuration.
+ */
+public record UpdateVersionConfigRequest(
+    @NotBlank(message = "Config JSON is required")
+    String config
+) {
+}

--- a/src/main/java/com/liftsimulator/admin/dto/VersionResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/VersionResponse.java
@@ -1,0 +1,40 @@
+package com.liftsimulator.admin.dto;
+
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import java.time.OffsetDateTime;
+
+/**
+ * Response DTO for lift system version details.
+ */
+public record VersionResponse(
+    Long id,
+    Long liftSystemId,
+    Integer versionNumber,
+    VersionStatus status,
+    Boolean isPublished,
+    OffsetDateTime publishedAt,
+    String config,
+    OffsetDateTime createdAt,
+    OffsetDateTime updatedAt
+) {
+    /**
+     * Creates a response DTO from a LiftSystemVersion entity.
+     *
+     * @param version the entity to convert
+     * @return the response DTO
+     */
+    public static VersionResponse fromEntity(LiftSystemVersion version) {
+        return new VersionResponse(
+            version.getId(),
+            version.getLiftSystem().getId(),
+            version.getVersionNumber(),
+            version.getStatus(),
+            version.getIsPublished(),
+            version.getPublishedAt(),
+            version.getConfig(),
+            version.getCreatedAt(),
+            version.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
@@ -1,0 +1,147 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.admin.dto.CreateVersionRequest;
+import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
+import com.liftsimulator.admin.dto.VersionResponse;
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * Service for managing lift system versions.
+ */
+@Service
+@Transactional(readOnly = true)
+public class LiftSystemVersionService {
+
+    private final LiftSystemRepository liftSystemRepository;
+    private final LiftSystemVersionRepository versionRepository;
+
+    public LiftSystemVersionService(
+            LiftSystemRepository liftSystemRepository,
+            LiftSystemVersionRepository versionRepository) {
+        this.liftSystemRepository = liftSystemRepository;
+        this.versionRepository = versionRepository;
+    }
+
+    /**
+     * Creates a new version for a lift system.
+     * Optionally clones configuration from an existing version.
+     *
+     * @param systemId the lift system ID
+     * @param request the creation request
+     * @return the created version
+     * @throws ResourceNotFoundException if lift system or clone source not found
+     */
+    @Transactional
+    public VersionResponse createVersion(Long systemId, CreateVersionRequest request) {
+        LiftSystem liftSystem = liftSystemRepository.findById(systemId)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Lift system not found with id: " + systemId
+            ));
+
+        // Determine the config to use
+        String config;
+        if (request.cloneFromVersionNumber() != null) {
+            // Clone from existing version
+            LiftSystemVersion sourceVersion = versionRepository
+                .findByLiftSystemIdAndVersionNumber(systemId, request.cloneFromVersionNumber())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                    "Version " + request.cloneFromVersionNumber()
+                    + " not found for lift system " + systemId
+                ));
+            config = sourceVersion.getConfig();
+        } else {
+            // Use provided config
+            config = request.config();
+        }
+
+        // Get next version number
+        Integer nextVersionNumber = getNextVersionNumber(systemId);
+
+        // Create new version
+        LiftSystemVersion version = new LiftSystemVersion(liftSystem, nextVersionNumber, config);
+        LiftSystemVersion savedVersion = versionRepository.save(version);
+
+        return VersionResponse.fromEntity(savedVersion);
+    }
+
+    /**
+     * Updates the configuration of an existing version.
+     *
+     * @param systemId the lift system ID
+     * @param versionNumber the version number
+     * @param request the update request
+     * @return the updated version
+     * @throws ResourceNotFoundException if version not found
+     */
+    @Transactional
+    public VersionResponse updateVersionConfig(
+            Long systemId, Integer versionNumber, UpdateVersionConfigRequest request) {
+        LiftSystemVersion version = versionRepository
+            .findByLiftSystemIdAndVersionNumber(systemId, versionNumber)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Version " + versionNumber + " not found for lift system " + systemId
+            ));
+
+        version.setConfig(request.config());
+        LiftSystemVersion updatedVersion = versionRepository.save(version);
+
+        return VersionResponse.fromEntity(updatedVersion);
+    }
+
+    /**
+     * Lists all versions for a lift system.
+     *
+     * @param systemId the lift system ID
+     * @return list of versions ordered by version number descending
+     * @throws ResourceNotFoundException if lift system not found
+     */
+    public List<VersionResponse> listVersions(Long systemId) {
+        // Verify lift system exists
+        if (!liftSystemRepository.existsById(systemId)) {
+            throw new ResourceNotFoundException(
+                "Lift system not found with id: " + systemId
+            );
+        }
+
+        return versionRepository.findByLiftSystemIdOrderByVersionNumberDesc(systemId)
+            .stream()
+            .map(VersionResponse::fromEntity)
+            .toList();
+    }
+
+    /**
+     * Retrieves a specific version.
+     *
+     * @param systemId the lift system ID
+     * @param versionNumber the version number
+     * @return the version details
+     * @throws ResourceNotFoundException if version not found
+     */
+    public VersionResponse getVersion(Long systemId, Integer versionNumber) {
+        LiftSystemVersion version = versionRepository
+            .findByLiftSystemIdAndVersionNumber(systemId, versionNumber)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Version " + versionNumber + " not found for lift system " + systemId
+            ));
+
+        return VersionResponse.fromEntity(version);
+    }
+
+    /**
+     * Gets the next version number for a lift system.
+     *
+     * @param systemId the lift system ID
+     * @return the next version number (1 if no versions exist)
+     */
+    private Integer getNextVersionNumber(Long systemId) {
+        Integer maxVersion = versionRepository.findMaxVersionNumberByLiftSystemId(systemId);
+        return (maxVersion == null) ? 1 : maxVersion + 1;
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/controller/LiftSystemVersionControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/LiftSystemVersionControllerTest.java
@@ -1,0 +1,272 @@
+package com.liftsimulator.admin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.admin.dto.CreateVersionRequest;
+import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for LiftSystemVersionController.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Transactional
+public class LiftSystemVersionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private LiftSystemRepository liftSystemRepository;
+
+    @Autowired
+    private LiftSystemVersionRepository versionRepository;
+
+    private LiftSystem testSystem;
+
+    @BeforeEach
+    public void setUp() {
+        versionRepository.deleteAll();
+        liftSystemRepository.deleteAll();
+
+        testSystem = new LiftSystem("test-system", "Test System", "Test Description");
+        testSystem = liftSystemRepository.save(testSystem);
+    }
+
+    @Test
+    public void testCreateVersion_WithConfig() throws Exception {
+        String config = "{\"floors\": 10, \"lifts\": 2}";
+        CreateVersionRequest request = new CreateVersionRequest(config, null);
+
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.liftSystemId").value(testSystem.getId()))
+            .andExpect(jsonPath("$.versionNumber").value(1))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+            .andExpect(jsonPath("$.isPublished").value(false))
+            .andExpect(jsonPath("$.config").value(config))
+            .andExpect(jsonPath("$.createdAt").exists())
+            .andExpect(jsonPath("$.updatedAt").exists());
+    }
+
+    @Test
+    public void testCreateVersion_CloneFromExisting() throws Exception {
+        String originalConfig = "{\"floors\": 10, \"lifts\": 2}";
+        LiftSystemVersion version1 = new LiftSystemVersion(testSystem, 1, originalConfig);
+        versionRepository.save(version1);
+
+        CreateVersionRequest request = new CreateVersionRequest("{}", 1);
+
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.versionNumber").value(2))
+            .andExpect(jsonPath("$.config").value(originalConfig));
+    }
+
+    @Test
+    public void testCreateVersion_CloneFromNonExistentVersion() throws Exception {
+        CreateVersionRequest request = new CreateVersionRequest("{}", 999);
+
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Version 999 not found for lift system " + testSystem.getId()));
+    }
+
+    @Test
+    public void testCreateVersion_NonExistentSystem() throws Exception {
+        String config = "{\"floors\": 10}";
+        CreateVersionRequest request = new CreateVersionRequest(config, null);
+
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", 999L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Lift system not found with id: 999"));
+    }
+
+    @Test
+    public void testCreateVersion_VersionNumberAutoIncrement() throws Exception {
+        versionRepository.save(new LiftSystemVersion(testSystem, 1, "{}"));
+        versionRepository.save(new LiftSystemVersion(testSystem, 2, "{}"));
+
+        CreateVersionRequest request = new CreateVersionRequest("{\"floors\": 15}", null);
+
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.versionNumber").value(3));
+    }
+
+    @Test
+    public void testCreateVersion_ValidationError_EmptyConfig() throws Exception {
+        CreateVersionRequest request = new CreateVersionRequest("", null);
+
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors").exists());
+    }
+
+    @Test
+    public void testUpdateVersionConfig_Success() throws Exception {
+        String originalConfig = "{\"floors\": 10}";
+        LiftSystemVersion version = new LiftSystemVersion(testSystem, 1, originalConfig);
+        versionRepository.save(version);
+
+        String updatedConfig = "{\"floors\": 15, \"lifts\": 3}";
+        UpdateVersionConfigRequest request = new UpdateVersionConfigRequest(updatedConfig);
+
+        mockMvc.perform(put("/api/lift-systems/{systemId}/versions/{versionNumber}",
+                testSystem.getId(), 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.versionNumber").value(1))
+            .andExpect(jsonPath("$.config").value(updatedConfig));
+    }
+
+    @Test
+    public void testUpdateVersionConfig_VersionNotFound() throws Exception {
+        UpdateVersionConfigRequest request = new UpdateVersionConfigRequest("{\"floors\": 15}");
+
+        mockMvc.perform(put("/api/lift-systems/{systemId}/versions/{versionNumber}",
+                testSystem.getId(), 999)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Version 999 not found for lift system " + testSystem.getId()));
+    }
+
+    @Test
+    public void testUpdateVersionConfig_ValidationError_EmptyConfig() throws Exception {
+        versionRepository.save(new LiftSystemVersion(testSystem, 1, "{}"));
+
+        UpdateVersionConfigRequest request = new UpdateVersionConfigRequest("");
+
+        mockMvc.perform(put("/api/lift-systems/{systemId}/versions/{versionNumber}",
+                testSystem.getId(), 1)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors").exists());
+    }
+
+    @Test
+    public void testListVersions_Success() throws Exception {
+        versionRepository.save(new LiftSystemVersion(testSystem, 1, "{\"floors\": 10}"));
+        versionRepository.save(new LiftSystemVersion(testSystem, 2, "{\"floors\": 15}"));
+        versionRepository.save(new LiftSystemVersion(testSystem, 3, "{\"floors\": 20}"));
+
+        mockMvc.perform(get("/api/lift-systems/{systemId}/versions", testSystem.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(3)))
+            .andExpect(jsonPath("$[0].versionNumber").value(3))
+            .andExpect(jsonPath("$[1].versionNumber").value(2))
+            .andExpect(jsonPath("$[2].versionNumber").value(1));
+    }
+
+    @Test
+    public void testListVersions_EmptyList() throws Exception {
+        mockMvc.perform(get("/api/lift-systems/{systemId}/versions", testSystem.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    public void testListVersions_NonExistentSystem() throws Exception {
+        mockMvc.perform(get("/api/lift-systems/{systemId}/versions", 999L))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Lift system not found with id: 999"));
+    }
+
+    @Test
+    public void testGetVersion_Success() throws Exception {
+        String config = "{\"floors\": 10, \"lifts\": 2}";
+        LiftSystemVersion version = new LiftSystemVersion(testSystem, 1, config);
+        versionRepository.save(version);
+
+        mockMvc.perform(get("/api/lift-systems/{systemId}/versions/{versionNumber}",
+                testSystem.getId(), 1))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.liftSystemId").value(testSystem.getId()))
+            .andExpect(jsonPath("$.versionNumber").value(1))
+            .andExpect(jsonPath("$.status").value("DRAFT"))
+            .andExpect(jsonPath("$.isPublished").value(false))
+            .andExpect(jsonPath("$.config").value(config));
+    }
+
+    @Test
+    public void testGetVersion_NotFound() throws Exception {
+        mockMvc.perform(get("/api/lift-systems/{systemId}/versions/{versionNumber}",
+                testSystem.getId(), 999))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Version 999 not found for lift system " + testSystem.getId()));
+    }
+
+    @Test
+    public void testVersionWorkflow_CreateMultipleVersionsAndRetrieve() throws Exception {
+        CreateVersionRequest request1 = new CreateVersionRequest("{\"floors\": 10}", null);
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request1)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.versionNumber").value(1));
+
+        CreateVersionRequest request2 = new CreateVersionRequest("{}", 1);
+        mockMvc.perform(post("/api/lift-systems/{systemId}/versions", testSystem.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request2)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.versionNumber").value(2))
+            .andExpect(jsonPath("$.config").value("{\"floors\": 10}"));
+
+        UpdateVersionConfigRequest updateRequest = new UpdateVersionConfigRequest("{\"floors\": 20}");
+        mockMvc.perform(put("/api/lift-systems/{systemId}/versions/{versionNumber}",
+                testSystem.getId(), 2)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.config").value("{\"floors\": 20}"));
+
+        mockMvc.perform(get("/api/lift-systems/{systemId}/versions", testSystem.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)));
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/service/LiftSystemVersionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/LiftSystemVersionServiceTest.java
@@ -1,0 +1,252 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.admin.dto.CreateVersionRequest;
+import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
+import com.liftsimulator.admin.dto.VersionResponse;
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for LiftSystemVersionService.
+ */
+@ExtendWith(MockitoExtension.class)
+public class LiftSystemVersionServiceTest {
+
+    @Mock
+    private LiftSystemRepository liftSystemRepository;
+
+    @Mock
+    private LiftSystemVersionRepository versionRepository;
+
+    @InjectMocks
+    private LiftSystemVersionService versionService;
+
+    private LiftSystem mockLiftSystem;
+    private LiftSystemVersion mockVersion;
+
+    @BeforeEach
+    public void setUp() {
+        mockLiftSystem = new LiftSystem();
+        mockLiftSystem.setId(1L);
+        mockLiftSystem.setSystemKey("test-system");
+        mockLiftSystem.setDisplayName("Test System");
+        mockLiftSystem.setDescription("Test Description");
+        mockLiftSystem.setCreatedAt(OffsetDateTime.now());
+        mockLiftSystem.setUpdatedAt(OffsetDateTime.now());
+
+        mockVersion = new LiftSystemVersion();
+        mockVersion.setId(1L);
+        mockVersion.setLiftSystem(mockLiftSystem);
+        mockVersion.setVersionNumber(1);
+        mockVersion.setConfig("{\"floors\": 10}");
+        mockVersion.setStatus(VersionStatus.DRAFT);
+        mockVersion.setIsPublished(false);
+        mockVersion.setCreatedAt(OffsetDateTime.now());
+        mockVersion.setUpdatedAt(OffsetDateTime.now());
+    }
+
+    @Test
+    public void testCreateVersion_WithConfig() {
+        String config = "{\"floors\": 10, \"lifts\": 2}";
+        CreateVersionRequest request = new CreateVersionRequest(config, null);
+
+        when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findMaxVersionNumberByLiftSystemId(1L)).thenReturn(null);
+        when(versionRepository.save(any(LiftSystemVersion.class))).thenReturn(mockVersion);
+
+        VersionResponse response = versionService.createVersion(1L, request);
+
+        assertNotNull(response);
+        assertEquals(1, response.versionNumber());
+        verify(liftSystemRepository).findById(1L);
+        verify(versionRepository).findMaxVersionNumberByLiftSystemId(1L);
+        verify(versionRepository).save(any(LiftSystemVersion.class));
+    }
+
+    @Test
+    public void testCreateVersion_WithCloning() {
+        String originalConfig = "{\"floors\": 10}";
+        LiftSystemVersion sourceVersion = new LiftSystemVersion();
+        sourceVersion.setConfig(originalConfig);
+
+        CreateVersionRequest request = new CreateVersionRequest("{}", 1);
+
+        when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1))
+            .thenReturn(Optional.of(sourceVersion));
+        when(versionRepository.findMaxVersionNumberByLiftSystemId(1L)).thenReturn(1);
+        when(versionRepository.save(any(LiftSystemVersion.class))).thenReturn(mockVersion);
+
+        VersionResponse response = versionService.createVersion(1L, request);
+
+        assertNotNull(response);
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
+        verify(versionRepository).save(any(LiftSystemVersion.class));
+    }
+
+    @Test
+    public void testCreateVersion_LiftSystemNotFound() {
+        CreateVersionRequest request = new CreateVersionRequest("{\"floors\": 10}", null);
+
+        when(liftSystemRepository.findById(999L)).thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> versionService.createVersion(999L, request)
+        );
+
+        assertEquals("Lift system not found with id: 999", exception.getMessage());
+        verify(liftSystemRepository).findById(999L);
+    }
+
+    @Test
+    public void testCreateVersion_CloneSourceNotFound() {
+        CreateVersionRequest request = new CreateVersionRequest("{}", 999);
+
+        when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 999))
+            .thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> versionService.createVersion(1L, request)
+        );
+
+        assertEquals("Version 999 not found for lift system 1", exception.getMessage());
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 999);
+    }
+
+    @Test
+    public void testCreateVersion_VersionNumberIncrement() {
+        CreateVersionRequest request = new CreateVersionRequest("{\"floors\": 15}", null);
+
+        when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findMaxVersionNumberByLiftSystemId(1L)).thenReturn(5);
+
+        LiftSystemVersion newVersion = new LiftSystemVersion();
+        newVersion.setId(6L);
+        newVersion.setLiftSystem(mockLiftSystem);
+        newVersion.setVersionNumber(6);
+        newVersion.setConfig("{\"floors\": 15}");
+        newVersion.setStatus(VersionStatus.DRAFT);
+        newVersion.setIsPublished(false);
+        newVersion.setCreatedAt(OffsetDateTime.now());
+        newVersion.setUpdatedAt(OffsetDateTime.now());
+
+        when(versionRepository.save(any(LiftSystemVersion.class))).thenReturn(newVersion);
+
+        VersionResponse response = versionService.createVersion(1L, request);
+
+        assertNotNull(response);
+        assertEquals(6, response.versionNumber());
+        verify(versionRepository).findMaxVersionNumberByLiftSystemId(1L);
+    }
+
+    @Test
+    public void testUpdateVersionConfig_Success() {
+        String updatedConfig = "{\"floors\": 20, \"lifts\": 3}";
+        UpdateVersionConfigRequest request = new UpdateVersionConfigRequest(updatedConfig);
+
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1))
+            .thenReturn(Optional.of(mockVersion));
+        when(versionRepository.save(any(LiftSystemVersion.class))).thenReturn(mockVersion);
+
+        VersionResponse response = versionService.updateVersionConfig(1L, 1, request);
+
+        assertNotNull(response);
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
+        verify(versionRepository).save(mockVersion);
+    }
+
+    @Test
+    public void testUpdateVersionConfig_VersionNotFound() {
+        UpdateVersionConfigRequest request = new UpdateVersionConfigRequest("{\"floors\": 20}");
+
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 999))
+            .thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> versionService.updateVersionConfig(1L, 999, request)
+        );
+
+        assertEquals("Version 999 not found for lift system 1", exception.getMessage());
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 999);
+    }
+
+    @Test
+    public void testListVersions_Success() {
+        List<LiftSystemVersion> versions = List.of(mockVersion);
+
+        when(liftSystemRepository.existsById(1L)).thenReturn(true);
+        when(versionRepository.findByLiftSystemIdOrderByVersionNumberDesc(1L))
+            .thenReturn(versions);
+
+        List<VersionResponse> responses = versionService.listVersions(1L);
+
+        assertEquals(1, responses.size());
+        assertEquals(1, responses.get(0).versionNumber());
+        verify(liftSystemRepository).existsById(1L);
+        verify(versionRepository).findByLiftSystemIdOrderByVersionNumberDesc(1L);
+    }
+
+    @Test
+    public void testListVersions_LiftSystemNotFound() {
+        when(liftSystemRepository.existsById(999L)).thenReturn(false);
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> versionService.listVersions(999L)
+        );
+
+        assertEquals("Lift system not found with id: 999", exception.getMessage());
+        verify(liftSystemRepository).existsById(999L);
+    }
+
+    @Test
+    public void testGetVersion_Success() {
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1))
+            .thenReturn(Optional.of(mockVersion));
+
+        VersionResponse response = versionService.getVersion(1L, 1);
+
+        assertNotNull(response);
+        assertEquals(1, response.versionNumber());
+        assertEquals(1L, response.liftSystemId());
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
+    }
+
+    @Test
+    public void testGetVersion_NotFound() {
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 999))
+            .thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> versionService.getVersion(1L, 999)
+        );
+
+        assertEquals("Version 999 not found for lift system 1", exception.getMessage());
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 999);
+    }
+}


### PR DESCRIPTION
Add comprehensive REST API support for managing lift system configuration versions with draft/published workflow capabilities.

Features:
- POST /api/lift-systems/{systemId}/versions - Create new version with optional cloning from existing version
- PUT /api/lift-systems/{systemId}/versions/{versionNumber} - Update version configuration JSON
- GET /api/lift-systems/{systemId}/versions - List all versions ordered by version number descending
- GET /api/lift-systems/{systemId}/versions/{versionNumber} - Get specific version

Implementation:
- LiftSystemVersionService with business logic for version operations
- Auto-incrementing version numbers per lift system (starting from 1)
- Configuration cloning support for creating versions from existing ones
- Comprehensive validation and error handling
- Type-safe DTOs: CreateVersionRequest, UpdateVersionConfigRequest, VersionResponse

Testing:
- LiftSystemVersionServiceTest: 10 unit tests with mocks
- LiftSystemVersionControllerTest: 13 integration tests with Spring context
- Full coverage of CRUD operations, cloning, and error scenarios

Documentation:
- Updated README with Version Management API documentation
- Updated CHANGELOG with v0.26.0 release notes
- Version bumped to 0.26.0 in pom.xml