### PR TITLE
Integrate Playwright tests into GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,24 @@ jobs:
       working-directory: frontend
       run: npm run build
 
-    - name: Test
+    - name: Run Playwright tests
       working-directory: frontend
       run: npm test
+
+    - name: Upload Playwright HTML report
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: frontend/playwright-report/
+        retention-days: 30
+
+    - name: Upload test artifacts
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: playwright-test-artifacts
+        path: |
+          frontend/test-results/
+          frontend/playwright-report/
+        retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated `.gitignore` to exclude Playwright artifacts (test-results/, playwright-report/, playwright/.cache/)
   - Documented setup and usage in frontend/README.md with complete instructions
   - Created ADR-0014 documenting the decision to adopt Playwright
-  - Integrated Playwright tests into CI pipeline with automatic browser installation
+  - Integrated Playwright tests into CI pipeline:
+    - Automatic Chromium browser installation with dependencies
+    - Playwright webServer auto-starts frontend on port 3000 during test execution
+    - HTML test report uploaded as GitHub Actions artifact (available for 30 days)
+    - Test artifacts (screenshots, videos, traces) uploaded on test failures
+    - Test failures properly fail the CI workflow to block PR merges
+    - Test reports accessible via GitHub Actions "Artifacts" section in workflow runs
 - **Automated UI Test Suite**: Converted 10 manual test cases to automated Playwright tests
   - **Test Helpers and Fixtures** (`e2e/helpers/test-helpers.ts`):
     - Comprehensive test data generators and helper functions

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -167,6 +167,37 @@ Playwright is configured in `playwright.config.ts` with:
 
 The configuration automatically starts the dev server before running tests and shuts it down afterward. You don't need to start the server manually.
 
+#### CI Integration
+
+Playwright tests run automatically in GitHub Actions CI on:
+- Pull requests to main
+- Pushes to main
+
+**Test Reports in CI:**
+
+When tests run in CI, Playwright generates an HTML report that is uploaded as a GitHub Actions artifact. To view the report:
+
+1. Go to the [Actions tab](../../actions) in GitHub
+2. Click on the workflow run you want to inspect
+3. Scroll down to the "Artifacts" section at the bottom of the page
+4. Download the `playwright-report` artifact (available for 30 days)
+5. Extract the zip file and open `index.html` in your browser
+
+**Test Artifacts on Failure:**
+
+If tests fail, additional artifacts are uploaded:
+- Screenshots of failed tests
+- Videos of test execution
+- Playwright traces for debugging
+
+These are available in the `playwright-test-artifacts` artifact in the same location.
+
+**CI Behavior:**
+- Test failures will fail the CI workflow and block PR merges
+- Tests run with 2 retries on CI to handle transient issues
+- Only Chromium browser is tested in CI (for speed and reliability)
+- Web server automatically starts on port 3000 before tests begin
+
 #### Test Structure & Naming
 
 - All E2E tests go in `e2e/*.spec.ts`


### PR DESCRIPTION
- Add upload-artifact@v4 steps to upload Playwright HTML reports (always)
- Upload test artifacts (screenshots, videos, traces) on test failures
- Reports and artifacts retained for 30 days
- Update CHANGELOG.md with comprehensive CI integration details
- Add CI Integration section to frontend/README.md with documentation on:
  - How to access test reports from GitHub Actions artifacts
  - Test artifacts available on failure
  - CI behavior and configuration

Test failures now properly fail the CI workflow to block PR merges.