### PR TITLE
Fix scenario validation and race condition in simulation run tests

### DIFF
--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -95,7 +95,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
 
         testScenario = new SimulationScenario();
         testScenario.setName("Test Scenario");
-        testScenario.setScenarioJson("{\"passengerFlows\": []}");
+        testScenario.setScenarioJson("{\"durationTicks\": 10, \"passengerFlows\": [{\"startTick\": 0, \"originFloor\": 0, \"destinationFloor\": 5, \"passengers\": 1}]}");
         testScenario = scenarioRepository.save(testScenario);
     }
 


### PR DESCRIPTION
Two issues fixed:

1. SimulationRunControllerTest.testCreateSimulationRun_WithScenario
   - Added missing 'durationTicks' field to scenario JSON
   - Added at least one passenger flow to satisfy @Size(min=1) validation
   - ScenarioDefinitionDTO requires durationTicks and non-empty passengerFlows

2. SimulationRunLifecycleIntegrationTest.testRunLifecycle_StartPollResults
   - Fixed race condition where actual simulation execution service completes before test's async task tries to call succeedRun()
   - Added status check before attempting state transition
   - Wrapped succeedRun() in try-catch to handle IllegalStateException
   - Test now gracefully handles both manual and automatic completion

The test creates a real simulation that runs via SimulationRunExecutionService, which can complete before the test's manual completion logic runs.