### PR TITLE
Optimize GlobalExceptionHandlerValidationTest with @WebMvcTest

### DIFF
--- a/src/test/java/com/liftsimulator/admin/controller/GlobalExceptionHandlerValidationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/GlobalExceptionHandlerValidationTest.java
@@ -8,9 +8,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -18,7 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -39,11 +36,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * annotations (like @ScriptAssert or custom validators), but those scenarios are less common.
  * The GlobalExceptionHandler safely handles both FieldError and ObjectError types.
  */
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@WebMvcTest(controllers = {GlobalExceptionHandler.class})
 @ActiveProfiles("test")
-@Transactional
 @Import(GlobalExceptionHandlerValidationTest.TestControllerConfig.class)
 public class GlobalExceptionHandlerValidationTest {
 


### PR DESCRIPTION
## Summary
Refactored `GlobalExceptionHandlerValidationTest` to use `@WebMvcTest` instead of `@SpringBootTest`, resulting in faster test execution and a more focused unit test approach.

## Key Changes
- Replaced `@SpringBootTest` with `@WebMvcTest(controllers = {GlobalExceptionHandler.class})` for a lightweight, slice-based test
- Removed `@AutoConfigureMockMvc` annotation (now implicit with `@WebMvcTest`)
- Removed `@AutoConfigureTestDatabase` annotation (not needed for web layer testing)
- Removed `@Transactional` annotation (unnecessary for non-database tests)
- Removed unused import for `Transactional`

## Benefits
- **Faster test execution**: `@WebMvcTest` only loads the web layer, not the entire application context
- **Better test isolation**: Focuses on testing the `GlobalExceptionHandler` and validation behavior without database or full Spring context
- **Cleaner test configuration**: Reduces unnecessary annotations and dependencies
- **Maintains test coverage**: The test still validates exception handling and validation error responses through MockMvc