### PR TITLE
Mock LiftSystemVersionRepository in LiftSystemService unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Footer Copyright Notice**: Updated the footer copyright to reference Manoj Bhaskaran.
 
 ### Fixed
+- **Lift System Service Tests**: Mocked version-count repository dependencies to prevent null pointer failures in LiftSystemService unit tests.
 - **Run Simulator UI Feedback**: Clicking Run Simulator now shows a graceful message noting the feature is unavailable until a future release.
 - **Version Search Matching**: Searching by version number now returns only exact version matches instead of versions that merely contain the digits.
 - **Create Version Validation Workflow**: Added a Validate button to the Create New Version form and require a successful validation before enabling version creation.

--- a/src/test/java/com/liftsimulator/admin/service/LiftSystemServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/LiftSystemServiceTest.java
@@ -5,6 +5,7 @@ import com.liftsimulator.admin.dto.LiftSystemResponse;
 import com.liftsimulator.admin.dto.UpdateLiftSystemRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +32,9 @@ public class LiftSystemServiceTest {
 
     @Mock
     private LiftSystemRepository liftSystemRepository;
+
+    @Mock
+    private LiftSystemVersionRepository liftSystemVersionRepository;
 
     @InjectMocks
     private LiftSystemService liftSystemService;
@@ -93,6 +97,8 @@ public class LiftSystemServiceTest {
     public void testGetAllLiftSystems() {
         List<LiftSystem> systems = List.of(mockLiftSystem);
         when(liftSystemRepository.findAll()).thenReturn(systems);
+        when(liftSystemVersionRepository.countVersionsByLiftSystemId())
+            .thenReturn(List.of(new Object[] {1L, 1L}));
 
         List<LiftSystemResponse> responses = liftSystemService.getAllLiftSystems();
 
@@ -104,6 +110,7 @@ public class LiftSystemServiceTest {
     @Test
     public void testGetLiftSystemById_Success() {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(liftSystemVersionRepository.countByLiftSystemId(1L)).thenReturn(1L);
 
         LiftSystemResponse response = liftSystemService.getLiftSystemById(1L);
 
@@ -135,6 +142,7 @@ public class LiftSystemServiceTest {
 
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
         when(liftSystemRepository.save(any(LiftSystem.class))).thenReturn(mockLiftSystem);
+        when(liftSystemVersionRepository.countByLiftSystemId(1L)).thenReturn(1L);
 
         LiftSystemResponse response = liftSystemService.updateLiftSystem(1L, request);
 


### PR DESCRIPTION
### Motivation
- `LiftSystemService` unit tests were throwing NPEs because the `LiftSystemVersionRepository` dependency was not mocked, so calls like `countByLiftSystemId()` and `countVersionsByLiftSystemId()` dereferenced a null repository.

### Description
- Added a `@Mock` for `LiftSystemVersionRepository` and stubbed `countVersionsByLiftSystemId()` and `countByLiftSystemId()` in `src/test/java/com/liftsimulator/admin/service/LiftSystemServiceTest.java` to return expected version counts for the list, fetch, and update test flows.
- Documented the test fix by adding an entry to `CHANGELOG.md` under the existing `0.42.0` section.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2b93863483258e82f40030d252a4)