### PR TITLE
Clarify Run Simulator unavailable message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improved error prevention by requiring validation before version creation
 
 ### Fixed
+- **Run Simulator UI Feedback**: Clicking Run Simulator now shows a graceful message noting the feature is unavailable until a future release.
 - **Version Search Matching**: Searching by version number now returns only exact version matches instead of versions that merely contain the digits.
 - **Create Version Validation Workflow**: Added a Validate button to the Create New Version form and require a successful validation before enabling version creation.
 - **Dashboard Versions Metric**: Lift system responses now include `versionCount`, allowing the dashboard and lift system list to accurately total configuration versions.

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -239,18 +239,12 @@ function LiftSystemDetail() {
    */
   const handleRunSimulation = async (versionNumber) => {
     setRunningVersion(versionNumber);
-    setSimulationStatus(null);
-    try {
-      const response = await liftSystemsApi.runSimulation(system.systemKey);
-      setSimulationStatus({ type: 'success', message: response.data.message });
-    } catch (err) {
-      setSimulationStatus({
-        type: 'error',
-        message: getApiErrorMessage(err, 'Failed to start simulator'),
-      });
-    } finally {
-      setRunningVersion(null);
-    }
+    setSimulationStatus({
+      type: 'error',
+      message:
+        'This feature is currently unavailable and will be enabled in a future release.',
+    });
+    setRunningVersion(null);
   };
 
   /**


### PR DESCRIPTION
### Motivation
- Provide a clear, user-friendly message when the UI's Run Simulator action is invoked but the feature is not available, replacing the previous generic/unwanted error text.

### Description
- Update `frontend/src/pages/LiftSystemDetail.jsx` to set `simulationStatus` to an error with the message "This feature is currently unavailable and will be enabled in a future release." and stop the running indicator in `handleRunSimulation`.
- Update the `0.42.0` entry in `CHANGELOG.md` to reflect the revised Run Simulator messaging.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d23b787408325a1106bfc1a459035)