### PR TITLE
Align random seed checkbox label in Scenario Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and a CLI compatibility test for the demo scenario.
 
 ### Fixed
+- **Scenario Builder**: Add clear selection styling for quick start templates on the Create Scenario screen.
+- **Scenario Builder**: Align the random seed checkbox with its label text on the Create Scenario screen.
 - Update the frontend footer to report the current application version (0.45.0) from the admin UI package metadata.
 - Avoid SpotBugs EI_EXPOSE_REP2 warnings in admin services by using defensive ObjectMapper copies and lazy execution service injection.
 - Handle unexpected IO failures when validating scenario payloads in the admin service.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ A modern React web application provides a user-friendly interface for managing l
   - Search by version number
 - **Scenario Builder**: Create and manage passenger flow scenarios for simulations
   - Build scenarios using template-based quick start or custom flows
+  - Highlight the selected quick start template for clear visual feedback
+  - Align the random seed checkbox with its label text for consistent form layout
   - Define passenger flows with origin, destination, timing, and passenger count
   - Server-side validation with detailed error and warning feedback
   - Advanced JSON editor mode for direct scenario editing

--- a/frontend/src/pages/ScenarioForm.css
+++ b/frontend/src/pages/ScenarioForm.css
@@ -75,6 +75,16 @@
   margin-right: 0.5rem;
 }
 
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkbox-label input[type="checkbox"] {
+  margin: 0;
+}
+
 .required {
   color: #e74c3c;
 }
@@ -106,6 +116,7 @@
   cursor: pointer;
   transition: all 0.2s;
   text-align: left;
+  position: relative;
 }
 
 .template-card:hover {
@@ -113,6 +124,25 @@
   background: #e8f4fd;
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+.template-card.is-selected {
+  border-color: #2ecc71;
+  background: #eafaf1;
+  box-shadow: 0 0 0 2px rgba(46, 204, 113, 0.2);
+}
+
+.template-card.is-selected::after {
+  content: '✓ Selected';
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: #2ecc71;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
 }
 
 .template-name {

--- a/frontend/src/pages/ScenarioForm.jsx
+++ b/frontend/src/pages/ScenarioForm.jsx
@@ -98,6 +98,7 @@ function ScenarioForm() {
   const [alertMessage, setAlertMessage] = useState(null);
   const [showAdvancedJson, setShowAdvancedJson] = useState(false);
   const [jsonText, setJsonText] = useState('');
+  const [selectedTemplateKey, setSelectedTemplateKey] = useState('');
 
   /**
    * Parses version config to extract floor range.
@@ -222,6 +223,7 @@ function ScenarioForm() {
     const template = SCENARIO_TEMPLATES[templateKey];
     if (!template) return;
 
+    setSelectedTemplateKey(templateKey);
     const json = template.scenarioJson;
     setDurationTicks(json.durationTicks);
     setPassengerFlows(json.passengerFlows || []);
@@ -497,8 +499,9 @@ function ScenarioForm() {
                 <button
                   key={key}
                   type="button"
-                  className="template-card"
+                  className={`template-card${selectedTemplateKey === key ? ' is-selected' : ''}`}
                   onClick={() => applyTemplate(key)}
+                  aria-pressed={selectedTemplateKey === key}
                 >
                   <div className="template-name">{template.name}</div>
                   <div className="template-description">{template.description}</div>
@@ -561,14 +564,14 @@ function ScenarioForm() {
 
               {/* Seed */}
               <div className="form-group">
-                <label htmlFor="useSeed">
+                <label htmlFor="useSeed" className="checkbox-label">
                   <input
                     type="checkbox"
                     id="useSeed"
                     checked={useSeed}
                     onChange={(e) => setUseSeed(e.target.checked)}
                   />
-                  {' '}Use Random Seed (for reproducibility)
+                  Use Random Seed (for reproducibility)
                 </label>
               </div>
 


### PR DESCRIPTION
### Motivation
- Fix a visual alignment bug where the "Use Random Seed (for reproducibility)" checkbox was vertically misaligned with its label on the Create New Scenario screen.
- Improve overall form consistency and match other checkbox controls in the Scenario builder UI.

### Description
- Add a dedicated `checkbox-label` class to the seed checkbox label in `frontend/src/pages/ScenarioForm.jsx` and remove the stray whitespace to ensure consistent inline content layout.
- Add CSS rules in `frontend/src/pages/ScenarioForm.css` to make `.checkbox-label` a flex container with `align-items: center` and to normalize checkbox margin, and include template-selection styling (`.template-card.is-selected`) for visual feedback.
- Introduce `selectedTemplateKey` state and expose selection state/`aria-pressed` on template buttons in `frontend/src/pages/ScenarioForm.jsx` to preserve and announce quick-start template selection.
- Document the UI fix in `README.md` and record the change in `CHANGELOG.md` under the fixed list for 0.45.0.

### Testing
- Started the frontend dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 3000`, and Vite reported ready and serving on port 3000 (success).
- Ran a Playwright script that loaded `http://localhost:3000/scenarios/new` and captured a screenshot at `artifacts/random-seed-checkbox-alignment.png` to verify checkbox alignment (screenshot saved successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974c4ffadd88325877755d4bffbb263)