### PR TITLE
Rename metrics to kpis and update field names in simulation results

### DIFF
--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -130,7 +130,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
                     Files.createDirectories(runDir);
                     Files.writeString(runDir.resolve("results.json"), objectMapper.writeValueAsString(Map.of(
                             "runSummary", Map.of("runId", runId, "status", "SUCCEEDED", "ticks", 20),
-                            "metrics", Map.of("totalPassengersServed", 1, "averageWaitTime", 2.5)
+                            "kpis", Map.of("passengersServed", 1, "avgWaitTicks", 2.5)
                     )));
                     runService.updateProgress(runId, 20L);
                     try {
@@ -165,7 +165,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCEEDED"))
                 .andExpect(jsonPath("$.results.runSummary.status").value("SUCCEEDED"))
-                .andExpect(jsonPath("$.results.metrics.totalPassengersServed").value(1))
+                .andExpect(jsonPath("$.results.kpis.passengersServed").value(1))
                 .andExpect(jsonPath("$.logsUrl").value("/api/simulation-runs/" + runId + "/logs"));
     }
 }


### PR DESCRIPTION
## Summary
Updated the simulation results JSON structure to use more standardized naming conventions for key performance indicators (KPIs).

## Changes
- Renamed `metrics` object to `kpis` in the results JSON structure
- Updated field names within the KPIs object:
  - `totalPassengersServed` → `passengersServed`
  - `averageWaitTime` → `avgWaitTicks`
- Updated corresponding test assertions to match the new field names

## Details
This change improves the clarity and consistency of the results API by:
- Using the more appropriate term "kpis" (Key Performance Indicators) instead of the generic "metrics"
- Simplifying field names to be more concise while remaining descriptive
- Aligning the naming convention with the domain language (using "ticks" as the time unit)

The changes are reflected in both the test data setup and the response assertions in the integration test.