### PR TITLE
Fix Configuration Validator rejecting valid configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.41.5] - 2026-01-18
+
+### Fixed
+- **Configuration Validator**: Fixed validation failure on valid configurations in standalone Configuration Validator tool
+  - ConfigValidator page now correctly sends validation requests as `{ config: "..." }` instead of parsed JSON object
+  - Resolves "Unknown property 'floors' is not allowed" error when validating configurations
+  - Improved validation result display to show errors and warnings distinctly
+  - Validation errors now display field name and message in a clear, structured format
+  - Warnings are shown separately from errors when configuration is valid but has potential issues
+
 ## [0.41.4] - 2026-01-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1233,6 +1233,8 @@ The current version (v0.41.4) includes comprehensive lift simulation and configu
   - Real-time validation using backend API
   - Sample configuration template provided
   - Split-pane layout showing editor and validation results
+  - Distinct display of errors and warnings with field-level detail
+  - Clear indication of validation success with optional warnings
 - **Health Check Monitor**: Real-time backend service health monitoring
   - Status display with color-coded indicators
   - Manual refresh capability

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.41.4",
+  "version": "0.41.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/ConfigValidator.jsx
+++ b/frontend/src/pages/ConfigValidator.jsx
@@ -14,8 +14,10 @@ function ConfigValidator() {
       setResult(null);
       setError(null);
 
-      const configObject = JSON.parse(config);
-      const response = await liftSystemsApi.validateConfig(configObject);
+      // Validate JSON syntax first
+      JSON.parse(config);
+      // Send config as string in request object
+      const response = await liftSystemsApi.validateConfig({ config });
       setResult(response.data);
     } catch (err) {
       if (err.name === 'SyntaxError') {
@@ -55,15 +57,50 @@ function ConfigValidator() {
 
         <div className="result-section">
           <h3>Validation Result</h3>
-          {result && (
+          {result && result.valid && (
             <div className="result-success">
               <h4>Configuration is valid!</h4>
-              <pre>{JSON.stringify(result, null, 2)}</pre>
+              {result.warnings && result.warnings.length > 0 && (
+                <div className="warnings">
+                  <h5>Warnings:</h5>
+                  <ul>
+                    {result.warnings.map((warning, index) => (
+                      <li key={index}>
+                        <strong>{warning.field}:</strong> {warning.message}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+          {result && !result.valid && (
+            <div className="result-error">
+              <h4>Validation Errors</h4>
+              <ul>
+                {result.errors.map((error, index) => (
+                  <li key={index}>
+                    <strong>{error.field}:</strong> {error.message}
+                  </li>
+                ))}
+              </ul>
+              {result.warnings && result.warnings.length > 0 && (
+                <div className="warnings">
+                  <h5>Warnings:</h5>
+                  <ul>
+                    {result.warnings.map((warning, index) => (
+                      <li key={index}>
+                        <strong>{warning.field}:</strong> {warning.message}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
           )}
           {error && (
             <div className="result-error">
-              <h4>Validation Error</h4>
+              <h4>Error</h4>
               <p>{error}</p>
             </div>
           )}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.41.4</version>
+    <version>0.41.5</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
- Fix ConfigValidator to send config as { config: "..." } instead of parsed object
- Resolves "Unknown property 'floors' is not allowed" error
- Improve validation result display with distinct errors and warnings
- Update version to 0.41.5 (patch fix per SemVer)
- Update CHANGELOG and README with fix details

Fixes validation failure in Configuration Validator tool (Scenario 9). Previously ConfigValidator sent parsed JSON object directly, causing the backend to reject valid 'floors' property. Now correctly wraps config string in request object matching API contract.