### PR TITLE
Fix Spring Boot startup 500 error

### DIFF
--- a/src/main/java/com/liftsimulator/admin/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/liftsimulator/admin/controller/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -144,6 +145,22 @@ public class GlobalExceptionHandler {
             OffsetDateTime.now()
         );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
+     * Handles ResponseStatusException with the original status code.
+     * This preserves the intended HTTP status (e.g., 404) instead of converting to 500.
+     */
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex) {
+        logger.info("Response status exception: {} - {}", ex.getStatusCode(), ex.getReason());
+
+        ErrorResponse error = new ErrorResponse(
+            ex.getStatusCode().value(),
+            ex.getReason() != null ? ex.getReason() : ex.getStatusCode().toString(),
+            OffsetDateTime.now()
+        );
+        return ResponseEntity.status(ex.getStatusCode()).body(error);
     }
 
     /**


### PR DESCRIPTION
… codes

The GlobalExceptionHandler was converting all ResponseStatusExceptions to 500 errors through its generic Exception handler. This caused the SpaForwardingController's 404 response (when index.html is not found) to be incorrectly returned as a 500 error.

Added a specific handler for ResponseStatusException that:
- Preserves the original HTTP status code (e.g., 404 instead of 500)
- Uses the exception's reason message
- Logs appropriately as info level

This allows the backend to start and API endpoints to be tested without requiring the frontend to be built first. When accessing the root URL without a built frontend, users now receive a proper 404 with the message "index.html not found. Build the frontend or use the dev server." instead of a generic 500 error.