### PR TITLE
Remove explicit jsonb columnDefinition from JSON columns

### DIFF
--- a/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
+++ b/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
@@ -55,7 +55,7 @@ public class LiftSystemVersion {
     private OffsetDateTime publishedAt;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "config", nullable = false, columnDefinition = "jsonb")
+    @Column(name = "config", nullable = false)
     private String config;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/liftsimulator/admin/entity/Scenario.java
+++ b/src/main/java/com/liftsimulator/admin/entity/Scenario.java
@@ -29,7 +29,7 @@ public class Scenario {
     private String name;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "scenario_json", nullable = false, columnDefinition = "jsonb")
+    @Column(name = "scenario_json", nullable = false)
     private String scenarioJson;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/liftsimulator/admin/entity/SimulationScenario.java
+++ b/src/main/java/com/liftsimulator/admin/entity/SimulationScenario.java
@@ -30,7 +30,7 @@ public class SimulationScenario {
     private String name;
 
     @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "scenario_json", nullable = false, columnDefinition = "jsonb")
+    @Column(name = "scenario_json", nullable = false)
     private String scenarioJson;
 
     @Column(name = "created_at", nullable = false, updatable = false)


### PR DESCRIPTION
## Summary
Removed explicit `columnDefinition = "jsonb"` from `@Column` annotations on JSON-typed fields across multiple entity classes. The `@JdbcTypeCode(SqlTypes.JSON)` annotation is sufficient to handle the database type mapping.

## Changes
- **LiftSystemVersion.java**: Removed `columnDefinition = "jsonb"` from `config` column
- **Scenario.java**: Removed `columnDefinition = "jsonb"` from `scenario_json` column
- **SimulationScenario.java**: Removed `columnDefinition = "jsonb"` from `scenario_json` column

## Details
The `@JdbcTypeCode(SqlTypes.JSON)` annotation already instructs Hibernate/JPA to map the field to the appropriate JSON type for the target database. Explicitly specifying `columnDefinition = "jsonb"` is redundant and can cause issues with database portability or schema generation tools. This change simplifies the annotations while maintaining the same functionality.