### PR TITLE
Add search/filter to Lift Systems page and bump version to 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.37.0] - 2026-01-16
+
+### Added
+- Lift Systems search bar with client-side filtering by display name and system key
+- Empty state message for search results with no matches
+
+### Changed
+- Lift Systems list now filters results case-insensitively based on the search query
+- Version bumped from 0.36.3 to 0.37.0
+- Frontend package version updated to 0.37.0
+
 ## [0.36.3] - 2026-01-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.36.3**
+Current version: **0.37.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -54,7 +54,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.36.3.jar
+java -jar target/lift-simulator-0.37.0.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
@@ -75,7 +75,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.36.3.jar
+java -jar target/lift-simulator-0.37.0.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -575,7 +575,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.36.3.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.37.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -819,7 +819,7 @@ dropdb lift_simulator_test
 
 ## Features
 
-The current version (v0.36.2) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.37.0) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -986,7 +986,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.36.2.jar`.
+The packaged JAR will be in `target/lift-simulator-0.37.0.jar`.
 
 ## Running Tests
 
@@ -1036,7 +1036,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1045,16 +1045,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1068,7 +1068,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1086,7 +1086,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1095,13 +1095,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.36.2.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.37.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,7 +54,7 @@ For a single-app setup (frontend served by Spring Boot on port 8080), build from
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.36.2.jar
+java -jar target/lift-simulator-0.37.0.jar
 ```
 
 This packages the React build output into the Spring Boot JAR and serves it from `/`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.36.2",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.36.2",
+      "version": "0.37.0",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.36.3",
+  "version": "0.37.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/LiftSystems.css
+++ b/frontend/src/pages/LiftSystems.css
@@ -3,10 +3,44 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 2rem;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }
 
 .lift-systems h2 {
   margin: 0;
+}
+
+.page-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.search-input input {
+  min-width: 240px;
+  padding: 0.65rem 0.85rem;
+  border-radius: 6px;
+  border: 1px solid #d0d7de;
+  font-size: 0.95rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.search-input input:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.2);
+}
+
+.search-input input::placeholder {
+  color: #9aa3ad;
+}
+
+.page-title {
+  display: flex;
+  align-items: center;
 }
 
 .btn-primary {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.36.3</version>
+    <version>0.37.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Users need a quick way to find a specific lift system when the list grows, so the Lift Systems page requires a client-side search/filter UI. 
- The change also aligns documentation and packaging by bumping the project and frontend versions to reflect the new release.

### Description
- Added a case-insensitive search input to the `LiftSystems` page and implemented client-side filtering by `displayName` and `systemKey` using `useMemo` and `useState` in `frontend/src/pages/LiftSystems.jsx`.
- Render now shows an empty-state message when no systems match the search and uses the filtered list for the grid display instead of the full `systems` array.
- Added responsive header layout and search field styles in `frontend/src/pages/LiftSystems.css` to match existing UI controls.
- Bumped versions and documentation: updated `CHANGELOG.md`, `README.md`, `frontend/README.md`, `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json` to `0.37.0`.

### Testing
- Ran `npm install` in `frontend`, which completed successfully with no errors.
- Started the frontend with `npm run dev` and Vite reported the dev server ready, which indicates the UI builds and serves correctly.
- Executed an automated Playwright smoke script that opened the app, interacted with the new search input (filled and cleared it), and produced a screenshot confirming the UI change; the script completed successfully and generated `artifacts/lift-systems-search.png`.
- Observed `vite` proxy `ECONNREFUSED` errors for `/api/lift-systems` while the backend was not running, which is expected for this local dev run and does not affect client-side search functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7987036083258e11b94861d8ca6b)