### PR TITLE
Fix LiftSystemDetail create-version form wiring and remove unused handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Run Simulator UI Feedback**: Clicking Run Simulator now shows a graceful message noting the feature is unavailable until a future release.
 - **Version Search Matching**: Searching by version number now returns only exact version matches instead of versions that merely contain the digits.
 - **Create Version Validation Workflow**: Added a Validate button to the Create New Version form and require a successful validation before enabling version creation.
+- **Lift System Detail Lint Errors**: Removed unused handlers and wired the create-version form submit to fix ESLint no-unused-vars/no-undef violations.
 - **Dashboard Versions Metric**: Lift system responses now include `versionCount`, allowing the dashboard and lift system list to accurately total configuration versions.
 - **Config Validation Compilation**: Corrected the Jackson exception reference type to restore compilation in ConfigValidationService.
 - **Configuration Validation Error Messages**: Non-numeric values in configuration fields now display clear, user-friendly error messages

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -6,7 +6,7 @@ import VersionActions from '../components/VersionActions';
 import ConfirmModal from '../components/ConfirmModal';
 import AlertModal from '../components/AlertModal';
 import EditSystemModal from '../components/EditSystemModal';
-import { getApiErrorMessage, handleApiError } from '../utils/errorHandlers';
+import { handleApiError } from '../utils/errorHandlers';
 import { getStatusBadgeClass } from '../utils/statusUtils';
 import './LiftSystemDetail.css';
 
@@ -108,58 +108,6 @@ function LiftSystemDetail() {
   }, [location.hash, loading, versions.length]);
 
   /**
-   * Handles configuration text changes in the create version form.
-   * Clears validation results when config is modified.
-   *
-   * @param {React.ChangeEvent<HTMLTextAreaElement>} e - Textarea change event
-   */
-  const handleConfigChange = (e) => {
-    setNewVersionConfig(e.target.value);
-    setValidationResult(null); // Clear validation when config changes
-    setHasConfigChanges(true); // Mark that config has changed since validation
-  };
-
-  /**
-   * Validates the new version configuration against business rules.
-   * Parses JSON and sends to validation API endpoint.
-   * Displays errors and warnings in the validation panel.
-   */
-  const handleValidate = async () => {
-    try {
-      setValidating(true);
-      setValidationResult(null);
-      setAlertMessage(null);
-
-      // Parse JSON to ensure it's valid before sending to API
-      JSON.parse(newVersionConfig);
-      const response = await liftSystemsApi.validateConfig({ config: newVersionConfig });
-      setValidationResult(response.data);
-      setHasConfigChanges(false); // Mark that validation is up-to-date with current config
-
-    } catch (err) {
-      if (err.name === 'SyntaxError') {
-        setAlertMessage('Invalid JSON format. Please fix syntax errors first.');
-      } else {
-        handleApiError(err, setAlertMessage, 'Validation failed');
-      }
-    } finally {
-      setValidating(false);
-    }
-  };
-
-  /**
-   * Determines whether a new version can be created.
-   * Requires valid configuration and no unsaved changes since validation.
-   *
-   * @returns {boolean} True if version can be created, false otherwise
-   */
-  const canCreateVersion = () => {
-    return validationResult &&
-           validationResult.valid &&
-           !hasConfigChanges;
-  };
-
-  /**
    * Handles new version creation from the inline form.
    * Creates version and refreshes the system data.
    *
@@ -178,8 +126,6 @@ function LiftSystemDetail() {
       setCreateValidationResult(null);
       setCreateValidationError(null);
       setShowCreateVersion(false);
-      setValidationResult(null);
-      setHasConfigChanges(false);
       await loadSystemData();
     } catch (err) {
       handleApiError(err, setAlertMessage, 'Failed to create version');
@@ -452,7 +398,7 @@ function LiftSystemDetail() {
         )}
 
         {showCreateVersion && (
-          <div className="create-version-form">
+          <form className="create-version-form" onSubmit={handleCreateVersion}>
             <div className="version-number-display">
               <h4>Version {versions.length > 0 ? Math.max(...versions.map(v => v.versionNumber)) + 1 : 1}</h4>
             </div>
@@ -534,7 +480,7 @@ function LiftSystemDetail() {
                 )}
               </div>
             )}
-          </div>
+          </form>
         )}
 
         {versions.length === 0 ? (


### PR DESCRIPTION
### Motivation
- Resolve ESLint `no-unused-vars` / `no-undef` errors in `frontend/src/pages/LiftSystemDetail.jsx` related to unused/undefined validation handlers and state used by the create-version UI.
- Ensure the Create New Version UI uses a proper form submit flow so `handleCreateVersion` is invoked reliably and markup is semantically correct.

### Description
- Removed the unused import `getApiErrorMessage` from `frontend/src/pages/LiftSystemDetail.jsx` and retained `handleApiError` only.
- Deleted unused handlers and validation helpers (`handleConfigChange`, `handleValidate`, `canCreateVersion`) and removed references to unused validation state to eliminate `no-unused-vars`/`no-undef` issues.
- Replaced the create-version wrapper `<div className="create-version-form">` with a `<form className="create-version-form" onSubmit={handleCreateVersion}>` and wired the submit button to use the existing `handleCreateVersion` flow.
- Stopped resetting removed/unused validation state in `handleCreateVersion` and updated the `CHANGELOG.md` by adding a note under the `0.42.0` entry describing the lint fix.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2a4a20c4832584fad4f44674b001)