### PR TITLE
Serve React production build from Spring Boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.32.0] - 2026-01-20
+
+### Added
+- Frontend production bundling profile to build the React UI and include it in the Spring Boot JAR
+- SPA route forwarding controller so client-side routes load correctly when served by Spring Boot
+
+### Changed
+- Version bumped from 0.31.0 to 0.32.0
+- Updated README and frontend docs with clear dev vs production run instructions
+
 ## [0.31.0] - 2026-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.31.0**
+Current version: **0.32.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -34,7 +34,7 @@ A modern React web application provides a user-friendly interface for managing l
 - **Configuration Validator**: Validate configuration JSON before publishing
 - **Health Check**: Monitor backend service status
 
-#### Running the Frontend
+#### Running the Frontend (Dev Mode)
 
 ```bash
 cd frontend
@@ -45,6 +45,17 @@ npm run dev
 The frontend will start on **http://localhost:3000** and automatically proxy API requests to the backend on port 8080.
 
 **See [frontend/README.md](frontend/README.md) for detailed setup instructions and documentation.**
+
+#### Production Build (Single App)
+
+To package the React UI with the Spring Boot backend and serve everything from **http://localhost:8080**:
+
+```bash
+mvn -Pfrontend clean package
+java -jar target/lift-simulator-0.32.0.jar
+```
+
+This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
 
 ### Backend API
 
@@ -62,7 +73,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.31.0.jar
+java -jar target/lift-simulator-0.32.0.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -540,7 +551,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.31.0.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.32.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,6 +48,17 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 
 Or use your IDE to run the main application class.
 
+## Production Build with Spring Boot
+
+For a single-app setup (frontend served by Spring Boot on port 8080), build from the repository root:
+
+```bash
+mvn -Pfrontend clean package
+java -jar target/lift-simulator-0.32.0.jar
+```
+
+This packages the React build output into the Spring Boot JAR and serves it from `/`.
+
 ## Available Scripts
 
 - `npm run dev` - Start development server (port 3000)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.29.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.29.0",
+      "version": "0.32.0",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.31.0",
+  "version": "0.32.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.31.0</version>
+    <version>0.32.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -24,6 +24,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <junit.version>5.10.1</junit.version>
+        <frontend.dir>${project.basedir}/frontend</frontend.dir>
+        <frontend.build.dir>${frontend.dir}/dist</frontend.build.dir>
     </properties>
 
     <dependencies>
@@ -229,4 +231,73 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>frontend</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.15.0</version>
+                        <configuration>
+                            <workingDirectory>${frontend.dir}</workingDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>install-node-and-npm</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v20.11.1</nodeVersion>
+                                    <npmVersion>10.2.4</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm-ci</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>ci</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm-build</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run build</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-frontend-assets</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.outputDirectory}/static</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>${frontend.build.dir}</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/com/liftsimulator/admin/controller/SpaForwardingController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SpaForwardingController.java
@@ -1,0 +1,17 @@
+package com.liftsimulator.admin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class SpaForwardingController {
+    @RequestMapping(
+            value = {
+                "/{path:^(?!api|actuator|error).*$}",
+                "/{path:^(?!api|actuator|error).*$}/**/{path:[^\\.]*}"
+            }
+    )
+    public String forwardToIndex() {
+        return "forward:/index.html";
+    }
+}


### PR DESCRIPTION
### Motivation
- Package frontend and backend into a single runnable application so the React UI can be served from Spring Boot without a separate frontend server.
- Provide a clear separation between development (Vite dev server) and production (bundled assets served by Spring Boot).
- Ensure client-side routes in the SPA resolve correctly when the production build is served from the backend.
- Bump the project version to reflect the release that includes frontend bundling.

### Description
- Added a Maven `frontend` profile that installs Node/npm, runs `npm ci` and `npm run build`, and copies `frontend/dist` into the Spring Boot output directory during `process-resources` (configured in `pom.xml`).
- Added `SpaForwardingController` (`com.liftsimulator.admin.controller.SpaForwardingController`) which forwards non-`/api` and non-`/actuator` requests to `index.html` to support SPA routing.
- Bumped versions to `0.32.0` (`pom.xml`, `frontend/package.json`, and updated `frontend/package-lock.json`) and added `frontend.dir`/`frontend.build.dir` properties to the POM.
- Updated documentation (`README.md`, `frontend/README.md`) and `CHANGELOG.md` with the new production packaging workflow and commands (`mvn -Pfrontend clean package` and `java -jar target/lift-simulator-0.32.0.jar`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b06291488325a49a7ec2772fe23e)