### PR TITLE
Fix simulation run status handling and exception type

### DIFF
--- a/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
@@ -89,7 +89,7 @@ public class ArtefactService {
     public String readLogs(SimulationRun run, Integer tail) throws IOException {
         String basePath = run.getArtefactBasePath();
         if (basePath == null || basePath.isBlank()) {
-            throw new IllegalStateException("Artefact base path is not set for run " + run.getId());
+            throw new IOException("Artefact base path is not set for run " + run.getId());
         }
 
         // Try common log file names

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -170,7 +170,11 @@ public class SimulationRunExecutionService {
                 runDir.toAbsolutePath().toString()
             );
 
-            runService.startRun(request.runId());
+            // Start the run if not already started (it may have been started by createAndStartRun)
+            SimulationRun currentRun = runService.getRunById(request.runId());
+            if (currentRun.getStatus() != SimulationRun.RunStatus.RUNNING) {
+                runService.startRun(request.runId());
+            }
             started = true;
             log(logWriter, "Simulation started for run " + request.runId());
 

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -170,8 +170,13 @@ public class SimulationRunService {
             generateBatchInputFile(run.getId());
         }
 
+        // Start the run before submitting for async execution
+        // This ensures the API returns RUNNING status immediately
+        run.start();
+        run = runRepository.save(run);
+
         // Submit the run for execution
-        // The execution service will transition the run to RUNNING and handle the actual simulation
+        // The execution service will handle the actual simulation
         executionService.submitRunForExecution(run.getId());
         return run;
     }


### PR DESCRIPTION
## Summary
This PR fixes issues with simulation run status management and improves exception handling consistency. The changes ensure that the run status is properly set to RUNNING immediately when a simulation is created and started, and prevent duplicate status transitions during async execution.

## Key Changes
- **SimulationRunService**: Start the run synchronously in `createAndStartRun()` before submitting for async execution, ensuring the API returns RUNNING status immediately to clients
- **SimulationRunExecutionService**: Add a status check before calling `startRun()` to prevent attempting to transition an already-running simulation
- **ArtefactService**: Change exception type from `IllegalStateException` to `IOException` in `readLogs()` to match the method signature and provide more semantically correct error handling

## Implementation Details
- The run is now transitioned to RUNNING status before being submitted to the execution service, providing immediate feedback to API consumers
- The execution service now checks the current run status before attempting to start it, preventing potential state transition errors
- This approach maintains the async execution model while ensuring consistent status reporting