### PR TITLE
Fix simulation run execution and passenger flow modeling

### DIFF
--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -36,6 +36,7 @@ public class SimulationRunService {
     private final BatchInputGenerator batchInputGenerator;
     private final ObjectMapper objectMapper;
     private final String artefactsBasePath;
+    private SimulationRunExecutionService executionService;
 
     public SimulationRunService(
             SimulationRunRepository runRepository,
@@ -52,6 +53,17 @@ public class SimulationRunService {
         this.batchInputGenerator = batchInputGenerator;
         this.objectMapper = objectMapper;
         this.artefactsBasePath = artefactsBasePath;
+    }
+
+    /**
+     * Sets the execution service. This is called by Spring after construction
+     * to avoid circular dependency issues.
+     *
+     * @param executionService the execution service
+     */
+    @org.springframework.beans.factory.annotation.Autowired
+    public void setExecutionService(SimulationRunExecutionService executionService) {
+        this.executionService = executionService;
     }
 
     /**
@@ -158,9 +170,10 @@ public class SimulationRunService {
             generateBatchInputFile(run.getId());
         }
 
-        // Start the run
-        run.start();
-        return runRepository.save(run);
+        // Submit the run for execution
+        // The execution service will transition the run to RUNNING and handle the actual simulation
+        executionService.submitRunForExecution(run.getId());
+        return run;
     }
 
     /**


### PR DESCRIPTION
1. Fix createAndStartRun to trigger actual execution
   - Add submitRunForExecution method to SimulationRunExecutionService
   - Wire executionService into SimulationRunService via setter injection
   - Submit runs for execution instead of just marking as RUNNING
   - Prevents runs from being stuck in RUNNING state indefinitely

2. Fix passenger flows to use hall calls instead of car calls
   - Change from LiftRequest.carCall() to LiftRequest.hallCall()
   - Determine direction (UP/DOWN) based on origin and destination
   - Skip same-floor flows that don't require lift movement
   - Properly models passenger pickup behavior and wait times

These changes ensure that UI-launched runs execute properly and that simulation results accurately reflect passenger flow semantics.

https://claude.ai/code/session_0115ddQtp8DFL3H7tYQHqitZ