### PR TITLE
Rename JUnit version property for clarity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <junit.version>5.10.1</junit.version>
+        <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <frontend.dir>${project.basedir}/frontend</frontend.dir>
         <frontend.build.dir>${frontend.dir}/dist</frontend.build.dir>
     </properties>
@@ -106,13 +106,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
Renamed the Maven property for JUnit Jupiter version from `junit.version` to `junit-jupiter.version` to better reflect its specific purpose and improve project maintainability.

## Changes
- Renamed property `junit.version` to `junit-jupiter.version` in `pom.xml`
- Updated all references to use the new property name:
  - `junit-jupiter-api` dependency
  - `junit-jupiter-engine` dependency

## Rationale
The new property name is more explicit and descriptive, making it immediately clear that this version applies specifically to JUnit Jupiter (JUnit 5) dependencies. This naming convention improves code clarity and makes it easier to distinguish from other potential testing framework versions that might be added in the future.