### PR TITLE
Fix inconsistent labels in Dashboard Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.41.5] - 2026-01-18
 
 ### Fixed
+- **Dashboard Label Consistency**: Updated label from "Total Versions" to "Configuration Versions" in the Overview section for consistency with terminology used throughout the application
 - **Configuration Validator**: Fixed validation failure on valid configurations in standalone Configuration Validator tool
   - ConfigValidator page now correctly sends validation requests as `{ config: "..." }` instead of parsed JSON object
   - Resolves "Unknown property 'floors' is not allowed" error when validating configurations

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -45,7 +45,7 @@ function Dashboard() {
                 <div className="stat-value">
                   {systems.reduce((sum, sys) => sum + (sys.versions?.length || 0), 0)}
                 </div>
-                <div className="stat-label">Total Versions</div>
+                <div className="stat-label">Configuration Versions</div>
               </div>
             </div>
           )}


### PR DESCRIPTION
Changed "Total Versions" to "Configuration Versions" for consistency with terminology used throughout the application.

Updated CHANGELOG.md with the fix.