### PR TITLE
Add cascade delete foreign key constraint to LiftSystemVersion

### DIFF
--- a/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
+++ b/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,7 +39,14 @@ public class LiftSystemVersion {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "lift_system_id", nullable = false)
+    @JoinColumn(
+        name = "lift_system_id",
+        nullable = false,
+        foreignKey = @ForeignKey(
+            name = "fk_lift_system_version_lift_system",
+            foreignKeyDefinition = "FOREIGN KEY (lift_system_id) REFERENCES lift_system(id) ON DELETE CASCADE"
+        )
+    )
     private LiftSystem liftSystem;
 
     @Column(name = "version_number", nullable = false)


### PR DESCRIPTION
## Summary
This PR adds explicit cascade delete foreign key constraint to the `LiftSystemVersion` entity and includes a comprehensive test to verify the cascade delete behavior works correctly.

## Key Changes
- **Entity Configuration**: Updated `LiftSystemVersion.java` to explicitly define a foreign key constraint with `ON DELETE CASCADE` on the `lift_system_id` column. This ensures that when a `LiftSystem` is deleted, all associated `LiftSystemVersion` records are automatically deleted by the database.
- **Test Coverage**: Added `testCascadeDeleteLiftSystemWithVersions()` test method to verify that deleting a lift system properly cascades and removes all related versions from the database.
- **Dependencies**: Added `LiftSystemVersionRepository` autowiring to the test class to enable verification of cascade delete behavior.

## Implementation Details
- The foreign key is explicitly named `fk_lift_system_version_lift_system` for clarity and maintainability
- The constraint uses `ON DELETE CASCADE` to enforce referential integrity at the database level
- The test creates a lift system with three versions, deletes the system, and verifies all versions are removed
- Entity manager is flushed and cleared between operations to ensure database-level cascade delete is tested (not just ORM-level behavior)