### PR TITLE
Fix Jackson validation path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Version Search Matching**: Searching by version number now returns only exact version matches instead of versions that merely contain the digits.
 - **Create Version Validation Workflow**: Added a Validate button to the Create New Version form and require a successful validation before enabling version creation.
 - **Dashboard Versions Metric**: Lift system responses now include `versionCount`, allowing the dashboard and lift system list to accurately total configuration versions.
+- **Config Validation Compilation**: Corrected the Jackson exception reference type to restore compilation in ConfigValidationService.
 - **Configuration Validation Error Messages**: Non-numeric values in configuration fields now display clear, user-friendly error messages
   - When entering non-numeric values (e.g., "A", "abc", true) for numeric fields, the system now shows: "Field 'fieldName' must be a numeric value, got 'value'"
   - Previously displayed generic JSON parsing errors: "Invalid JSON format: Unrecognized token..."

--- a/src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
@@ -133,12 +134,12 @@ public class ConfigValidationService {
      * @param path The path from the JsonMappingException
      * @return The field name, or "config" if path is empty
      */
-    private String getFieldNameFromPath(List<com.fasterxml.jackson.core.JsonProcessingException.Reference> path) {
+    private String getFieldNameFromPath(List<JsonMappingException.Reference> path) {
         if (path == null || path.isEmpty()) {
             return "config";
         }
         // Get the last reference in the path (most specific field)
-        com.fasterxml.jackson.core.JsonProcessingException.Reference lastRef = path.get(path.size() - 1);
+        JsonMappingException.Reference lastRef = path.get(path.size() - 1);
         String fieldName = lastRef.getFieldName();
         return fieldName != null ? fieldName : "config";
     }


### PR DESCRIPTION
### Motivation
- Resolve a compilation error caused by referencing a non-existent `JsonProcessingException.Reference` type when extracting Jackson mapping path information in `ConfigValidationService`.

### Description
- Replace fully-qualified `JsonProcessingException.Reference` usage with `JsonMappingException.Reference` and add the `JsonMappingException` import in `src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java`, and add a short note about the compilation fix under `0.42.0` in `CHANGELOG.md`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d291a62bc832590560ec75c2d1e4d)