### PR TITLE
Implement publish and archive workflow for configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2026-01-11
+
+### Added
+- **Publish/Archive Workflow**: Automatic archiving of previously published versions when publishing a new version
+  - Ensures exactly one published configuration per lift system at any given time
+  - Enhanced `LiftSystemVersionService.publishVersion()` to automatically archive previously published versions
+  - Transactional workflow guarantees atomic state transitions
+  - No manual archiving required - reduces human error and improves workflow efficiency
+- **Runtime Configuration API**: New dedicated API for retrieving published configurations
+  - `RuntimeConfigService` providing read-only access to published configurations
+  - `GET /api/runtime/systems/{systemKey}/config` - Get currently published configuration by system key
+  - `GET /api/runtime/systems/{systemKey}/versions/{versionNumber}` - Get specific published version
+  - Returns 404 if no published version exists
+  - Clear separation between admin APIs (management) and runtime APIs (consumption)
+  - `RuntimeConfigDTO` with streamlined response format
+- **Comprehensive Test Coverage**: Tests for publish/archive workflow and runtime APIs
+  - `testPublishVersion_ArchivesPreviouslyPublishedVersion()` validates automatic archiving behavior
+  - `RuntimeConfigServiceTest` with 6 unit tests covering all runtime API scenarios
+  - Tests for system not found, no published version, and version not published error paths
+- **Documentation**: ADR-0010 for publish/archive workflow design decisions
+
+### Changed
+- Version bumped from 0.27.0 to 0.28.0
+- `publishVersion()` method now archives previously published versions before publishing new version
+- Publish workflow is transactional - if archiving or publishing fails, entire operation rolls back
+- Updated service layer tests to verify archiving behavior
+
+### Documentation
+- Updated README with Runtime API documentation and usage examples
+- Added ADR-0010 to Architecture Decisions section
+- Updated version references from 0.27.0 to 0.28.0
+
+### Technical Details
+- Publish operation uses `@Transactional` to ensure atomicity
+- Previously published versions are found via `findByLiftSystemIdAndIsPublishedTrue()`
+- Each published version's `archive()` method sets status to ARCHIVED
+- Runtime APIs filter for `isPublished = true` configurations only
+- Runtime package structure: `com.liftsimulator.runtime.{controller,service,dto}`
+
 ## [0.27.0] - 2026-01-11
 
 ### Added

--- a/docs/decisions/0010-publish-archive-workflow.md
+++ b/docs/decisions/0010-publish-archive-workflow.md
@@ -1,0 +1,216 @@
+# ADR-0010: Publish/Archive Workflow for Configuration Management
+
+**Date**: 2026-01-11
+
+**Status**: Accepted
+
+## Context
+
+The Lift Config Service manages versioned lift system configurations with status tracking (DRAFT, PUBLISHED, ARCHIVED). While the basic versioning infrastructure exists, there is no enforcement mechanism to ensure exactly one published configuration per lift system at any given time.
+
+Without this enforcement:
+
+1. **Multiple published versions** could exist simultaneously, creating ambiguity about which configuration to use
+2. **Runtime systems** have no clear way to retrieve the "current" configuration
+3. **Manual archiving** would be required, prone to human error
+4. **State transitions** lack proper workflow management
+
+We need a publish/archive workflow that:
+- Automatically archives the previously published version when publishing a new one
+- Guarantees exactly one published configuration per lift system
+- Provides dedicated runtime APIs that return only published configurations
+- Enforces validation before allowing publication
+
+## Decision
+
+We will implement an **automatic publish/archive workflow** that ensures exactly one published version per lift system through transactional state transitions and dedicated runtime APIs.
+
+### Implementation Details
+
+#### 1. Enhanced Publish Service
+
+**Modified `LiftSystemVersionService.publishVersion()`**:
+- Transactional operation ensuring atomic state changes
+- Before publishing a new version:
+  1. Validate the configuration (already implemented)
+  2. Check if version is already published (already implemented)
+  3. **NEW**: Find all currently published versions for the lift system
+  4. **NEW**: Archive each published version by calling `version.archive()`
+  5. Publish the new version
+- Result: Only one version remains in PUBLISHED status
+
+**Code Flow**:
+```java
+@Transactional
+public VersionResponse publishVersion(Long systemId, Integer versionNumber) {
+    // ... existing validation logic ...
+
+    // Archive any previously published versions
+    List<LiftSystemVersion> publishedVersions =
+        versionRepository.findByLiftSystemIdAndIsPublishedTrue(systemId);
+    for (LiftSystemVersion publishedVersion : publishedVersions) {
+        publishedVersion.archive();
+        versionRepository.save(publishedVersion);
+    }
+
+    // Publish the new version
+    version.publish();
+    versionRepository.save(version);
+
+    return VersionResponse.fromEntity(version);
+}
+```
+
+#### 2. Runtime API Layer
+
+**New Package Structure**: `com.liftsimulator.runtime`
+- Separates runtime (consumer) APIs from admin (management) APIs
+- Runtime APIs are read-only and return only published configurations
+
+**RuntimeConfigService** (`com.liftsimulator.runtime.service.RuntimeConfigService`):
+- Provides methods to retrieve published configurations
+- Methods:
+  - `getPublishedConfig(String systemKey)`: Returns the currently published version
+  - `getPublishedVersion(String systemKey, Integer versionNumber)`: Returns a specific version if published
+- Throws `ResourceNotFoundException` if no published version exists
+
+**RuntimeConfigDTO** (`com.liftsimulator.runtime.dto.RuntimeConfigDTO`):
+- Lightweight DTO for runtime responses
+- Contains: `systemKey`, `displayName`, `versionNumber`, `config`, `publishedAt`
+- Excludes internal metadata (id, status, timestamps)
+
+**RuntimeConfigController** (`com.liftsimulator.runtime.controller.RuntimeConfigController`):
+- REST endpoints under `/api/runtime/systems`
+- Endpoints:
+  - `GET /api/runtime/systems/{systemKey}/config`: Get current published config
+  - `GET /api/runtime/systems/{systemKey}/versions/{versionNumber}`: Get specific published version
+- Returns 404 if system not found or no published version exists
+
+#### 3. State Transition Guarantees
+
+**Transactional Safety**:
+- All publish operations use `@Transactional` to ensure atomicity
+- If archiving or publishing fails, entire transaction rolls back
+- Prevents inconsistent states (e.g., two published versions)
+
+**Database Constraints**:
+- Existing unique constraint on `(lift_system_id, version_number)` prevents duplicate versions
+- Application-level enforcement ensures single published version per system
+
+#### 4. Testing Strategy
+
+**Service Layer Tests** (`LiftSystemVersionServiceTest`):
+- `testPublishVersion_Success()`: Updated to verify archiving call
+- `testPublishVersion_ArchivesPreviouslyPublishedVersion()`: New test verifying:
+  - Previously published version is archived (status = ARCHIVED)
+  - New version is published (status = PUBLISHED)
+  - Both save operations occur
+
+**Runtime Service Tests** (`RuntimeConfigServiceTest`):
+- `testGetPublishedConfig_Success()`: Retrieves published config by system key
+- `testGetPublishedConfig_NoPublishedVersion()`: Returns 404 when no published version
+- `testGetPublishedVersion_VersionNotPublished()`: Returns 404 for non-published versions
+- Full coverage of error paths (system not found, version not found, not published)
+
+### Alternatives Considered
+
+#### 1. Database Constraint for Single Published Version
+
+**Option**: Add unique partial index `(lift_system_id) WHERE is_published = true`
+- **Pros**: Database enforces single published version guarantee
+- **Cons**:
+  - PostgreSQL-specific partial index syntax
+  - Less portable across databases
+  - Cryptic error messages on constraint violation
+  - Requires migration to add constraint
+- **Rejected**: Application-level enforcement provides better control and error handling
+
+#### 2. Manual Archive Endpoint
+
+**Option**: Provide separate `POST /archive` endpoint for users to archive versions
+- **Pros**: Explicit control over archiving
+- **Cons**:
+  - Error-prone: users might forget to archive before publishing
+  - Multiple API calls required for publish workflow
+  - Race conditions if multiple users publish simultaneously
+  - Poor user experience
+- **Rejected**: Automatic archiving is safer and simpler
+
+#### 3. Soft Delete Instead of Archive Status
+
+**Option**: Use `deleted_at` timestamp instead of ARCHIVED status
+- **Pros**: Common pattern for soft deletes
+- **Cons**:
+  - ARCHIVED is semantically different from deleted
+  - Archived versions may still be useful for history/audit
+  - Less clear in status queries
+- **Rejected**: ARCHIVED status better represents the intent
+
+#### 4. Versioned Runtime API (e.g., /api/v1/runtime)
+
+**Option**: Version the runtime API path
+- **Pros**: Easier to evolve API contract over time
+- **Cons**:
+  - Premature optimization before API stabilizes
+  - Increases complexity of path management
+  - Can add versioning later if needed
+- **Deferred**: Can be added in future if API changes require it
+
+## Consequences
+
+### Positive
+
+1. **Single Source of Truth**: Exactly one published configuration per lift system guaranteed
+2. **Automatic Workflow**: No manual archiving required; reduces human error
+3. **Transactional Safety**: Atomic state transitions prevent inconsistent states
+4. **Clear Runtime API**: Dedicated endpoints for retrieving published configurations
+5. **Separation of Concerns**: Admin APIs vs. runtime APIs clearly separated
+6. **Better UX**: Users don't need to manually archive before publishing
+7. **Auditability**: Archived versions remain in database for history tracking
+8. **Testability**: Comprehensive test coverage for state transitions
+
+### Negative
+
+1. **Increased Complexity**: More database queries during publish operation
+2. **Performance Cost**: Additional query to find published versions (minimal impact)
+3. **No Rollback Endpoint**: Reverting to a previous version requires republishing it
+4. **Archive Accumulation**: Archived versions accumulate over time (future cleanup needed)
+
+### Risks and Mitigations
+
+**Risk**: Performance degradation with many published versions to archive
+- **Mitigation**: In practice, only one version should be published (enforced by workflow)
+- **Mitigation**: Query is indexed on `(lift_system_id, is_published)`
+
+**Risk**: Confusion about archived versions vs. deleted versions
+- **Mitigation**: Clear API documentation explaining status meanings
+- **Mitigation**: Version list API shows all statuses for transparency
+
+**Risk**: Runtime API returning 404 disrupts consumer systems
+- **Mitigation**: Clear error messages indicating no published version
+- **Mitigation**: Admin UI should warn if unpublishing last version
+
+**Risk**: Archive accumulation consumes database space
+- **Mitigation**: Future ADR can address archival retention policies
+- **Mitigation**: Archived versions provide valuable audit trail
+
+## Compliance
+
+This ADR complies with:
+- **ACID Transactions**: Spring `@Transactional` ensures consistency
+- **RESTful API Design**: Clear separation of admin vs. runtime concerns
+- **Single Responsibility Principle**: Runtime service focused solely on published configs
+- **Fail-Safe Defaults**: Operations fail if published config not available
+
+## Related Decisions
+
+- **ADR-0009**: Configuration Validation Framework - Validation enforced before publish
+- **ADR-0008**: JPA Entities and JSONB Mapping - Version status tracking
+- **ADR-0006**: Spring Boot Admin Backend - REST API architecture
+- **ADR-0007**: PostgreSQL and Flyway Integration - Transactional database operations
+
+## References
+
+- [Spring Transaction Management](https://docs.spring.io/spring-framework/reference/data-access/transaction.html)
+- [RESTful API Design Best Practices](https://restfulapi.net/)
+- [Database Indexing for Performance](https://use-the-index-luke.com/)

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.27.0</version>
+    <version>0.28.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
@@ -153,6 +153,7 @@ public class LiftSystemVersionService {
     /**
      * Publishes a version after validating its configuration.
      * Only versions with valid configurations can be published.
+     * Automatically archives any previously published version for the same lift system.
      *
      * @param systemId the lift system ID
      * @param versionNumber the version number
@@ -183,6 +184,14 @@ public class LiftSystemVersionService {
                 "Cannot publish version with validation errors",
                 validationResponse
             );
+        }
+
+        // Archive any previously published versions for this lift system
+        List<LiftSystemVersion> publishedVersions = versionRepository
+            .findByLiftSystemIdAndIsPublishedTrue(systemId);
+        for (LiftSystemVersion publishedVersion : publishedVersions) {
+            publishedVersion.archive();
+            versionRepository.save(publishedVersion);
         }
 
         // Publish the version

--- a/src/main/java/com/liftsimulator/runtime/controller/RuntimeConfigController.java
+++ b/src/main/java/com/liftsimulator/runtime/controller/RuntimeConfigController.java
@@ -1,0 +1,50 @@
+package com.liftsimulator.runtime.controller;
+
+import com.liftsimulator.runtime.dto.RuntimeConfigDTO;
+import com.liftsimulator.runtime.service.RuntimeConfigService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for runtime configuration access.
+ * Provides read-only access to published configurations.
+ */
+@RestController
+@RequestMapping("/api/runtime/systems")
+public class RuntimeConfigController {
+
+    private final RuntimeConfigService runtimeConfigService;
+
+    public RuntimeConfigController(RuntimeConfigService runtimeConfigService) {
+        this.runtimeConfigService = runtimeConfigService;
+    }
+
+    /**
+     * Retrieves the currently published configuration for a lift system.
+     * Only returns configurations that are in PUBLISHED status.
+     *
+     * @param systemKey the unique system key
+     * @return the published configuration
+     */
+    @GetMapping("/{systemKey}/config")
+    public RuntimeConfigDTO getPublishedConfig(@PathVariable String systemKey) {
+        return runtimeConfigService.getPublishedConfig(systemKey);
+    }
+
+    /**
+     * Retrieves a specific published version by system key and version number.
+     * Only returns the version if it is currently published.
+     *
+     * @param systemKey the unique system key
+     * @param versionNumber the version number
+     * @return the published version
+     */
+    @GetMapping("/{systemKey}/versions/{versionNumber}")
+    public RuntimeConfigDTO getPublishedVersion(
+            @PathVariable String systemKey,
+            @PathVariable Integer versionNumber) {
+        return runtimeConfigService.getPublishedVersion(systemKey, versionNumber);
+    }
+}

--- a/src/main/java/com/liftsimulator/runtime/dto/RuntimeConfigDTO.java
+++ b/src/main/java/com/liftsimulator/runtime/dto/RuntimeConfigDTO.java
@@ -1,0 +1,42 @@
+package com.liftsimulator.runtime.dto;
+
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+
+import java.time.OffsetDateTime;
+
+/**
+ * DTO for runtime configuration responses.
+ * Contains only published configuration data.
+ *
+ * @param systemKey unique identifier for the lift system
+ * @param displayName display name of the lift system
+ * @param versionNumber the version number
+ * @param config the configuration JSON
+ * @param publishedAt when the version was published
+ */
+public record RuntimeConfigDTO(
+    String systemKey,
+    String displayName,
+    Integer versionNumber,
+    String config,
+    OffsetDateTime publishedAt
+) {
+
+    /**
+     * Creates a RuntimeConfigDTO from entities.
+     *
+     * @param liftSystem the lift system entity
+     * @param version the published version entity
+     * @return the runtime config DTO
+     */
+    public static RuntimeConfigDTO fromEntity(LiftSystem liftSystem, LiftSystemVersion version) {
+        return new RuntimeConfigDTO(
+            liftSystem.getSystemKey(),
+            liftSystem.getDisplayName(),
+            version.getVersionNumber(),
+            version.getConfig(),
+            version.getPublishedAt()
+        );
+    }
+}

--- a/src/main/java/com/liftsimulator/runtime/service/RuntimeConfigService.java
+++ b/src/main/java/com/liftsimulator/runtime/service/RuntimeConfigService.java
@@ -1,0 +1,87 @@
+package com.liftsimulator.runtime.service;
+
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.service.ResourceNotFoundException;
+import com.liftsimulator.runtime.dto.RuntimeConfigDTO;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service for runtime configuration retrieval.
+ * Provides access to published configurations only.
+ */
+@Service
+@Transactional(readOnly = true)
+public class RuntimeConfigService {
+
+    private final LiftSystemRepository liftSystemRepository;
+    private final LiftSystemVersionRepository versionRepository;
+
+    public RuntimeConfigService(
+            LiftSystemRepository liftSystemRepository,
+            LiftSystemVersionRepository versionRepository) {
+        this.liftSystemRepository = liftSystemRepository;
+        this.versionRepository = versionRepository;
+    }
+
+    /**
+     * Retrieves the published configuration for a lift system by system key.
+     * Only returns configurations that are currently published.
+     *
+     * @param systemKey the unique system key
+     * @return the published configuration
+     * @throws ResourceNotFoundException if system not found or no published version exists
+     */
+    public RuntimeConfigDTO getPublishedConfig(String systemKey) {
+        var liftSystem = liftSystemRepository.findBySystemKey(systemKey)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Lift system not found with key: " + systemKey
+            ));
+
+        var publishedVersions = versionRepository
+            .findByLiftSystemIdAndIsPublishedTrue(liftSystem.getId());
+
+        if (publishedVersions.isEmpty()) {
+            throw new ResourceNotFoundException(
+                "No published version found for lift system: " + systemKey
+            );
+        }
+
+        // Should only be one published version due to publish/archive workflow
+        LiftSystemVersion publishedVersion = publishedVersions.get(0);
+
+        return RuntimeConfigDTO.fromEntity(liftSystem, publishedVersion);
+    }
+
+    /**
+     * Retrieves a specific published version by system key and version number.
+     * Only returns the version if it is currently published.
+     *
+     * @param systemKey the unique system key
+     * @param versionNumber the version number
+     * @return the published version
+     * @throws ResourceNotFoundException if system not found, version not found, or version not published
+     */
+    public RuntimeConfigDTO getPublishedVersion(String systemKey, Integer versionNumber) {
+        var liftSystem = liftSystemRepository.findBySystemKey(systemKey)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Lift system not found with key: " + systemKey
+            ));
+
+        var version = versionRepository
+            .findByLiftSystemIdAndVersionNumber(liftSystem.getId(), versionNumber)
+            .orElseThrow(() -> new ResourceNotFoundException(
+                "Version " + versionNumber + " not found for lift system: " + systemKey
+            ));
+
+        if (!version.getIsPublished()) {
+            throw new ResourceNotFoundException(
+                "Version " + versionNumber + " is not published for lift system: " + systemKey
+            );
+        }
+
+        return RuntimeConfigDTO.fromEntity(liftSystem, version);
+    }
+}

--- a/src/test/java/com/liftsimulator/runtime/service/RuntimeConfigServiceTest.java
+++ b/src/test/java/com/liftsimulator/runtime/service/RuntimeConfigServiceTest.java
@@ -1,0 +1,189 @@
+package com.liftsimulator.runtime.service;
+
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.service.ResourceNotFoundException;
+import com.liftsimulator.runtime.dto.RuntimeConfigDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for RuntimeConfigService.
+ */
+@ExtendWith(MockitoExtension.class)
+public class RuntimeConfigServiceTest {
+
+    @Mock
+    private LiftSystemRepository liftSystemRepository;
+
+    @Mock
+    private LiftSystemVersionRepository versionRepository;
+
+    @InjectMocks
+    private RuntimeConfigService runtimeConfigService;
+
+    private LiftSystem mockLiftSystem;
+    private LiftSystemVersion mockPublishedVersion;
+
+    @BeforeEach
+    public void setUp() {
+        mockLiftSystem = new LiftSystem();
+        mockLiftSystem.setId(1L);
+        mockLiftSystem.setSystemKey("test-system");
+        mockLiftSystem.setDisplayName("Test System");
+        mockLiftSystem.setDescription("Test Description");
+        mockLiftSystem.setCreatedAt(OffsetDateTime.now());
+        mockLiftSystem.setUpdatedAt(OffsetDateTime.now());
+
+        mockPublishedVersion = new LiftSystemVersion();
+        mockPublishedVersion.setId(1L);
+        mockPublishedVersion.setLiftSystem(mockLiftSystem);
+        mockPublishedVersion.setVersionNumber(1);
+        mockPublishedVersion.setConfig("{\"floors\": 10, \"lifts\": 2}");
+        mockPublishedVersion.setStatus(VersionStatus.PUBLISHED);
+        mockPublishedVersion.setIsPublished(true);
+        mockPublishedVersion.setPublishedAt(OffsetDateTime.now());
+        mockPublishedVersion.setCreatedAt(OffsetDateTime.now());
+        mockPublishedVersion.setUpdatedAt(OffsetDateTime.now());
+    }
+
+    @Test
+    public void testGetPublishedConfig_Success() {
+        when(liftSystemRepository.findBySystemKey("test-system"))
+            .thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndIsPublishedTrue(1L))
+            .thenReturn(List.of(mockPublishedVersion));
+
+        RuntimeConfigDTO result = runtimeConfigService.getPublishedConfig("test-system");
+
+        assertNotNull(result);
+        assertEquals("test-system", result.systemKey());
+        assertEquals("Test System", result.displayName());
+        assertEquals(1, result.versionNumber());
+        assertEquals("{\"floors\": 10, \"lifts\": 2}", result.config());
+        assertNotNull(result.publishedAt());
+
+        verify(liftSystemRepository).findBySystemKey("test-system");
+        verify(versionRepository).findByLiftSystemIdAndIsPublishedTrue(1L);
+    }
+
+    @Test
+    public void testGetPublishedConfig_LiftSystemNotFound() {
+        when(liftSystemRepository.findBySystemKey("nonexistent"))
+            .thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> runtimeConfigService.getPublishedConfig("nonexistent")
+        );
+
+        assertEquals("Lift system not found with key: nonexistent", exception.getMessage());
+        verify(liftSystemRepository).findBySystemKey("nonexistent");
+    }
+
+    @Test
+    public void testGetPublishedConfig_NoPublishedVersion() {
+        when(liftSystemRepository.findBySystemKey("test-system"))
+            .thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndIsPublishedTrue(1L))
+            .thenReturn(Collections.emptyList());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> runtimeConfigService.getPublishedConfig("test-system")
+        );
+
+        assertEquals("No published version found for lift system: test-system", exception.getMessage());
+        verify(liftSystemRepository).findBySystemKey("test-system");
+        verify(versionRepository).findByLiftSystemIdAndIsPublishedTrue(1L);
+    }
+
+    @Test
+    public void testGetPublishedVersion_Success() {
+        when(liftSystemRepository.findBySystemKey("test-system"))
+            .thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1))
+            .thenReturn(Optional.of(mockPublishedVersion));
+
+        RuntimeConfigDTO result = runtimeConfigService.getPublishedVersion("test-system", 1);
+
+        assertNotNull(result);
+        assertEquals("test-system", result.systemKey());
+        assertEquals("Test System", result.displayName());
+        assertEquals(1, result.versionNumber());
+        assertEquals("{\"floors\": 10, \"lifts\": 2}", result.config());
+        assertNotNull(result.publishedAt());
+
+        verify(liftSystemRepository).findBySystemKey("test-system");
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
+    }
+
+    @Test
+    public void testGetPublishedVersion_LiftSystemNotFound() {
+        when(liftSystemRepository.findBySystemKey("nonexistent"))
+            .thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> runtimeConfigService.getPublishedVersion("nonexistent", 1)
+        );
+
+        assertEquals("Lift system not found with key: nonexistent", exception.getMessage());
+        verify(liftSystemRepository).findBySystemKey("nonexistent");
+    }
+
+    @Test
+    public void testGetPublishedVersion_VersionNotFound() {
+        when(liftSystemRepository.findBySystemKey("test-system"))
+            .thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 999))
+            .thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> runtimeConfigService.getPublishedVersion("test-system", 999)
+        );
+
+        assertEquals("Version 999 not found for lift system: test-system", exception.getMessage());
+        verify(liftSystemRepository).findBySystemKey("test-system");
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 999);
+    }
+
+    @Test
+    public void testGetPublishedVersion_VersionNotPublished() {
+        mockPublishedVersion.setIsPublished(false);
+        mockPublishedVersion.setStatus(VersionStatus.DRAFT);
+
+        when(liftSystemRepository.findBySystemKey("test-system"))
+            .thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1))
+            .thenReturn(Optional.of(mockPublishedVersion));
+
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> runtimeConfigService.getPublishedVersion("test-system", 1)
+        );
+
+        assertEquals("Version 1 is not published for lift system: test-system", exception.getMessage());
+        verify(liftSystemRepository).findBySystemKey("test-system");
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
+    }
+}


### PR DESCRIPTION
- Enhanced publish service to automatically archive previously published versions
  - Only one published configuration per lift system guaranteed
  - Transactional workflow ensures atomic state transitions

- Added runtime API for published configurations
  - GET /api/runtime/systems/{systemKey}/config
  - GET /api/runtime/systems/{systemKey}/versions/{versionNumber}
  - Read-only API returning only published configurations

- Comprehensive test coverage
  - Updated LiftSystemVersionServiceTest with archive workflow tests
  - Added RuntimeConfigServiceTest with full coverage

- Documentation updates
  - Created ADR-0010 for publish/archive workflow design
  - Updated README with runtime API section
  - Updated CHANGELOG with v0.28.0 changes
  - Bumped version to 0.28.0

Closes #141 - Implements publish/archive workflow as specified