### PR TITLE
Add frontend TypeScript declaration models and enable JSDoc type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.0] - 2026-01-25
+
+### Added
+- Frontend TypeScript declaration file for core lift system, version, and validation models
+- JSDoc-based typing for key admin UI components with @ts-check enabled
+- Frontend jsconfig configuration to enable JavaScript type checking in editors
+
+### Changed
+- Version bumped from 0.38.1 to 0.39.0
+- Frontend package version updated to 0.39.0
+- Documentation updated to describe using shared model typings in JSDoc
+
 ## [0.38.1] - 2026-01-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.38.1**
+Current version: **0.39.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -52,13 +52,30 @@ The frontend API base URL and request timeout can be configured via Vite environ
 
 **See [frontend/README.md](frontend/README.md) for detailed setup instructions and documentation.**
 
+#### Frontend Type Definitions (JSDoc)
+
+The admin UI ships TypeScript declaration files for core data models to provide type-aware IntelliSense in JavaScript files without a full TypeScript migration. To opt in, add `// @ts-check` to the top of your file and reference the types in JSDoc:
+
+```js
+// @ts-check
+
+/**
+ * @param {import('../types/models').LiftSystem} system
+ */
+function renderSystem(system) {
+  // IDE now knows system shape
+}
+```
+
+The shared models live in `frontend/src/types/models.d.ts` and include LiftSystem, Version, and ValidationResult interfaces. See the frontend README for more details.
+
 #### Production Build (Single App)
 
 To package the React UI with the Spring Boot backend and serve everything from **http://localhost:8080**:
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.38.1.jar
+java -jar target/lift-simulator-0.39.0.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
@@ -79,7 +96,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.38.1.jar
+java -jar target/lift-simulator-0.39.0.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -579,7 +596,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.38.1.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.39.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -823,7 +840,7 @@ dropdb lift_simulator_test
 
 ## Features
 
-The current version (v0.38.1) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.39.0) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -990,7 +1007,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.38.1.jar`.
+The packaged JAR will be in `target/lift-simulator-0.39.0.jar`.
 
 ## Running Tests
 
@@ -1040,7 +1057,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1049,16 +1066,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1072,7 +1089,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1090,7 +1107,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1099,13 +1116,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.38.1.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,6 +17,29 @@ This is the frontend admin application for the Lift Simulator system. It provide
 - **React Router 7.12.0** - Client-side routing
 - **Axios 1.13.2** - HTTP client for API calls
 
+## Type Checking (JSDoc + Type Declarations)
+
+The frontend remains JavaScript-first, but it includes TypeScript declaration files for core data models to enable editor type checking and autocomplete:
+
+1. Ensure `frontend/jsconfig.json` is present (it enables `checkJs` and `allowJs`).
+2. Add `// @ts-check` to the top of any JS file where you want type checking.
+3. Use JSDoc imports to reference shared models from `src/types/models.d.ts`.
+
+Example:
+
+```js
+// @ts-check
+
+/**
+ * @param {import('../types/models').LiftSystem} system
+ */
+function renderSystem(system) {
+  return system.displayName;
+}
+```
+
+Shared interfaces include `LiftSystem`, `Version`, and `ValidationResult`.
+
 ## Prerequisites
 
 - Node.js 18+ and npm
@@ -54,7 +77,7 @@ For a single-app setup (frontend served by Spring Boot on port 8080), build from
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.38.1.jar
+java -jar target/lift-simulator-0.39.0.jar
 ```
 
 This packages the React build output into the Spring Boot JAR and serves it from `/`.

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.38.1",
+      "version": "0.39.0",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.38.1",
+  "version": "0.39.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/VersionActions.jsx
+++ b/frontend/src/components/VersionActions.jsx
@@ -1,5 +1,19 @@
+// @ts-check
 import { Link } from 'react-router-dom';
 
+/**
+ * @typedef {Object} VersionActionsProps
+ * @property {string} systemId
+ * @property {number} versionNumber
+ * @property {import('../types/models').VersionStatus} status
+ * @property {(versionNumber: number) => void} onPublish
+ * @property {(versionNumber: number) => void} onRunSimulation
+ * @property {number | null} runningVersion
+ */
+
+/**
+ * @param {VersionActionsProps} props
+ */
 function VersionActions({
   systemId,
   versionNumber,

--- a/frontend/src/pages/ConfigEditor.jsx
+++ b/frontend/src/pages/ConfigEditor.jsx
@@ -1,3 +1,4 @@
+// @ts-check
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
@@ -10,7 +11,9 @@ function ConfigEditor() {
   const { systemId, versionNumber } = useParams();
   const navigate = useNavigate();
 
+  /** @type {import('../types/models').LiftSystem | null} */
   const [system, setSystem] = useState(null);
+  /** @type {import('../types/models').Version | null} */
   const [version, setVersion] = useState(null);
   const [config, setConfig] = useState('');
   const [loading, setLoading] = useState(true);
@@ -20,6 +23,7 @@ function ConfigEditor() {
   const [validating, setValidating] = useState(false);
   const [publishing, setPublishing] = useState(false);
 
+  /** @type {import('../types/models').ValidationResult | null} */
   const [validationResult, setValidationResult] = useState(null);
   const [lastSaved, setLastSaved] = useState(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -1,3 +1,4 @@
+// @ts-check
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
@@ -12,17 +13,22 @@ function LiftSystemDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
+  /** @type {import('../types/models').LiftSystem | null} */
   const [system, setSystem] = useState(null);
+  /** @type {import('../types/models').Version[]} */
   const [versions, setVersions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showCreateVersion, setShowCreateVersion] = useState(false);
   const [newVersionConfig, setNewVersionConfig] = useState('');
   const [creating, setCreating] = useState(false);
+  /** @type {number | null} */
   const [runningVersion, setRunningVersion] = useState(null);
+  /** @type {{ type: 'success' | 'error'; message: string } | null} */
   const [simulationStatus, setSimulationStatus] = useState(null);
 
   const [showPublishConfirm, setShowPublishConfirm] = useState(false);
+  /** @type {number | null} */
   const [versionToPublish, setVersionToPublish] = useState(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [alertMessage, setAlertMessage] = useState(null);
@@ -82,6 +88,9 @@ function LiftSystemDetail() {
     }
   };
 
+  /**
+   * @param {number} versionNumber
+   */
   const handlePublishVersion = (versionNumber) => {
     setVersionToPublish(versionNumber);
     setShowPublishConfirm(true);
@@ -96,6 +105,9 @@ function LiftSystemDetail() {
     }
   };
 
+  /**
+   * @param {number} versionNumber
+   */
   const handleRunSimulation = async (versionNumber) => {
     setRunningVersion(versionNumber);
     setSimulationStatus(null);

--- a/frontend/src/pages/LiftSystems.jsx
+++ b/frontend/src/pages/LiftSystems.jsx
@@ -1,3 +1,4 @@
+// @ts-check
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
@@ -8,6 +9,7 @@ import './LiftSystems.css';
 
 function LiftSystems() {
   const navigate = useNavigate();
+  /** @type {import('../types/models').LiftSystem[]} */
   const [systems, setSystems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -32,6 +34,9 @@ function LiftSystems() {
     }
   };
 
+  /**
+   * @param {{ systemKey: string; displayName: string; description?: string }} formData
+   */
   const handleCreateSystem = async (formData) => {
     try {
       const response = await liftSystemsApi.createSystem(formData);

--- a/frontend/src/types/models.d.ts
+++ b/frontend/src/types/models.d.ts
@@ -1,0 +1,37 @@
+export type VersionStatus = 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
+
+export interface LiftSystem {
+  id: string;
+  systemKey: string;
+  displayName: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  versions?: Version[];
+}
+
+export interface Version {
+  id: string;
+  versionNumber: number;
+  status: VersionStatus;
+  config: string;
+  createdAt: string;
+  publishedAt?: string;
+  archivedAt?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors?: ValidationError[];
+  warnings?: ValidationWarning[];
+}
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationWarning {
+  field: string;
+  message: string;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.38.1</version>
+    <version>0.39.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Provide lightweight, editor-aware type safety for the admin UI without migrating the codebase to TypeScript.
- Improve IDE autocomplete and reduce runtime errors by defining core data shapes for lift systems, versions, and validation results.
- Document and ship an opt-in developer workflow using `// @ts-check` and JSDoc so contributors can get type checking in plain JS files.

### Description
- Added `frontend/src/types/models.d.ts` with `LiftSystem`, `Version`, `ValidationResult`, `ValidationError`, and `ValidationWarning` interfaces and `VersionStatus` type.
- Added `frontend/jsconfig.json` to enable `checkJs`/JSDoc-based type checking in editors and configured `allowJs`/`noEmit` for the frontend.
- Annotated key pages and components with `// @ts-check` and JSDoc types (notably `LiftSystems.jsx`, `LiftSystemDetail.jsx`, `ConfigEditor.jsx`, and `VersionActions.jsx`) to consume the shared models.
- Updated documentation and metadata: `README.md`, `frontend/README.md`, and `CHANGELOG.md` describe the new workflow, and project versions were bumped to `0.39.0` in `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json`.

### Testing
- No automated tests were run as part of this change (no `mvn test` or `npm test` executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aeed33f4c8325b6fe621742fabadc)