### PR TITLE
Fix Mockito mock typing for version count in LiftSystemService tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Lift System Service Tests**: Mocked version-count repository dependencies to prevent null pointer failures in LiftSystemService unit tests.
+- **Lift System Service Tests**: Corrected mocked version-count return typing to fix test compilation.
 - **Run Simulator UI Feedback**: Clicking Run Simulator now shows a graceful message noting the feature is unavailable until a future release.
 - **Version Search Matching**: Searching by version number now returns only exact version matches instead of versions that merely contain the digits.
 - **Create Version Validation Workflow**: Added a Validate button to the Create New Version form and require a successful validation before enabling version creation.

--- a/src/test/java/com/liftsimulator/admin/service/LiftSystemServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/LiftSystemServiceTest.java
@@ -98,7 +98,7 @@ public class LiftSystemServiceTest {
         List<LiftSystem> systems = List.of(mockLiftSystem);
         when(liftSystemRepository.findAll()).thenReturn(systems);
         when(liftSystemVersionRepository.countVersionsByLiftSystemId())
-            .thenReturn(List.of(new Object[] {1L, 1L}));
+            .thenReturn(List.<Object[]>of(new Object[] {1L, 1L}));
 
         List<LiftSystemResponse> responses = liftSystemService.getAllLiftSystems();
 


### PR DESCRIPTION
### Motivation
- Resolve a test compilation failure caused by Mockito type inference when returning a list of object arrays from the version-count repository mock.

### Description
- Updated `src/test/java/com/liftsimulator/admin/service/LiftSystemServiceTest.java` to return `List.<Object[]>of(new Object[] {1L, 1L})` so the mocked `countVersionsByLiftSystemId()` matches the expected `List<Object[]>` type and added a note under `0.42.0` in `CHANGELOG.md` documenting the compilation/test fix; no README changes were required.

### Testing
- No automated tests were executed for this change; the edit is a small typing fix intended to resolve the prior test compilation error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d2c7c71a48325a55af81c66aa5429)