### PR TITLE
Ensure H2 test schema initialization for integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Handle unexpected IO failures when validating scenario payloads in the admin service.
 - Validate scenario floor ranges and start ticks when generating batch scenario content in memory.
+- Initialize the H2 test schema for Spring Boot integration tests to prevent application context startup failures.
 - **Simulator Run UI**: Only apply preselected system/version from query params once so user selections are not overridden.
 - **Simulator Landing**: Ignore stale version fetch responses when switching between systems quickly.
 - **Simulator Landing**: Clear version options when loading versions fails to prevent mismatched selections.

--- a/README.md
+++ b/README.md
@@ -2473,6 +2473,7 @@ Integration tests for the repositories are available:
 
 **Test Database Configuration:**
 - Tests use **H2 in-memory database** with PostgreSQL compatibility mode
+- The H2 test database initializes the `lift_simulator` schema automatically for integration tests
 - No external database required for running tests
 - Schema is automatically created via JPA's `ddl-auto: create-drop`
 - Flyway is disabled for tests (schema created from JPA entities)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;INIT=CREATE SCHEMA IF NOT EXISTS lift_simulator\;SET SCHEMA lift_simulator
     driver-class-name: org.h2.Driver
     username: sa
     password:


### PR DESCRIPTION
### Motivation
- Integration tests were failing to start the Spring context due to the `lift_simulator` schema not existing in the H2 test database, causing repeated ApplicationContext load failures in tests like `LiftSystemControllerTest`.
- Make the H2 in-memory test database initialize and use the `lift_simulator` schema automatically so JPA can create tables and tests can run reliably in CI/local environments without a real Postgres instance.

### Description
- Updated `src/test/resources/application-test.yml` to append `;INIT=CREATE SCHEMA IF NOT EXISTS lift_simulator\;SET SCHEMA lift_simulator` to the H2 JDBC URL so the schema is created and selected before Hibernate starts.
- Documented the automatic test schema initialization in `README.md` under the integration test notes to explain why tests do not require a running Postgres instance.
- Recorded the fix in `CHANGELOG.md` under version `0.45.0` in the "Fixed" section noting H2 test schema initialization for Spring Boot integration tests.
- No SemVer bump was required; changes are recorded under the existing `0.45.0` entry.

### Testing
- Attempted to run the controller integration test with `mvn -Dtest=LiftSystemControllerTest test`, but the build failed because Maven could not resolve the parent POM (`org.springframework.boot:spring-boot-starter-parent:3.2.1`) due to a 403 from `repo.maven.apache.org`, so automated test execution could not complete.
- Attempted to run the full test suite with `mvn test`, but it likewise failed for the same Maven dependency resolution error, so no tests could be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697392f9c91483258fe94cd51ef6e76f)