### PR TITLE
Add frontend testing and CI docs, run frontend checks in CI, bump version to 0.39.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-and-test:
+  backend:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,3 +35,33 @@ jobs:
 
     - name: Package
       run: mvn -q package -DskipTests
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: Install dependencies
+      working-directory: frontend
+      run: npm ci
+
+    - name: Lint
+      working-directory: frontend
+      run: npm run lint
+
+    - name: Build
+      working-directory: frontend
+      run: npm run build
+
+    - name: Test
+      working-directory: frontend
+      run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.1] - 2026-01-19
+
+### Added
+- Frontend testing strategy documentation, including tooling recommendations, conventions, and example scenarios
+- CI/CD documentation for frontend and backend workflows, plus local check commands
+- Deployment guidance for Vercel/Netlify, AWS S3 + CloudFront, Docker, and Spring Boot integration
+- CI status badge in the frontend README
+
+### Changed
+- GitHub Actions workflow now runs frontend install, lint, build, and test steps
+- Frontend npm scripts now include `lint:fix` and `test` placeholders
+- Version bumped from 0.39.0 to 0.39.1
+- Frontend package version updated to 0.39.1
+
 ## [0.39.0] - 2026-01-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.39.0**
+Current version: **0.39.1**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -75,7 +75,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.39.0.jar
+java -jar target/lift-simulator-0.39.1.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
@@ -96,7 +96,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.39.0.jar
+java -jar target/lift-simulator-0.39.1.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -596,7 +596,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.39.0.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.39.1.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -840,7 +840,7 @@ dropdb lift_simulator_test
 
 ## Features
 
-The current version (v0.39.0) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.39.1) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -1014,7 +1014,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.39.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.39.1.jar`.
 
 ## Running Tests
 
@@ -1064,7 +1064,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1073,16 +1073,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1096,7 +1096,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1114,7 +1114,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1123,13 +1123,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.39.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.39.1.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,13 +1,15 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "lint:fix": "eslint . --fix",
+    "preview": "vite preview",
+    "test": "echo \"No frontend tests configured yet.\" && exit 0"
   },
   "dependencies": {
     "axios": "^1.13.2",

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.39.0</version>
+    <version>0.39.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation

- The frontend README lacked testing and CI/CD documentation and the repository CI only exercised backend checks, making it unclear how to run frontend checks or deploy the UI.
- Provide a low-friction path for adding tests by adding scripts and a documented testing strategy so future test work can follow conventions.

### Description

- Expanded `frontend/README.md` with a Testing section (strategy, recommended tooling, structure, example scenarios), a CI/CD section that explains the GitHub Actions workflow, and deployment guidance for Vercel/Netlify, AWS S3 + CloudFront, Docker, and Spring Boot integration, plus a CI status badge.  
- Added frontend npm scripts in `frontend/package.json`: `lint:fix` and a placeholder `test`, and updated `frontend/package-lock.json`.  
- Updated `.github/workflows/ci.yml` to add a `frontend` job that runs `npm ci`, `npm run lint`, `npm run build`, and `npm test` in `frontend/`.  
- Bumped the project and frontend package versions to `0.39.1` and updated `pom.xml`, top-level `README.md`, and `CHANGELOG.md` with the release notes describing the documentation/CI changes.

### Testing

- No automated tests were executed as part of this change; the change is documentation and CI/workflow updates only.  
- The updated CI workflow will run backend tests (`mvn test jacoco:report`) plus style/analysis (`checkstyle`, `spotbugs`) and will run frontend steps (`npm ci`, `npm run lint`, `npm run build`, `npm test`) on GitHub Actions.  
- Note that the new `frontend` `test` script is currently a placeholder that exits successfully (`echo ... && exit 0`), so CI will not fail on frontend tests until real tests are added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696afe3c470083259ffa03a04b700777)