### PR TITLE
Fix validation error when editing draft version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Version number automatically updates based on existing versions
 - Show descriptive validation feedback in the Create Version modal when configuration JSON fails backend validation.
 
+## [0.41.4] - 2026-01-18
+
+### Fixed
+- **Draft Version Validation**: Fixed validation failure when editing DRAFT versions
+  - ConfigEditor now correctly sends validation requests as `{ config: "..." }` instead of parsed JSON object
+  - Resolves "Unknown property 'floors' is not allowed" error when validating DRAFT configurations
+  - Both handleValidate and handleSaveDraft validation calls updated to use correct request format
+  - Validation now works consistently with create and update operations
+
 ## [0.41.3] - 2026-01-17
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.41.3",
+  "version": "0.41.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/ConfigEditor.jsx
+++ b/frontend/src/pages/ConfigEditor.jsx
@@ -111,7 +111,7 @@ function ConfigEditor() {
       if (!validationResult) {
         setValidating(true);
         try {
-          const response = await liftSystemsApi.validateConfig(configObject);
+          const response = await liftSystemsApi.validateConfig({ config });
           setValidationResult(response.data);
 
           // If validation fails, prevent save and show errors
@@ -166,7 +166,7 @@ function ConfigEditor() {
       setError(null);
 
       const configObject = JSON.parse(config);
-      const response = await liftSystemsApi.validateConfig(configObject);
+      const response = await liftSystemsApi.validateConfig({ config });
       setValidationResult(response.data);
 
     } catch (err) {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.41.3</version>
+    <version>0.41.4</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
The ConfigEditor was sending validation requests incorrectly. It was sending the parsed JSON object directly instead of wrapping it in a ConfigValidationRequest object with a config property.

This caused the backend to reject the request with "Unknown property 'floors' is not allowed" because Jackson's strict property validation (FAIL_ON_UNKNOWN_PROPERTIES) was treating the configuration fields as unknown properties of ConfigValidationRequest.

Changes:
- Updated ConfigEditor.jsx handleValidate() to send { config } instead of configObject
- Updated ConfigEditor.jsx handleSaveDraft() to send { config } instead of configObject
- Updated version to 0.41.4 in pom.xml and package.json
- Updated CHANGELOG with fix details

Fixes validation when editing DRAFT versions.