### PR TITLE
Fix sort order for Status in Manage Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Validation errors now display field name and message in a clear, structured format
   - Warnings are shown separately from errors when configuration is valid but has potential issues
 - **Lift Systems Version Counts**: Lift system list responses now compute version totals per system to prevent zeroed counts on the Lift Systems page.
+- **Versions Status Sort Order**: Fixed incorrect sort order when sorting versions by status in Manage Versions screen
+  - When selecting "Published" order (desc), versions now correctly display: Published, Draft, Archived
+  - When selecting "Archived" order (asc), versions now correctly display: Archived, Draft, Published
+  - Previously the sort order was reversed, showing Archived first when "Published" was selected and vice versa
 
 ## [0.41.4] - 2026-01-18
 

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -269,7 +269,7 @@ function LiftSystemDetail() {
       } else if (sortBy === 'createdAt') {
         comparison = new Date(a.createdAt) - new Date(b.createdAt);
       } else if (sortBy === 'status') {
-        const statusOrder = { PUBLISHED: 1, DRAFT: 2, ARCHIVED: 3 };
+        const statusOrder = { ARCHIVED: 1, DRAFT: 2, PUBLISHED: 3 };
         comparison = statusOrder[a.status] - statusOrder[b.status];
       }
 


### PR DESCRIPTION
When sorting versions by status, the sort order was reversed from the UI labels:
- Selecting "Published" order was showing: Archived, Draft, Published (incorrect)
- Selecting "Archived" order was showing: Published, Draft, Archived (incorrect)

Fixed by reversing the statusOrder mapping from { PUBLISHED: 1, DRAFT: 2, ARCHIVED: 3 } to { ARCHIVED: 1, DRAFT: 2, PUBLISHED: 3 }, so the sort order now correctly matches the UI dropdown labels:
- "Published First" (desc) now shows: Published, Draft, Archived
- "Archived First" (asc) now shows: Archived, Draft, Published

Files changed:
- frontend/src/pages/LiftSystemDetail.jsx: Fixed statusOrder mapping
- CHANGELOG.md: Added entry under 0.42.0 Fixed section