### PR TITLE
Document "Run Simulator" button feature in changelog and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Run setup supports optional seed entry for reproducibility
   - Polling-based run status with elapsed time, progress, and terminal state handling
   - Results rendering with KPI cards, per-lift and per-floor tables, artefact downloads, and CLI reproduction guidance
-  - Published version list links into simulator flow with preselected system and version
+  - **Run Simulator button**: Added discoverable "Run Simulator" button next to each published version that launches the run workflow with preselected system and version
 - **Backend Scenario Enhancements**:
   - Added `name` field to Scenario entity for better identification
   - Implemented `GET /api/scenarios` endpoint to list all scenarios

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ A modern React web application provides a user-friendly interface for managing l
   - Advanced JSON editor mode for direct scenario editing
   - Optional random seed for reproducible simulations
 - **Simulator Runs**: Launch published versions with scenarios, poll status, and review results
+  - **Run Simulator button**: Quick access button next to each published version for immediate simulation launch
   - Run setup with lift system, published version, and passenger flow scenario selection
   - Live status updates with elapsed time and progress details
   - Results view with KPI cards, per-lift/per-floor tables, artefact downloads, and CLI reproduction hints
@@ -1898,7 +1899,9 @@ The current version (v0.45.0) includes comprehensive lift simulation and configu
   - Read-only view for published and archived versions
   - Split-pane layout with editor and validation results side-by-side
 - **Simulator Runs**: End-to-end UI flow for executing and monitoring simulation runs
-  - Launch runs from published versions or the dedicated Simulator landing page
+  - **Run Simulator button**: Discoverable button next to each published version for quick access to simulation workflow
+  - Launch runs from published versions (via button) or the dedicated Simulator landing page
+  - Automatic preselection of lift system and version when launching from published version list
   - Poll run status with elapsed time, progress, and status indicators
   - Results rendering with KPI cards, per-lift/per-floor tables, artefact downloads, and CLI reproduction details
 - **Configuration Validator**: Interactive JSON editor for validating configurations


### PR DESCRIPTION
## Summary
Updated documentation to highlight the new "Run Simulator" button feature that provides quick access to launch simulations directly from the published versions list.

## Changes Made
- **CHANGELOG.md**: Enhanced the description of the published version list feature to explicitly call out the new "Run Simulator" button as a discoverable UI element that launches the run workflow with preselected system and version
- **README.md**: 
  - Added a dedicated bullet point under "Simulator Runs" section highlighting the "Run Simulator" button feature
  - Clarified that runs can be launched from published versions via the button or from the dedicated Simulator landing page
  - Added explicit mention of automatic preselection of lift system and version when launching from the published version list

## Details
These documentation updates reflect the improved user experience for accessing the simulator workflow. The "Run Simulator" button makes the simulation launch feature more discoverable and reduces friction for users who want to quickly test published versions without navigating to a separate landing page.