### PR TITLE
Fix frontend footer version display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a CLI compatibility test for the demo scenario.
 
 ### Fixed
+- Update the frontend footer to report the current application version (0.45.0) from the admin UI package metadata.
 - Avoid SpotBugs EI_EXPOSE_REP2 warnings in admin services by using defensive ObjectMapper copies and lazy execution service injection.
 - Handle unexpected IO failures when validating scenario payloads in the admin service.
 - Validate scenario floor ranges and start ticks when generating batch scenario content in memory.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,6 +18,10 @@ This is the frontend admin application for the Lift Simulator system. It provide
 - Monitoring system health
 - Reviewing per-system version counts in the Lift Systems list
 
+## Versioning
+
+The footer displays the current UI version by reading the `version` field from `frontend/package.json` at build time. Update that field as part of each release to keep the footer in sync with the deployed build.
+
 ## Tech Stack
 
 This project uses the following core dependencies (version ranges as specified in `package.json`):

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "dependencies": {
         "axios": "^1.13.2",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.44.0",
+  "version": "0.45.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
### Motivation
- The UI footer displayed the previous package version (0.44.0) causing confusion during UAT; the footer should reflect the current release and be documented as coming from the frontend package metadata.

### Description
- Bumped the frontend package `version` to `0.45.0` in `frontend/package.json` and updated `frontend/package-lock.json`, added a short `Versioning` note in `frontend/README.md` stating the footer reads `frontend/package.json`, and recorded the fix in `CHANGELOG.md` under 0.45.0.

### Testing
- Ran `npm install` in `frontend` (succeeded), started the dev server with `npm run dev` (Vite started and served on port 3000), and executed a small Playwright script to capture the running app which confirmed the footer displays `Version 0.45.0` (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974719893cc8325b5af01391dbfde28)