### PR TITLE
Replace H2 with Testcontainers PostgreSQL for integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,20 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Testcontainers for PostgreSQL integration testing -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- JUnit 5 for testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/test/java/com/liftsimulator/BaseIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/BaseIntegrationTest.java
@@ -1,0 +1,33 @@
+package com.liftsimulator;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Base class for integration tests that need a real PostgreSQL database.
+ * Uses Testcontainers to start a PostgreSQL container for testing.
+ */
+@Testcontainers
+@SpringBootTest
+@ActiveProfiles("test")
+public abstract class BaseIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine")
+            .withDatabaseName("lift_simulator")
+            .withUsername("test")
+            .withPassword("test")
+            .withInitScript("init-test-schema.sql");
+
+    @DynamicPropertySource
+    static void registerPgProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/controller/LiftSystemControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/LiftSystemControllerTest.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.BaseIntegrationTest;
 import com.liftsimulator.admin.dto.CreateLiftSystemRequest;
 import com.liftsimulator.admin.dto.UpdateLiftSystemRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
@@ -8,11 +9,8 @@ import com.liftsimulator.admin.repository.LiftSystemRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,12 +25,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests for LiftSystemController.
  */
-@SpringBootTest
 @AutoConfigureMockMvc
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Transactional
-public class LiftSystemControllerTest {
+public class LiftSystemControllerTest extends BaseIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/liftsimulator/admin/controller/LiftSystemVersionControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/LiftSystemVersionControllerTest.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.BaseIntegrationTest;
 import com.liftsimulator.admin.dto.CreateVersionRequest;
 import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
@@ -10,11 +11,8 @@ import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,12 +26,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests for LiftSystemVersionController.
  */
-@SpringBootTest
 @AutoConfigureMockMvc
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Transactional
-public class LiftSystemVersionControllerTest {
+public class LiftSystemVersionControllerTest extends BaseIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.BaseIntegrationTest;
 import com.liftsimulator.admin.dto.CreateSimulationRunRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
@@ -14,11 +15,8 @@ import com.liftsimulator.admin.repository.SimulationScenarioRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,12 +34,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration tests for SimulationRunController.
  */
-@SpringBootTest
 @AutoConfigureMockMvc
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
 @Transactional
-public class SimulationRunControllerTest {
+public class SimulationRunControllerTest extends BaseIntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -2,6 +2,7 @@ package com.liftsimulator.admin.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.BaseIntegrationTest;
 import com.liftsimulator.admin.dto.CreateSimulationRunRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
@@ -16,11 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -41,11 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Integration test for simulation run lifecycle (start -> poll -> results).
  */
-@SpringBootTest
 @AutoConfigureMockMvc
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-public class SimulationRunLifecycleIntegrationTest {
+public class SimulationRunLifecycleIntegrationTest extends BaseIntegrationTest {
 
     @TempDir
     static Path artefactsRoot;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,12 +1,10 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;INIT=CREATE SCHEMA IF NOT EXISTS lift_simulator\;SET SCHEMA lift_simulator
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    # URL, username, and password will be provided dynamically by Testcontainers
+    driver-class-name: org.postgresql.Driver
 
   jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: create-drop
     show-sql: true

--- a/src/test/resources/init-test-schema.sql
+++ b/src/test/resources/init-test-schema.sql
@@ -1,0 +1,2 @@
+-- Initialize test database schema
+CREATE SCHEMA IF NOT EXISTS lift_simulator;


### PR DESCRIPTION
## Summary
Migrated integration tests from using an in-memory H2 database to a real PostgreSQL database via Testcontainers. This ensures tests run against the actual database engine used in production, improving test reliability and catching database-specific issues earlier.

## Key Changes
- **Added Testcontainers dependencies**: Added `testcontainers-postgresql` and `testcontainers-junit-jupiter` (v1.19.0) to `pom.xml`
- **Created BaseIntegrationTest**: New abstract base class that configures a PostgreSQL container for all integration tests, using dynamic property sources to inject database credentials at runtime
- **Updated test configuration**: Modified `application-test.yml` to use PostgreSQL dialect and driver instead of H2, with credentials provided dynamically by Testcontainers
- **Refactored test classes**: Updated 4 integration test classes to extend `BaseIntegrationTest` and removed redundant `@SpringBootTest`, `@AutoConfigureTestDatabase`, and `@ActiveProfiles` annotations
- **Added init script**: Created `init-test-schema.sql` to initialize the test database schema

## Implementation Details
- Uses PostgreSQL 15-alpine image for lightweight container startup
- Testcontainers automatically manages container lifecycle (start before tests, cleanup after)
- Dynamic property registration ensures each test run gets fresh database credentials
- All test classes now inherit common database configuration, reducing duplication and improving maintainability