### PR TITLE
Add artefactBasePath field to SimulationRunResponse DTO

### DIFF
--- a/src/main/java/com/liftsimulator/admin/dto/SimulationRunResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/SimulationRunResponse.java
@@ -7,10 +7,6 @@ import java.time.OffsetDateTime;
 
 /**
  * Response DTO for simulation run details.
-import java.time.OffsetDateTime;
-
-/**
- * Response payload for simulation run metadata.
  */
 public record SimulationRunResponse(
     Long id,
@@ -24,7 +20,8 @@ public record SimulationRunResponse(
     Long totalTicks,
     Long currentTick,
     Long seed,
-    String errorMessage
+    String errorMessage,
+    String artefactBasePath
 ) {
     /**
      * Creates a response DTO from a SimulationRun entity.
@@ -32,14 +29,6 @@ public record SimulationRunResponse(
      * @param run the entity to convert
      * @return the response DTO
      */
-    public static SimulationRunResponse fromEntity(SimulationRun run) {
-        return new SimulationRunResponse(
-            run.getId(),
-            run.getLiftSystem().getId(),
-            run.getVersion().getId(),
-    String errorMessage,
-    String artefactBasePath
-) {
     public static SimulationRunResponse fromEntity(SimulationRun run) {
         return new SimulationRunResponse(
             run.getId(),
@@ -53,7 +42,8 @@ public record SimulationRunResponse(
             run.getTotalTicks(),
             run.getCurrentTick(),
             run.getSeed(),
-            run.getErrorMessage()
+            run.getErrorMessage(),
+            run.getArtefactBasePath()
         );
     }
 
@@ -67,9 +57,5 @@ public record SimulationRunResponse(
             return null;
         }
         return (currentTick.doubleValue() / totalTicks.doubleValue()) * 100.0;
-    }
-            run.getErrorMessage(),
-            run.getArtefactBasePath()
-        );
     }
 }


### PR DESCRIPTION
## Summary
This PR adds the `artefactBasePath` field to the `SimulationRunResponse` record and updates the corresponding entity mapping to include this new field.

## Changes
- Added `artefactBasePath` field to the `SimulationRunResponse` record
- Updated `fromEntity()` method to map `run.getArtefactBasePath()` when creating response DTOs
- Cleaned up duplicate/malformed code in the record definition and factory method
- Fixed javadoc formatting issues

## Implementation Details
The `artefactBasePath` field is now included in the simulation run response payload, allowing clients to access the artifact base path for each simulation run. The field is properly mapped from the `SimulationRun` entity in the `fromEntity()` factory method.