### PR TITLE
Update footer copyright attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Users must explicitly validate before creating a version, preventing invalid configurations
   - Consistent user experience across all configuration editing workflows
   - Improved error prevention by requiring validation before version creation
+- **Footer Copyright Notice**: Updated the footer copyright to reference Manoj Bhaskaran.
 
 ### Fixed
 - **Run Simulator UI Feedback**: Clicking Run Simulator now shows a graceful message noting the feature is unavailable until a future release.

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -40,7 +40,7 @@ function Layout() {
         <Outlet />
       </main>
       <footer className="footer">
-        <p>Lift Simulator Admin &copy; 2026 | Version {packageJson.version}</p>
+        <p>Manoj Bhaskaran &copy; 2026 | Version {packageJson.version}</p>
       </footer>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Correct the footer copyright attribution which previously referenced a generic label to the proper owner name.

### Description
- Updated the footer text in `frontend/src/components/Layout.jsx` to `Manoj Bhaskaran` and added a corresponding note under the existing `0.42.0` entry in `CHANGELOG.md`.

### Testing
- Started the frontend dev server with `npm run dev` and captured a homepage screenshot via Playwright that shows the updated footer, while the dev server reported an unrelated JSX parse error in `frontend/src/pages/LiftSystemDetail.jsx` during bundling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d25a6b3088325962364c209a5224d)