### PR TITLE
Fix lint errors in ScenarioForm.jsx

### DIFF
--- a/frontend/src/pages/ScenarioForm.jsx
+++ b/frontend/src/pages/ScenarioForm.jsx
@@ -95,7 +95,7 @@ function ScenarioForm() {
     if (isEditMode) {
       loadScenario();
     }
-  }, [id]);
+  }, [id, isEditMode, loadScenario]);
 
   /**
    * Loads scenario data for editing.
@@ -271,7 +271,7 @@ function ScenarioForm() {
           setSeed('');
           setUseSeed(false);
         }
-      } catch (err) {
+      } catch {
         setAlertMessage('Invalid JSON format. Please fix the JSON before switching back to form mode.');
         return;
       }


### PR DESCRIPTION
- Remove unused 'err' variable in catch block at line 274
- Add missing dependencies (isEditMode, loadScenario) to useEffect at line 98