### PR TITLE
Add UAT scenario for editing draft configurations and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Expanded UAT documentation to cover draft configuration editing and updated scenario counts.
+- Refined sample scenario documentation to align with the draft-editing workflow.
+
 ## [0.40.0] - 2026-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Once set up, starting the application is quick:
 Follow the comprehensive test scenarios in **[docs/UAT-TEST-SCENARIOS.md](docs/UAT-TEST-SCENARIOS.md)**
 
 The UAT guide includes:
-- 13 detailed test scenarios covering all major workflows
+- 14 detailed test scenarios covering all major workflows
 - Expected results for each test
 - Pass/fail criteria
 - Issue reporting template

--- a/docs/UAT-TEST-SCENARIOS.md
+++ b/docs/UAT-TEST-SCENARIOS.md
@@ -1,7 +1,7 @@
 # UAT Test Scenarios - Lift Simulator
 
 **Version:** 0.40.0
-**Last Updated:** 2026-01-17
+**Last Updated:** 2026-01-20
 **Purpose:** User Acceptance Testing guide for single-user local deployment
 
 ## Overview
@@ -223,14 +223,47 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 6: Publish a Configuration Version
+## Scenario 6: Edit a Draft Configuration Version
+
+**Objective:** Verify that users can edit a draft configuration and save changes
+
+**Prerequisites:**
+- Test Building A exists
+- Version 2 is in DRAFT status (from Scenario 5)
+
+**Steps:**
+1. Navigate to Test Building A detail page
+2. Locate Version 2 with status "DRAFT"
+3. Click "Edit" (or "Edit Configuration") to open the configuration editor
+4. Confirm the editor is pre-populated with the existing configuration
+5. Replace the editor contents with the sample configuration from `src/main/resources/scenarios/high-rise-residential.json`
+6. Click "Validate" to verify the updated configuration
+7. Click "Save Draft"
+8. Return to the versions list
+
+**Expected Results:**
+- Configuration editor loads with the current draft configuration
+- Validation passes with no errors
+- Version remains in DRAFT status after saving
+- Updated configuration persists when reopening the editor
+- Last updated timestamp changes (if displayed)
+
+**Pass Criteria:**
+- ✅ Draft configuration can be edited and saved
+- ✅ Validation must succeed before saving
+- ✅ Draft status is preserved after saving
+- ✅ Updated configuration is persisted correctly
+
+---
+
+## Scenario 7: Publish a Configuration Version
 
 **Objective:** Verify the publish workflow and auto-archiving of previous published versions
 
 **Prerequisites:**
 - Test Building A exists
 - Version 1 has valid configuration (from Scenario 3)
-- Version 2 has valid configuration (from Scenario 5)
+- Version 2 has valid configuration and saved edits (from Scenarios 5-6)
 
 **Steps:**
 1. Navigate to Test Building A detail page
@@ -264,7 +297,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 7: Create Multiple Versions and Test Pagination
+## Scenario 8: Create Multiple Versions and Test Pagination
 
 **Objective:** Verify version list pagination, sorting, and filtering
 
@@ -310,7 +343,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 8: Test Configuration Validator Tool
+## Scenario 9: Test Configuration Validator Tool
 
 **Objective:** Verify standalone configuration validation tool
 
@@ -368,7 +401,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 9: Test Health Check Endpoint
+## Scenario 10: Test Health Check Endpoint
 
 **Objective:** Verify system health monitoring
 
@@ -404,7 +437,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 10: Test System Deletion and Cascade
+## Scenario 11: Test System Deletion and Cascade
 
 **Objective:** Verify that deleting a lift system cascades to versions
 
@@ -435,7 +468,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 11: Test Both Controller Strategies
+## Scenario 12: Test Both Controller Strategies
 
 **Objective:** Verify both controller strategies are accepted
 
@@ -487,7 +520,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 12: Test Edge Cases and Boundary Values
+## Scenario 13: Test Edge Cases and Boundary Values
 
 **Objective:** Verify validation at boundary values
 
@@ -557,7 +590,7 @@ Before starting UAT, ensure:
 
 ---
 
-## Scenario 13: Test UI Responsiveness and Error Handling
+## Scenario 14: Test UI Responsiveness and Error Handling
 
 **Objective:** Verify UI handles errors gracefully
 

--- a/src/main/resources/scenarios/README.md
+++ b/src/main/resources/scenarios/README.md
@@ -73,7 +73,7 @@ This directory contains example lift system configurations for testing and refer
 ### In the Admin UI
 
 1. Navigate to a lift system detail page
-2. Create a new version
+2. Create a new version (or open an existing draft)
 3. Click "Edit" on the version
 4. Copy the contents of one of these files
 5. Paste into the configuration editor
@@ -148,7 +148,7 @@ See the main [README.md](../../../../README.md) for complete validation rules an
 
 1. **Start Simple:** Begin with `basic-office-building.json` to verify basic functionality
 2. **Test Validation:** Use `invalid-example.json` to ensure error handling works
-3. **Scale Up:** Move to `high-rise-residential.json` for complex scenarios
+3. **Scale Up:** Move to `high-rise-residential.json` for complex scenarios (UAT Scenario 6)
 4. **Create Variants:** Modify these templates to test edge cases
 5. **Compare Strategies:** Create two versions with different controller strategies and compare behavior
 


### PR DESCRIPTION
### Motivation
- Cover the configuration editor workflow by adding an explicit UAT scenario for editing and saving draft versions. 
- Ensure UAT scenarios and sample configuration docs remain consistent with the app’s draft/edit/save flow. 
- Keep top-level documentation in sync (README and CHANGELOG) so testers see the correct scenario count and change history.

### Description
- Updated `docs/UAT-TEST-SCENARIOS.md` to add a new "Edit a Draft Configuration Version" scenario, renumber subsequent scenarios, and refresh the `Last Updated` date. 
- Updated `src/main/resources/scenarios/README.md` to mention opening existing drafts in the Admin UI and to reference the new UAT draft-editing workflow. 
- Updated `README.md` to reflect the updated count of UAT scenarios (`14` instead of `13`). 
- Added an `Unreleased` section to `CHANGELOG.md` documenting the documentation changes related to UAT and sample scenarios.

### Testing
- No automated tests were run because the changes are documentation-only, and the edits were limited to Markdown files (`docs/UAT-TEST-SCENARIOS.md`, `src/main/resources/scenarios/README.md`, `README.md`, `CHANGELOG.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b27cd64b08325bf980885156e44f7)