### PR TITLE
Add run-lifecycle integration tests, CLI compatibility test, and golden-file batch-input checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Provides unique passenger aliases (p1, p2, p3...) and proper event ordering
   - Added comprehensive test suite including golden-file tests and format validation
   - Documented in README with usage examples and API reference
+- **Testing**: Added run lifecycle integration coverage, golden-file contract checks for batch input generation,
+  and a CLI compatibility test for the demo scenario.
 
 ### Fixed
 - **Simulator Run UI**: Only apply preselected system/version from query params once so user selections are not overridden.

--- a/README.md
+++ b/README.md
@@ -2888,6 +2888,8 @@ mvn test
 
 The test suite includes integration coverage for the scenario system using fixtures in
 `src/test/resources/scenarios`.
+It also exercises simulation run lifecycle polling and batch input generator contracts
+with golden files under `src/test/resources/batch-input`.
 
 ## Quality Checks
 

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -1,0 +1,164 @@
+package com.liftsimulator.admin.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.admin.dto.CreateSimulationRunRequest;
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import com.liftsimulator.admin.entity.SimulationScenario;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
+import com.liftsimulator.admin.repository.SimulationScenarioRepository;
+import com.liftsimulator.admin.service.SimulationRunService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for simulation run lifecycle (start -> poll -> results).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+public class SimulationRunLifecycleIntegrationTest {
+
+    @TempDir
+    static Path artefactsRoot;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("simulation.artefacts.base-path", () -> artefactsRoot.toString());
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private LiftSystemRepository liftSystemRepository;
+
+    @Autowired
+    private LiftSystemVersionRepository versionRepository;
+
+    @Autowired
+    private SimulationScenarioRepository scenarioRepository;
+
+    @Autowired
+    private SimulationRunRepository runRepository;
+
+    @Autowired
+    private SimulationRunService runService;
+
+    private LiftSystem testSystem;
+    private LiftSystemVersion testVersion;
+    private SimulationScenario testScenario;
+
+    @BeforeEach
+    public void setUp() {
+        runRepository.deleteAll();
+        scenarioRepository.deleteAll();
+        versionRepository.deleteAll();
+        liftSystemRepository.deleteAll();
+
+        testSystem = new LiftSystem("lifecycle-system", "Lifecycle System", "Test Description");
+        testSystem = liftSystemRepository.save(testSystem);
+
+        testVersion = new LiftSystemVersion(testSystem);
+        testVersion.setVersionNumber(1);
+        testVersion.setStatus(VersionStatus.PUBLISHED);
+        testVersion.setConfig("{\"minFloor\": 0, \"maxFloor\": 10, \"numLifts\": 2}");
+        testVersion = versionRepository.save(testVersion);
+
+        testScenario = new SimulationScenario();
+        testScenario.setName("Lifecycle Scenario");
+        testScenario.setScenarioJson("{\"durationTicks\": 20, \"passengerFlows\": [{\"startTick\": 0, \"originFloor\": 0, \"destinationFloor\": 5, \"passengers\": 1}]}");
+        testScenario = scenarioRepository.save(testScenario);
+    }
+
+    @Test
+    public void testRunLifecycle_StartPollResults() throws Exception {
+        CreateSimulationRunRequest request = new CreateSimulationRunRequest(
+                testSystem.getId(),
+                testVersion.getId(),
+                testScenario.getId(),
+                4242L
+        );
+
+        MvcResult createResult = mockMvc.perform(post("/api/simulation-runs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("RUNNING"))
+                .andReturn();
+
+        JsonNode createJson = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        long runId = createJson.get("id").asLong();
+
+        CompletableFuture<Void> completion = CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(150);
+                Path runDir = Path.of(runService.getRunById(runId).getArtefactBasePath());
+                Files.createDirectories(runDir);
+                Files.writeString(runDir.resolve("results.json"), objectMapper.writeValueAsString(Map.of(
+                        "runSummary", Map.of("runId", runId, "status", "SUCCEEDED", "ticks", 20),
+                        "metrics", Map.of("totalPassengersServed", 1, "averageWaitTime", 2.5)
+                )));
+                runService.updateProgress(runId, 20L);
+                runService.succeedRun(runId);
+            } catch (Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        });
+
+        boolean completed = false;
+        for (int i = 0; i < 20; i++) {
+            MvcResult pollResult = mockMvc.perform(get("/api/simulation-runs/" + runId))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            JsonNode pollJson = objectMapper.readTree(pollResult.getResponse().getContentAsString());
+            if ("SUCCEEDED".equals(pollJson.get("status").asText())) {
+                completed = true;
+                break;
+            }
+            Thread.sleep(100);
+        }
+
+        completion.get(2, TimeUnit.SECONDS);
+
+        assertTrue(completed, "Run should reach SUCCEEDED status while polling");
+
+        mockMvc.perform(get("/api/simulation-runs/" + runId + "/results"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("SUCCEEDED"))
+                .andExpect(jsonPath("$.results.runSummary.status").value("SUCCEEDED"))
+                .andExpect(jsonPath("$.results.metrics.totalPassengersServed").value(1))
+                .andExpect(jsonPath("$.logsUrl").value("/api/simulation-runs/" + runId + "/logs"));
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/service/BatchInputGeneratorTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/BatchInputGeneratorTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -109,25 +110,35 @@ public class BatchInputGeneratorTest {
                 "Golden Test Scenario"
         );
 
-        String expected = """
-                name: Golden Test Scenario
-                ticks: 30
-                min_floor: 0
-                max_floor: 10
-                initial_floor: 0
-                travel_ticks_per_floor: 1
-                door_transition_ticks: 2
-                door_dwell_ticks: 3
-                door_reopen_window_ticks: 2
-                home_floor: 0
-                idle_timeout_ticks: 5
-                controller_strategy: NEAREST_REQUEST_ROUTING
-                idle_parking_mode: PARK_TO_HOME_FLOOR
+        String expected = readResource("batch-input/golden-basic.scenario");
 
-                0, hall_call, p1, 0, UP
-                5, hall_call, p2, 8, DOWN
-                5, hall_call, p3, 8, DOWN
-                """;
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testGenerateScenarioContent_GoldenFileDirectionalScan() throws IOException {
+        LiftConfigDTO liftConfig = new LiftConfigDTO(
+                -1, 12, 2, 2, 3, 4, 1, 1, 8,
+                ControllerStrategy.DIRECTIONAL_SCAN,
+                IdleParkingMode.STAY_AT_CURRENT_FLOOR
+        );
+
+        PassengerFlowDTO flow1 = new PassengerFlowDTO(0, -1, 6, 2);
+        PassengerFlowDTO flow2 = new PassengerFlowDTO(12, 10, 1, 1);
+
+        ScenarioDefinitionDTO scenario = new ScenarioDefinitionDTO(
+                40,
+                List.of(flow1, flow2),
+                null
+        );
+
+        String result = generator.generateScenarioContent(
+                liftConfig,
+                scenario,
+                "Directional Scan Scenario"
+        );
+
+        String expected = readResource("batch-input/golden-directional-scan.scenario");
 
         assertEquals(expected, result);
     }
@@ -463,5 +474,10 @@ public class BatchInputGeneratorTest {
             assertTrue(hasValidPrefix,
                     "Line contains unexpected field: " + line);
         }
+    }
+
+    private String readResource(String resourcePath) throws IOException {
+        Path path = Paths.get("src/test/resources").resolve(resourcePath);
+        return Files.readString(path).replace("\r\n", "\n");
     }
 }

--- a/src/test/java/com/liftsimulator/scenario/ScenarioCliCompatibilityTest.java
+++ b/src/test/java/com/liftsimulator/scenario/ScenarioCliCompatibilityTest.java
@@ -1,0 +1,88 @@
+package com.liftsimulator.scenario;
+
+import com.liftsimulator.domain.ControllerStrategy;
+import com.liftsimulator.domain.IdleParkingMode;
+import com.liftsimulator.engine.ControllerFactory;
+import com.liftsimulator.engine.RequestManagingLiftController;
+import com.liftsimulator.engine.SimulationEngine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Backwards compatibility test for known-good CLI scenario input.
+ */
+public class ScenarioCliCompatibilityTest {
+    private static final int DEFAULT_MIN_FLOOR = 0;
+    private static final int DEFAULT_MAX_FLOOR = 10;
+    private static final int DEFAULT_INITIAL_FLOOR = 0;
+    private static final int DEFAULT_TRAVEL_TICKS_PER_FLOOR = 1;
+    private static final int DEFAULT_DOOR_TRANSITION_TICKS = 2;
+    private static final int DEFAULT_DOOR_DWELL_TICKS = 3;
+    private static final int DEFAULT_DOOR_REOPEN_WINDOW_TICKS = -1;
+    private static final int DEFAULT_HOME_FLOOR = 0;
+    private static final int DEFAULT_IDLE_TIMEOUT_TICKS = 5;
+    private static final IdleParkingMode DEFAULT_IDLE_PARKING_MODE = IdleParkingMode.PARK_TO_HOME_FLOOR;
+    private static final ControllerStrategy DEFAULT_CONTROLLER_STRATEGY = ControllerStrategy.NEAREST_REQUEST_ROUTING;
+
+    @Test
+    void testDemoScenarioStillRuns() throws Exception {
+        ScenarioParser parser = new ScenarioParser();
+        ScenarioDefinition scenario = parser.parseResource("/scenarios/demo.scenario");
+
+        int minFloor = scenario.getConfiguredMinFloor() != null ? scenario.getConfiguredMinFloor() : DEFAULT_MIN_FLOOR;
+        int maxFloor = scenario.getConfiguredMaxFloor() != null ? scenario.getConfiguredMaxFloor() : DEFAULT_MAX_FLOOR;
+        if (scenario.getMinFloor() != null) {
+            minFloor = Math.min(minFloor, scenario.getMinFloor());
+        }
+        if (scenario.getMaxFloor() != null) {
+            maxFloor = Math.max(maxFloor, scenario.getMaxFloor());
+        }
+        int initialFloorValue = scenario.getInitialFloor() != null ? scenario.getInitialFloor() : DEFAULT_INITIAL_FLOOR;
+        int initialFloor = Math.min(Math.max(initialFloorValue, minFloor), maxFloor);
+        int travelTicksPerFloor = scenario.getTravelTicksPerFloor() != null
+                ? scenario.getTravelTicksPerFloor()
+                : DEFAULT_TRAVEL_TICKS_PER_FLOOR;
+        int doorTransitionTicks = scenario.getDoorTransitionTicks() != null
+                ? scenario.getDoorTransitionTicks()
+                : DEFAULT_DOOR_TRANSITION_TICKS;
+        int doorDwellTicks = scenario.getDoorDwellTicks() != null
+                ? scenario.getDoorDwellTicks()
+                : DEFAULT_DOOR_DWELL_TICKS;
+        int doorReopenWindowTicks = scenario.getDoorReopenWindowTicks() != null
+                ? scenario.getDoorReopenWindowTicks()
+                : DEFAULT_DOOR_REOPEN_WINDOW_TICKS;
+        int homeFloor = scenario.getHomeFloor() != null ? scenario.getHomeFloor() : DEFAULT_HOME_FLOOR;
+        int idleTimeoutTicks = scenario.getIdleTimeoutTicks() != null
+                ? scenario.getIdleTimeoutTicks()
+                : DEFAULT_IDLE_TIMEOUT_TICKS;
+        IdleParkingMode idleParkingMode = scenario.getIdleParkingMode() != null
+                ? scenario.getIdleParkingMode()
+                : DEFAULT_IDLE_PARKING_MODE;
+        ControllerStrategy controllerStrategy = scenario.getControllerStrategy() != null
+                ? scenario.getControllerStrategy()
+                : DEFAULT_CONTROLLER_STRATEGY;
+
+        RequestManagingLiftController controller = (RequestManagingLiftController) ControllerFactory.createController(
+                controllerStrategy,
+                homeFloor,
+                idleTimeoutTicks,
+                idleParkingMode
+        );
+
+        SimulationEngine engine = SimulationEngine.builder(controller, minFloor, maxFloor)
+                .initialFloor(initialFloor)
+                .travelTicksPerFloor(travelTicksPerFloor)
+                .doorTransitionTicks(doorTransitionTicks)
+                .doorDwellTicks(doorDwellTicks)
+                .doorReopenWindowTicks(doorReopenWindowTicks)
+                .build();
+
+        ScenarioRunner runner = new ScenarioRunner(engine, controller);
+        runner.run(scenario);
+
+        assertNotNull(engine.getCurrentState());
+        assertEquals(scenario.getTotalTicks(), engine.getCurrentTick());
+    }
+}

--- a/src/test/resources/batch-input/golden-basic.scenario
+++ b/src/test/resources/batch-input/golden-basic.scenario
@@ -1,0 +1,17 @@
+name: Golden Test Scenario
+ticks: 30
+min_floor: 0
+max_floor: 10
+initial_floor: 0
+travel_ticks_per_floor: 1
+door_transition_ticks: 2
+door_dwell_ticks: 3
+door_reopen_window_ticks: 2
+home_floor: 0
+idle_timeout_ticks: 5
+controller_strategy: NEAREST_REQUEST_ROUTING
+idle_parking_mode: PARK_TO_HOME_FLOOR
+
+0, hall_call, p1, 0, UP
+5, hall_call, p2, 8, DOWN
+5, hall_call, p3, 8, DOWN

--- a/src/test/resources/batch-input/golden-directional-scan.scenario
+++ b/src/test/resources/batch-input/golden-directional-scan.scenario
@@ -1,0 +1,17 @@
+name: Directional Scan Scenario
+ticks: 40
+min_floor: -1
+max_floor: 12
+initial_floor: 1
+travel_ticks_per_floor: 2
+door_transition_ticks: 3
+door_dwell_ticks: 4
+door_reopen_window_ticks: 1
+home_floor: 1
+idle_timeout_ticks: 8
+controller_strategy: DIRECTIONAL_SCAN
+idle_parking_mode: STAY_AT_CURRENT_FLOOR
+
+0, hall_call, p1, -1, UP
+0, hall_call, p2, -1, UP
+12, hall_call, p3, 10, DOWN


### PR DESCRIPTION
### Motivation

- Protect the new async run workflow (start -> poll -> results) with an integration test that validates the full lifecycle and results output.
- Ensure the `BatchInputGenerator` continues to produce a backwards-compatible legacy `.scenario` format via golden-file contract tests.
- Verify legacy CLI scenario inputs still run with the in-repo simulator to avoid regressions in CLI compatibility.

### Description

- Added an integration test `SimulationRunLifecycleIntegrationTest` that creates a run via `POST /api/simulation-runs`, polls the run until completion, writes a `results.json` artifact, and verifies the `GET /api/simulation-runs/{id}/results` structured JSON response and `logsUrl`.
- Added `ScenarioCliCompatibilityTest` to parse `/scenarios/demo.scenario` and exercise the legacy CLI flow via `ScenarioRunner` to ensure the demo scenario still executes end-to-end.
- Extended `BatchInputGeneratorTest` to perform golden-file comparisons using new fixtures added under `src/test/resources/batch-input` (`golden-basic.scenario` and `golden-directional-scan.scenario`) and a `readResource` helper for deterministic comparisons.
- Documented the new tests in `README.md` and added a short note to `CHANGELOG.md` under `0.45.0` describing the added testing coverage.

### Testing

- Ran the targeted Maven command `mvn test -Dtest=SimulationRunLifecycleIntegrationTest,ScenarioCliCompatibilityTest,BatchInputGeneratorTest` to execute the new tests.
- Automated run did not complete because Maven failed to resolve the Spring Boot parent POM due to a remote fetch error (`403 Forbidden` from repo.maven.apache.org), so the new tests could not be executed to completion in this environment.
- Local/CI expectation: after Maven connectivity is available, the `BatchInputGeneratorTest` golden comparisons and the two new integration tests should run under the existing `test` profile (H2 in-memory DB and `application-test.yml`), and the run lifecycle test uses a `@TempDir` `simulation.artefacts.base-path` override at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737c34fa5c8325a01219e7b59794e8)