### PR TITLE
Improve create version validation feedback messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Show descriptive validation feedback in the Create Version modal when configuration JSON fails backend validation.
+
 ## [0.41.3] - 2026-01-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ A modern React web application provides a user-friendly interface for managing l
   - Sort by version number, creation date, or status
   - Filter by status (All/Published/Draft/Archived)
   - Search by version number
+- **Validation Feedback**: Display detailed configuration validation errors when version creation fails
 - **Configuration Editor**: Edit configuration JSON with validation, save draft, and publish workflows
 - **Configuration Validator**: Validate configuration JSON before publishing
 - **Health Check**: Monitor backend service status

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,6 +14,7 @@ This is the frontend admin application for the Lift Simulator system. It provide
 - Managing lift systems and configurations
 - Creating and publishing configuration versions
 - Validating configuration JSON
+- Displaying detailed validation errors when configuration JSON is invalid
 - Monitoring system health
 
 ## Tech Stack

--- a/frontend/src/utils/errorHandlers.js
+++ b/frontend/src/utils/errorHandlers.js
@@ -14,8 +14,43 @@
  * // Returns: "Something went wrong"
  * getApiErrorMessage({}, 'Something went wrong');
  */
+function formatValidationIssues(issues) {
+  if (!Array.isArray(issues) || issues.length === 0) {
+    return null;
+  }
+
+  const messages = issues
+    .map((issue) => {
+      if (!issue || !issue.message) {
+        return null;
+      }
+      const fieldPrefix = issue.field ? `${issue.field}: ` : '';
+      return `${fieldPrefix}${issue.message}`;
+    })
+    .filter(Boolean);
+
+  return messages.length > 0 ? messages.join('; ') : null;
+}
+
+function formatFieldErrors(fieldErrors) {
+  if (!fieldErrors || typeof fieldErrors !== 'object') {
+    return null;
+  }
+
+  const messages = Object.entries(fieldErrors)
+    .map(([field, message]) => (message ? `${field}: ${message}` : null))
+    .filter(Boolean);
+
+  return messages.length > 0 ? messages.join('; ') : null;
+}
+
 export function getApiErrorMessage(error, fallbackMessage = 'Something went wrong') {
-  const detail = error?.response?.data?.message || error?.message;
+  const responseData = error?.response?.data;
+  const validationDetail =
+    formatValidationIssues(responseData?.errors) ||
+    formatFieldErrors(responseData?.fieldErrors);
+  const detail = validationDetail || responseData?.message || error?.message;
+
   if (detail && fallbackMessage) {
     return `${fallbackMessage}: ${detail}`;
   }


### PR DESCRIPTION
### Motivation
- The Create Version flow returned an unhelpful error like `Request failed with status code 400` when the backend rejected configuration JSON, so surface the backend validation details to the user for actionable feedback.

### Description
- Enhance `getApiErrorMessage` in `frontend/src/utils/errorHandlers.js` to format and prefer backend `errors` (validation issues) and `fieldErrors` before falling back to `message` or `error.message`.
- Add helper formatters for validation issues and field errors so UI alerts display concise, readable messages.
- Update `CHANGELOG.md`, `README.md`, and `frontend/README.md` to document the improved validation feedback for version creation.

### Testing
- No automated tests were executed for this change (manual verification expected in the UI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cf5250e4083259767f9cc9d20ead6)