### PR TITLE
Fix CHANGELOG dates for 0.36.1 and 0.36.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.36.1] - 2026-02-13
+## [0.36.2] - 2026-01-16
+
+### Added
+- Shared Modal component to centralize overlay, header, and focus/keyboard handling for modal variants
+- Shared Modal CSS for consistent base modal styling across the UI
+
+### Changed
+- AlertModal and ConfirmModal now render via the shared Modal component to reduce duplication
+- Version bumped from 0.36.1 to 0.36.2
+- Frontend package version updated to 0.36.2
+
+## [0.36.1] - 2026-01-16
 
 ### Added
 - Frontend API client now supports environment-configured base URL and request timeout via Vite env variables

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.36.1**
+Current version: **0.36.2**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -54,7 +54,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.36.1.jar
+java -jar target/lift-simulator-0.36.2.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
@@ -75,7 +75,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.36.1.jar
+java -jar target/lift-simulator-0.36.2.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -575,7 +575,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.36.1.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.36.2.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -819,7 +819,7 @@ dropdb lift_simulator_test
 
 ## Features
 
-The current version (v0.36.1) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.36.2) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -986,7 +986,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.36.1.jar`.
+The packaged JAR will be in `target/lift-simulator-0.36.2.jar`.
 
 ## Running Tests
 
@@ -1036,7 +1036,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1045,16 +1045,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1068,7 +1068,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1086,7 +1086,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1095,13 +1095,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.36.1.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,7 +54,7 @@ For a single-app setup (frontend served by Spring Boot on port 8080), build from
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.36.1.jar
+java -jar target/lift-simulator-0.36.2.jar
 ```
 
 This packages the React build output into the Spring Boot JAR and serves it from `/`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.36.1",
+      "version": "0.36.2",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.36.1",
+  "version": "0.36.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/AlertModal.jsx
+++ b/frontend/src/components/AlertModal.jsx
@@ -1,32 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import Modal from './Modal';
 import './AlertModal.css';
 
 function AlertModal({ isOpen, onClose, title = 'Error', message, type = 'error' }) {
   const okButtonRef = useRef(null);
-  const modalRef = useRef(null);
-
-  useEffect(() => {
-    if (isOpen && okButtonRef.current) {
-      // Focus the OK button when modal opens
-      okButtonRef.current.focus();
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e) => {
-      if (e.key === 'Escape' || e.key === 'Enter') {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isOpen, onClose]);
 
   if (!isOpen) return null;
 
@@ -46,29 +23,31 @@ function AlertModal({ isOpen, onClose, title = 'Error', message, type = 'error' 
   };
 
   return (
-    <div className="modal-overlay" onClick={onClose} role="alertdialog" aria-modal="true" aria-labelledby="alert-modal-title">
-      <div className="modal-content alert-modal" onClick={(e) => e.stopPropagation()} ref={modalRef}>
-        <div className="modal-header">
-          <h2 id="alert-modal-title">{title}</h2>
-          <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>
-        </div>
-
-        <div className={`alert-modal-body alert-${type}`}>
-          <div className="alert-icon">{getIcon()}</div>
-          <p>{message}</p>
-        </div>
-
-        <div className="modal-actions">
-          <button
-            ref={okButtonRef}
-            onClick={onClose}
-            className="btn-primary"
-          >
-            OK
-          </button>
-        </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      role="alertdialog"
+      className="alert-modal"
+      initialFocusRef={okButtonRef}
+      onEnter={onClose}
+      trapFocus={false}
+    >
+      <div className={`alert-modal-body alert-${type}`}>
+        <div className="alert-icon">{getIcon()}</div>
+        <p>{message}</p>
       </div>
-    </div>
+
+      <div className="modal-actions">
+        <button
+          ref={okButtonRef}
+          onClick={onClose}
+          className="btn-primary"
+        >
+          OK
+        </button>
+      </div>
+    </Modal>
   );
 }
 

--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -1,59 +1,18 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import Modal from './Modal';
 import './ConfirmModal.css';
 
-function ConfirmModal({ isOpen, onClose, onConfirm, title, message, confirmText = 'Confirm', cancelText = 'Cancel', confirmStyle = 'primary' }) {
+function ConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title,
+  message,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  confirmStyle = 'primary'
+}) {
   const confirmButtonRef = useRef(null);
-  const modalRef = useRef(null);
-
-  useEffect(() => {
-    if (isOpen && confirmButtonRef.current) {
-      // Focus the confirm button when modal opens
-      confirmButtonRef.current.focus();
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    const handleTabKey = (e) => {
-      if (e.key === 'Tab') {
-        const modal = modalRef.current;
-        if (!modal) return;
-
-        const focusableElements = modal.querySelectorAll(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
-        const firstElement = focusableElements[0];
-        const lastElement = focusableElements[focusableElements.length - 1];
-
-        if (e.shiftKey) {
-          if (document.activeElement === firstElement) {
-            e.preventDefault();
-            lastElement.focus();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            e.preventDefault();
-            firstElement.focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('keydown', handleTabKey);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.removeEventListener('keydown', handleTabKey);
-    };
-  }, [isOpen, onClose]);
 
   const handleConfirm = () => {
     onConfirm();
@@ -63,31 +22,31 @@ function ConfirmModal({ isOpen, onClose, onConfirm, title, message, confirmText 
   if (!isOpen) return null;
 
   return (
-    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title">
-      <div className="modal-content confirm-modal" onClick={(e) => e.stopPropagation()} ref={modalRef}>
-        <div className="modal-header">
-          <h2 id="confirm-modal-title">{title}</h2>
-          <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>
-        </div>
-
-        <div className="confirm-modal-body">
-          <p>{message}</p>
-        </div>
-
-        <div className="modal-actions">
-          <button onClick={onClose} className="btn-secondary">
-            {cancelText}
-          </button>
-          <button
-            ref={confirmButtonRef}
-            onClick={handleConfirm}
-            className={`btn-${confirmStyle}`}
-          >
-            {confirmText}
-          </button>
-        </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      role="dialog"
+      className="confirm-modal"
+      initialFocusRef={confirmButtonRef}
+    >
+      <div className="confirm-modal-body">
+        <p>{message}</p>
       </div>
-    </div>
+
+      <div className="modal-actions">
+        <button onClick={onClose} className="btn-secondary">
+          {cancelText}
+        </button>
+        <button
+          ref={confirmButtonRef}
+          onClick={handleConfirm}
+          className={`btn-${confirmStyle}`}
+        >
+          {confirmText}
+        </button>
+      </div>
+    </Modal>
   );
 }
 

--- a/frontend/src/components/CreateSystemModal.css
+++ b/frontend/src/components/CreateSystemModal.css
@@ -1,60 +1,3 @@
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-  padding: 1rem;
-}
-
-.modal-content {
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
-  max-width: 600px;
-  width: 100%;
-  max-height: 90vh;
-  overflow-y: auto;
-}
-
-.modal-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.5rem;
-  border-bottom: 1px solid #ecf0f1;
-}
-
-.modal-header h2 {
-  margin: 0;
-  color: #2c3e50;
-}
-
-.close-button {
-  background: none;
-  border: none;
-  font-size: 2rem;
-  color: #7f8c8d;
-  cursor: pointer;
-  padding: 0;
-  width: 2rem;
-  height: 2rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  transition: background-color 0.3s;
-}
-
-.close-button:hover {
-  background-color: #ecf0f1;
-}
-
 .modal-content form {
   padding: 1.5rem;
 }
@@ -107,23 +50,4 @@
   margin: 0.25rem 0 0 0;
   font-size: 0.85rem;
   color: #7f8c8d;
-}
-
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  padding-top: 1rem;
-  border-top: 1px solid #ecf0f1;
-}
-
-@media (max-width: 640px) {
-  .modal-content {
-    max-height: 100vh;
-    border-radius: 0;
-  }
-
-  .modal-overlay {
-    padding: 0;
-  }
 }

--- a/frontend/src/components/CreateSystemModal.jsx
+++ b/frontend/src/components/CreateSystemModal.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import './Modal.css';
 import './CreateSystemModal.css';
 
 function CreateSystemModal({ isOpen, onClose, onSubmit }) {

--- a/frontend/src/components/Modal.css
+++ b/frontend/src/components/Modal.css
@@ -1,0 +1,75 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #ecf0f1;
+}
+
+.modal-header h2 {
+  margin: 0;
+  color: #2c3e50;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  color: #7f8c8d;
+  cursor: pointer;
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background-color 0.3s;
+}
+
+.close-button:hover {
+  background-color: #ecf0f1;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #ecf0f1;
+}
+
+@media (max-width: 640px) {
+  .modal-content {
+    max-height: 100vh;
+    border-radius: 0;
+  }
+
+  .modal-overlay {
+    padding: 0;
+  }
+}

--- a/frontend/src/components/Modal.jsx
+++ b/frontend/src/components/Modal.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useId, useRef } from 'react';
+import './Modal.css';
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+function Modal({
+  isOpen,
+  onClose,
+  title,
+  role = 'dialog',
+  className = '',
+  children,
+  initialFocusRef,
+  onEnter,
+  trapFocus = true
+}) {
+  const modalRef = useRef(null);
+  const generatedTitleId = useId();
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const modal = modalRef.current;
+    if (!modal) return;
+
+    const focusTarget = initialFocusRef?.current || modal.querySelector(FOCUSABLE_SELECTOR);
+    focusTarget?.focus();
+  }, [isOpen, initialFocusRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (onEnter && e.key === 'Enter') {
+        onEnter();
+        return;
+      }
+
+      if (!trapFocus || e.key !== 'Tab') return;
+
+      const modal = modalRef.current;
+      if (!modal) return;
+
+      const focusableElements = modal.querySelectorAll(FOCUSABLE_SELECTOR);
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (focusableElements.length === 1) {
+        e.preventDefault();
+        firstElement.focus();
+        return;
+      }
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else if (document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose, onEnter, trapFocus]);
+
+  if (!isOpen) return null;
+
+  const titleId = `${generatedTitleId}-title`;
+
+  return (
+    <div className="modal-overlay" onClick={onClose} role={role} aria-modal="true" aria-labelledby={titleId}>
+      <div
+        className={`modal-content ${className}`.trim()}
+        onClick={(e) => e.stopPropagation()}
+        ref={modalRef}
+      >
+        <div className="modal-header">
+          <h2 id={titleId}>{title}</h2>
+          <button className="close-button" onClick={onClose} aria-label="Close">&times;</button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default Modal;

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.36.1</version>
+    <version>0.36.2</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Finalize the modal refactor that centralizes modal markup, keyboard handling, and focus management into a shared component for consistent UX and to reduce duplication.
- Bump frontend and backend package metadata to reflect the new release version `0.36.2` per Semantic Versioning.
- Correct incorrect release dates in `CHANGELOG.md` so the entries for `0.36.1` and `0.36.2` read `2026-01-16`.

### Description
- Added a reusable `Modal` component and stylesheet in `frontend/src/components/Modal.jsx` and `frontend/src/components/Modal.css` that implement overlay, header, close button, ARIA attributes, focus management, Enter/Escape handling, and optional Tab focus trapping.
- Refactored `AlertModal.jsx` and `ConfirmModal.jsx` to use the shared `Modal` and reduced duplicated logic, and updated `CreateSystemModal.jsx` to import the shared `Modal.css` for base styles.
- Bumped versions to `0.36.2` in `frontend/package.json`, `frontend/package-lock.json`, and `pom.xml`, and updated README references to the new artifact/JAR name.
- Fixed release dates in `CHANGELOG.md` for `0.36.2` and `0.36.1` to `2026-01-16`.

### Testing
- Started the frontend dev server with `npm run dev` (Vite) and confirmed the dev server started successfully on the expected port during the modal refactor verification.
- Ran a Playwright-based UI smoke script that loaded the app and captured a screenshot (`artifacts/modal.png`) during the modal verification step and it completed successfully.
- No unit test suites or Maven test runs were executed for the changelog date correction change (no `mvn test` or frontend unit tests were run for this specific edit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6f699888832583f10ca6aa766c0e)