### PR TITLE
Remove simulation_scenario compatibility view and align docs to `scenario` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Simulator Landing**: Clear version options when loading versions fails to prevent mismatched selections.
 - Add database-level ON DELETE CASCADE constraint to SimulationRun foreign keys (lift_system_id and version_id) via Hibernate's @OnDelete annotation. This ensures SimulationRun records are automatically deleted when their parent LiftSystem or LiftSystemVersion is deleted, matching the existing database schema and preventing constraint violations.
 - Align the "Use Random Seed (for reproducibility)" checkbox with its label on the Create Scenario screen.
+- Align README schema/entity references to the `scenario` table after legacy `simulation_scenario` removal.
 
 ## [0.44.0] - 2026-01-20
 

--- a/README.md
+++ b/README.md
@@ -2366,7 +2366,7 @@ The schema includes the following tables:
 - `lift_simulator.flyway_schema_history` - Flyway migration tracking (auto-created)
 - `lift_system` - Lift system configuration roots
 - `lift_system_version` - Versioned lift configuration payloads (JSONB)
-- `simulation_scenario` - Reusable test scenarios with JSON configuration (V3)
+- `scenario` - Reusable test scenarios with JSON configuration (V3)
 - `simulation_run` - Individual simulation run executions with lifecycle tracking (V3)
 
 The `simulation_run` table tracks run status (CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED) and maintains referential integrity with lift systems and versions for persistent run lifecycle management.
@@ -2390,8 +2390,8 @@ The backend includes JPA entities and Spring Data repositories for database acce
   - Version status enum: DRAFT, PUBLISHED, ARCHIVED
   - Helper methods: `publish()`, `archive()`
 
-- **SimulationScenario** (`com.liftsimulator.admin.entity.SimulationScenario`)
-  - Maps to `simulation_scenario` table
+- **Scenario** (`com.liftsimulator.admin.entity.Scenario`)
+  - Maps to `scenario` table
   - Reusable test scenarios for lift system testing
   - **JSONB field mapping**: Stores scenario configuration as JSON
   - Automatic timestamp management via `@PrePersist` and `@PreUpdate`
@@ -2400,7 +2400,7 @@ The backend includes JPA entities and Spring Data repositories for database acce
   - Maps to `simulation_run` table
   - Individual simulation run executions with lifecycle tracking
   - Run status enum: CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED
-  - Relationships: Many-to-one with LiftSystem, LiftSystemVersion, and SimulationScenario
+  - Relationships: Many-to-one with LiftSystem, LiftSystemVersion, and Scenario
   - Status transition methods: `start()`, `succeed()`, `fail()`, `cancel()`
   - Progress tracking via `updateProgress(Long tick)`
 
@@ -2418,7 +2418,7 @@ The backend includes JPA entities and Spring Data repositories for database acce
   - Find by status: `findByStatus(VersionStatus status)`
   - Get max version number: `findMaxVersionNumberByLiftSystemId(Long liftSystemId)`
 
-- **SimulationScenarioRepository** (`com.liftsimulator.admin.repository.SimulationScenarioRepository`)
+- **ScenarioRepository** (`com.liftsimulator.admin.repository.ScenarioRepository`)
   - Find by name: `findByName(String name)`
   - Find by name pattern: `findByNameContainingIgnoreCase(String name)`
   - Check existence: `existsByName(String name)`


### PR DESCRIPTION
### Motivation
- Revert the previously added compatibility view approach because the codebase should be kept in sync with the canonical schema (the `scenario` table) rather than masking mismatches with a read-only view.

### Description
- Reverted and removed the Flyway migration that created the `simulation_scenario` compatibility view and updated repository history to drop that migration file (`V10__add_simulation_scenario_compat_view.sql`).
- Updated `README.md` to replace legacy `simulation_scenario` references with `scenario` and to use `Scenario`/`ScenarioRepository` names that match current JPA mappings.
- Updated `CHANGELOG.md` to note the documentation alignment for the 0.45.0 release and did not change the project version (no SemVer bump required); if missing-table errors persist after deployment, run `mvn clean package` and redeploy to ensure no stale build artifacts remain.

### Testing
- No automated tests were executed because this is a docs-and-migration-revert change (no runtime code changes), so no test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69777c607df48325a72934524d6d37bd)