### PR TITLE
fix: correct log file naming and improve Windows compatibility

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.flyway.create-schemas=true
 # Logging Configuration
 logging.level.root=INFO
 logging.level.com.liftsimulator=DEBUG
-logging.file.name=logs/application.log
+logging.file.name=logs/application
 logging.file.path=logs
 
 # Actuator Configuration

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -50,6 +50,20 @@
         </rollingPolicy>
     </appender>
 
+    <!-- Async wrapper for FILE appender (improves performance and Windows compatibility) -->
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <!-- Async wrapper for ERROR_FILE appender (improves performance and Windows compatibility) -->
+    <appender name="ASYNC_ERROR_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>256</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="ERROR_FILE"/>
+    </appender>
+
     <!-- Spring Framework -->
     <logger name="org.springframework" level="INFO"/>
     <logger name="org.springframework.web" level="INFO"/>
@@ -71,8 +85,8 @@
     <!-- Root logger configuration -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
-        <appender-ref ref="ERROR_FILE"/>
+        <appender-ref ref="ASYNC_FILE"/>
+        <appender-ref ref="ASYNC_ERROR_FILE"/>
     </root>
 
     <!-- Profile-specific configuration -->


### PR DESCRIPTION
Fixed two issues with logging configuration:

Issue 1: Double file extension (application.log.log)
- Root cause: logging.file.name included .log extension, then logback added another .log extension
- Fix: Removed .log from logging.file.name in application.properties
- Result: Files now correctly named application.log and application-error.log

Issue 2: File locking on Windows after Ctrl+C termination
- Root cause: Synchronous file appenders don't release handles cleanly on abrupt shutdown (Ctrl+C)
- Fix: Wrapped file appenders with AsyncAppender
  - Added ASYNC_FILE wrapper with 512-entry queue
  - Added ASYNC_ERROR_FILE wrapper with 256-entry queue
  - Set discardingThreshold=0 to preserve all log messages
- Benefits:
  - Better shutdown handling on Windows
  - Improved logging performance (async writes)
  - Reduced file lock contention
  - Graceful queue draining on JVM shutdown

Changes:
- src/main/resources/application.properties
  - Changed: logging.file.name=logs/application (removed .log extension)
- src/main/resources/logback-spring.xml
  - Added: ASYNC_FILE and ASYNC_ERROR_FILE appenders
  - Updated: Root logger now uses async appenders
  - Improved: Windows compatibility and shutdown handling

Testing:
- Log files should now be named correctly: logs/application.log
- Files should be accessible immediately after Ctrl+C on Windows
- No performance degradation (async actually improves performance)