### PR TITLE
Fix configuration JSON validation error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Dashboard Versions Metric**: Lift system responses now include `versionCount`, allowing the dashboard and lift system list to accurately total configuration versions.
+- **Configuration Validation Error Messages**: Non-numeric values in configuration fields now display clear, user-friendly error messages
+  - When entering non-numeric values (e.g., "A", "abc", true) for numeric fields, the system now shows: "Field 'fieldName' must be a numeric value, got 'value'"
+  - Previously displayed generic JSON parsing errors: "Invalid JSON format: Unrecognized token..."
+  - Added specific handling for InvalidFormatException and MismatchedInputException in ConfigValidationService
+  - Error messages now include the field name and the actual invalid value provided
+  - Improves user experience when creating or editing lift system version configurations
 
 
 ## [0.41.5] - 2026-01-18


### PR DESCRIPTION
When users enter non-numeric values (e.g., "A", "abc", true) for numeric configuration fields, the system now displays clear, user-friendly error messages instead of generic JSON parsing errors.

Changes:
- Enhanced ConfigValidationService to catch InvalidFormatException and MismatchedInputException
- Added getFieldNameFromPath() helper method to extract field names from Jackson error paths
- Error messages now show: "Field 'fieldName' must be a numeric value, got 'value'"
- Added comprehensive test cases for non-numeric value validation
- Updated CHANGELOG.md with fix details

Fixes issue where validation errors showed:
  "Invalid JSON format: Unrecognized token 'A': was expecting..."

Now shows:
  "Field 'floors' must be a numeric value, got 'A'"

This is a patch-level bug fix (version 0.41.5 maintained).