### PR TITLE
Document jsonb column definition fix in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle unexpected IO failures when validating scenario payloads in the admin service.
 - Validate scenario floor ranges and start ticks when generating batch scenario content in memory.
 - Initialize the H2 test schema for Spring Boot integration tests to prevent application context startup failures.
+- Remove PostgreSQL-specific jsonb column definitions from JPA entities to fix H2 test database compatibility and ApplicationContext loading failures in @SpringBootTest integration tests.
 - **Simulator Run UI**: Only apply preselected system/version from query params once so user selections are not overridden.
 - **Simulator Landing**: Ignore stale version fetch responses when switching between systems quickly.
 - **Simulator Landing**: Clear version options when loading versions fails to prevent mismatched selections.


### PR DESCRIPTION
Add entry explaining the removal of PostgreSQL-specific columnDefinition to fix H2 compatibility in integration tests.

https://claude.ai/code/session_01HMxkeTPM16QxkrwUomkRCi