### PR TITLE
Add env-configurable API client timeout and base URL; bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.1] - 2026-02-13
+
+### Added
+- Frontend API client now supports environment-configured base URL and request timeout via Vite env variables
+
+### Changed
+- Default Axios request timeout set to 10 seconds to prevent hanging requests
+- Version bumped from 0.36.0 to 0.36.1
+- Frontend package version updated to 0.36.1
+
 ## [0.36.0] - 2026-01-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.36.0**
+Current version: **0.36.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -44,6 +44,8 @@ npm run dev
 
 The frontend will start on **http://localhost:3000** and automatically proxy API requests to the backend on port 8080.
 
+The frontend API base URL and request timeout can be configured via Vite environment variables. See the [frontend README](frontend/README.md#environment-variables) for details.
+
 **See [frontend/README.md](frontend/README.md) for detailed setup instructions and documentation.**
 
 #### Production Build (Single App)
@@ -52,7 +54,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.35.2.jar
+java -jar target/lift-simulator-0.36.1.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
@@ -73,7 +75,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.35.2.jar
+java -jar target/lift-simulator-0.36.1.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -573,7 +575,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.35.2.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.36.1.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -817,7 +819,7 @@ dropdb lift_simulator_test
 
 ## Features
 
-The current version (v0.35.2) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.36.1) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -984,7 +986,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.35.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.36.1.jar`.
 
 ## Running Tests
 
@@ -1034,7 +1036,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1043,16 +1045,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1066,7 +1068,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1084,7 +1086,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1093,13 +1095,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.35.2.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,7 +54,7 @@ For a single-app setup (frontend served by Spring Boot on port 8080), build from
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.35.2.jar
+java -jar target/lift-simulator-0.36.1.jar
 ```
 
 This packages the React build output into the Spring Boot JAR and serves it from `/`.
@@ -67,6 +67,24 @@ This packages the React build output into the Spring Boot JAR and serves it from
 - `npm run lint` - Run ESLint
 
 ## API Configuration
+
+### Environment Variables
+
+The API client can be configured at build time via Vite environment variables:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `VITE_API_BASE_URL` | Base URL for API requests (e.g., `https://api.example.com/api`) | `/api` |
+| `VITE_API_TIMEOUT_MS` | Axios request timeout in milliseconds | `10000` |
+
+Example `.env` file:
+
+```bash
+VITE_API_BASE_URL=http://localhost:8080/api
+VITE_API_TIMEOUT_MS=15000
+```
+
+If `VITE_API_BASE_URL` is left unset, the app will continue to use `/api`, which works with the Vite proxy in local development.
 
 ### Proxy Setup
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.33.3",
+  "version": "0.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.33.3",
+      "version": "0.36.1",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.36.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,7 +1,13 @@
 import axios from 'axios';
 
+const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api').trim() || '/api';
+const timeoutFromEnv = Number(import.meta.env.VITE_API_TIMEOUT_MS);
+const requestTimeoutMs =
+  Number.isFinite(timeoutFromEnv) && timeoutFromEnv > 0 ? timeoutFromEnv : 10000;
+
 const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL: apiBaseUrl,
+  timeout: requestTimeoutMs,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.35.2</version>
+    <version>0.36.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation

- Prevent frontend HTTP requests from hanging indefinitely by adding a default request timeout to the centralized Axios client.
- Allow the API base URL and timeout to be configured per-environment to support development, staging, and production deployments.
- Keep documentation and release metadata consistent by updating READMEs, changelog, and package/pom versions.

### Description

- Updated `frontend/src/api/client.js` to read `VITE_API_BASE_URL` and `VITE_API_TIMEOUT_MS` from `import.meta.env`, use `/api` as the fallback, and apply a default timeout of `10000` ms.
- Documented the new environment variables in `frontend/README.md` and added a reference to the frontend env config from the root `README.md`.
- Bumped the frontend package version (`frontend/package.json` and `frontend/package-lock.json`) to `0.36.1`, updated the project `pom.xml` version to `0.36.1`, and updated runtime/JAR references in the READMEs.
- Added an entry to `CHANGELOG.md` describing the new env-configurable API client settings and the timeout default.

### Testing

- No automated tests were run as part of this change.
- Changes are limited to client configuration, docs, and version metadata; manual verification recommended (start frontend with `npm run dev` and set `VITE_API_BASE_URL`/`VITE_API_TIMEOUT_MS` to confirm behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969b84227b08325b387b0ea5e039ff3)