### PR TITLE
Refactor LiftSystemVersion constructor to accept version and config

### DIFF
--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -90,10 +90,8 @@ public class SimulationRunControllerTest {
         testSystem = new LiftSystem("test-system", "Test System", "Test Description");
         testSystem = liftSystemRepository.save(testSystem);
 
-        testVersion = new LiftSystemVersion(testSystem);
-        testVersion.setVersionNumber(1);
+        testVersion = new LiftSystemVersion(testSystem, 1, "{\"numLifts\": 2, \"numFloors\": 10}");
         testVersion.setStatus(VersionStatus.PUBLISHED);
-        testVersion.setConfig("{\"numLifts\": 2, \"numFloors\": 10}");
         testVersion = versionRepository.save(testVersion);
 
         testScenario = new SimulationScenario();

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -90,10 +90,8 @@ public class SimulationRunLifecycleIntegrationTest {
         testSystem = new LiftSystem("lifecycle-system", "Lifecycle System", "Test Description");
         testSystem = liftSystemRepository.save(testSystem);
 
-        testVersion = new LiftSystemVersion(testSystem);
-        testVersion.setVersionNumber(1);
+        testVersion = new LiftSystemVersion(testSystem, 1, "{\"minFloor\": 0, \"maxFloor\": 10, \"numLifts\": 2}");
         testVersion.setStatus(VersionStatus.PUBLISHED);
-        testVersion.setConfig("{\"minFloor\": 0, \"maxFloor\": 10, \"numLifts\": 2}");
         testVersion = versionRepository.save(testVersion);
 
         testScenario = new SimulationScenario();

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -73,7 +73,8 @@ public class SimulationRunServiceTest {
                 versionRepository,
                 scenarioRepository,
                 batchInputGenerator,
-                objectMapper
+                objectMapper,
+                tempDir.toString()
         );
 
         mockLiftSystem = new LiftSystem();


### PR DESCRIPTION
## Summary
Updated test setup code to use the refactored `LiftSystemVersion` constructor that accepts version number and configuration as constructor parameters, rather than setting them via setters after instantiation.

## Key Changes
- **SimulationRunControllerTest.java**: Refactored `LiftSystemVersion` instantiation to pass version number (1) and config JSON directly to constructor instead of using setters
- **SimulationRunLifecycleIntegrationTest.java**: Applied same refactoring pattern for consistency across test suite
- **SimulationRunServiceTest.java**: Added missing `tempDir.toString()` parameter to `SimulationRunService` constructor call

## Implementation Details
- Consolidated object initialization from 4 lines to 2 lines per test setup
- Maintains same test behavior while improving code clarity and reducing boilerplate
- Constructor now follows builder-like pattern with essential parameters passed at instantiation time
- Status is still set via setter as it appears to be optional or has a default value