### PR TITLE
Handle IOException in scenario validation; update README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a CLI compatibility test for the demo scenario.
 
 ### Fixed
+- Handle unexpected IO failures when validating scenario payloads in the admin service.
 - **Simulator Run UI**: Only apply preselected system/version from query params once so user selections are not overridden.
 - **Simulator Landing**: Ignore stale version fetch responses when switching between systems quickly.
 - **Simulator Landing**: Clear version options when loading versions fails to prevent mismatched selections.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Use these as starting points or reference examples.
 - Verify PostgreSQL version is 12+
 - Check Flyway migration files in `src/main/resources/db/migration/`
 
+**Scenario validation fails with "Unable to read scenario payload":**
+- Confirm the scenario JSON is valid and not empty
+- Retry the request after verifying the payload format
+
 For detailed troubleshooting, see the relevant sections below.
 
 ---

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java
@@ -16,6 +16,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -88,6 +89,13 @@ public class ScenarioValidationService {
             errors.add(new ValidationIssue(
                 "scenario",
                 "Invalid JSON format: " + e.getOriginalMessage(),
+                ValidationIssue.Severity.ERROR
+            ));
+            return new ScenarioValidationResponse(false, errors, warnings);
+        } catch (IOException e) {
+            errors.add(new ValidationIssue(
+                "scenario",
+                "Unable to read scenario payload: " + e.getMessage(),
                 ValidationIssue.Severity.ERROR
             ));
             return new ScenarioValidationResponse(false, errors, warnings);


### PR DESCRIPTION
### Motivation
- Ensure unexpected `IOException` from Jackson while reading scenario JSON is surfaced as a clear validation error instead of causing an unhandled failure.
- Provide brief troubleshooting guidance for the new "Unable to read scenario payload" error in the documentation.
- Place the fix entry in the correct release section of the changelog (`0.45.0`) rather than leaving it under `Unreleased`.

### Description
- Catch `IOException` in `ScenarioValidationService.validate` and convert it into a `ValidationIssue` with the message `Unable to read scenario payload` (file: `src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java`).
- Add the necessary `import java.io.IOException` and error handling logic to the validation service.
- Add a short troubleshooting note to `README.md` documenting the `Unable to read scenario payload` scenario validation error.
- Move the changelog entry for this fix into the `0.45.0` section of `CHANGELOG.md`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697384c9a00c832597e2bdd3bfc62a11)