### PR TITLE
Validate scenario inputs when generating in-memory batch scenario content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Handle unexpected IO failures when validating scenario payloads in the admin service.
+- Validate scenario floor ranges and start ticks when generating batch scenario content in memory.
 - **Simulator Run UI**: Only apply preselected system/version from query params once so user selections are not overridden.
 - **Simulator Landing**: Ignore stale version fetch responses when switching between systems quickly.
 - **Simulator Landing**: Clear version options when loading versions fails to prevent mismatched selections.

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ Path inputFile = runService.generateBatchInputFile(runId);
 - **Automatic direction calculation**: Determines UP/DOWN based on origin and destination floors
 - **Unique passenger aliases**: Each passenger gets a unique alias (p1, p2, p3...)
 - **Event ordering**: Events are sorted by tick, then by alias
-- **Validation**: Ensures floor values are within configured range and start ticks are valid
+- **Validation**: Ensures floor values are within configured range and start ticks are valid when generating content or files
 - **Artifact management**: Files are stored in run-specific directories under `artefactBasePath`
 
 **Scenario JSON Structure:**

--- a/src/main/java/com/liftsimulator/admin/service/BatchInputGenerator.java
+++ b/src/main/java/com/liftsimulator/admin/service/BatchInputGenerator.java
@@ -50,8 +50,6 @@ public class BatchInputGenerator {
             Path outputPath
     ) throws IOException {
         LiftConfigDTO liftConfig = parseLiftConfig(liftConfigJson);
-        validateScenarioAgainstConfig(scenarioDefinition, liftConfig);
-
         String content = generateScenarioContent(liftConfig, scenarioDefinition, scenarioName);
         writeScenarioFile(outputPath, content);
     }
@@ -65,6 +63,7 @@ public class BatchInputGenerator {
             ScenarioDefinitionDTO scenarioDefinition,
             String scenarioName
     ) {
+        validateScenarioAgainstConfig(scenarioDefinition, liftConfig);
         StringBuilder sb = new StringBuilder();
 
         appendHeader(sb, scenarioName);


### PR DESCRIPTION
### Motivation
- Tests expected invalid scenario definitions to throw `IllegalArgumentException` when building scenario content, but validation was only invoked when writing files.
- The generator should consistently validate scenario constraints regardless of whether content is produced in-memory or written to disk.
- Documentation and changelog should reflect the enforced validation behavior under the current `0.45.0` release notes.

### Description
- Move `validateScenarioAgainstConfig(...)` into `BatchInputGenerator.generateScenarioContent(...)` so in-memory content generation enforces floor range and tick constraints.  
- Remove the now-redundant validation call from `BatchInputGenerator.generateBatchInputFile(...)` to avoid double-validation.  
- Update `README.md` to clarify that validation applies when generating content or files.  
- Add a note to `CHANGELOG.md` under `0.45.0` describing the fix for in-memory batch scenario validation.

### Testing
- Attempted to run `mvn -Dtest=GlobalExceptionHandlerValidationTest test`, but the build failed to start due to a Maven parent POM download error (HTTP 403 from repo.maven.apache.org), so automated tests could not be executed in this environment.  
- Static inspection and unit test sources were reviewed to ensure the validation location change satisfies `BatchInputGeneratorTest` expectations for `generateScenarioContent`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738ef0ff588325a25997025fe3e98e)