### PR TITLE
Fix: Display next version number in Create Version form

### DIFF
--- a/frontend/src/pages/LiftSystemDetail.css
+++ b/frontend/src/pages/LiftSystemDetail.css
@@ -134,6 +134,20 @@
   margin-bottom: 1.5rem;
 }
 
+.version-number-display {
+  margin-bottom: 1.25rem;
+  padding: 0.75rem 1rem;
+  background: white;
+  border-radius: 6px;
+  border-left: 4px solid #3498db;
+}
+
+.version-number-display h4 {
+  margin: 0;
+  color: #2c3e50;
+  font-size: 1.1rem;
+}
+
 .create-version-form label {
   display: block;
   font-weight: 600;

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -344,6 +344,9 @@ function LiftSystemDetail() {
 
         {showCreateVersion && (
           <form onSubmit={handleCreateVersion} className="create-version-form">
+            <div className="version-number-display">
+              <h4>Version {versions.length > 0 ? Math.max(...versions.map(v => v.versionNumber)) + 1 : 1}</h4>
+            </div>
             <label htmlFor="config">Configuration JSON</label>
             <textarea
               id="config"


### PR DESCRIPTION
The Create Version modal was not showing the expected next version number when opened. This fix adds a prominent display of the next version number (calculated as max existing version + 1, or 1 if no versions exist) at the top of the form.

Changes:
- Added version number display element in LiftSystemDetail.jsx:348
- Added CSS styling for version-number-display with blue border accent
- Version number automatically calculates from existing versions array

Fixes issue where users couldn't see what version they were creating.