### PR TITLE
Fix blank Create Scenario regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Scenario Builder**: Add clear selection styling for quick start templates on the Create Scenario screen.
 - **Scenario Builder**: Align the random seed checkbox with its label text on the Create Scenario screen.
+- **Scenario Builder**: Prevent blank page regression when navigating to the Create New Scenario screen.
 - Update the frontend footer to report the current application version (0.45.0) from the admin UI package metadata.
 - Avoid SpotBugs EI_EXPOSE_REP2 warnings in admin services by using defensive ObjectMapper copies and lazy execution service injection.
 - Handle unexpected IO failures when validating scenario payloads in the admin service.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ A modern React web application provides a user-friendly interface for managing l
   - Search by version number
 - **Scenario Builder**: Create and manage passenger flow scenarios for simulations
   - Build scenarios using template-based quick start or custom flows
+  - Navigate directly to the Create Scenario screen at `/scenarios/new` without blank-page regressions
   - Highlight the selected quick start template for clear visual feedback
   - Align the random seed checkbox with its label text for consistent form layout
   - Define passenger flows with origin, destination, timing, and passenger count

--- a/frontend/src/pages/ScenarioForm.jsx
+++ b/frontend/src/pages/ScenarioForm.jsx
@@ -119,40 +119,6 @@ function ScenarioForm() {
     }
   };
 
-  useEffect(() => {
-    loadLiftSystems();
-  }, []);
-
-  useEffect(() => {
-    if (isEditMode) {
-      loadScenario();
-    }
-  }, [id, isEditMode, loadScenario]);
-
-  useEffect(() => {
-    if (selectedSystemId) {
-      loadVersions(selectedSystemId);
-    } else {
-      setVersions([]);
-      setSelectedVersionId('');
-      setFloorRange(null);
-    }
-  }, [selectedSystemId]);
-
-  useEffect(() => {
-    if (selectedVersionId && versions.length > 0) {
-      const selectedVersion = versions.find(v => v.id === parseInt(selectedVersionId, 10));
-      if (selectedVersion) {
-        const floorInfo = parseVersionConfig(selectedVersion.config);
-        setFloorRange(floorInfo);
-      } else {
-        setFloorRange(null);
-      }
-    } else {
-      setFloorRange(null);
-    }
-  }, [selectedVersionId, versions]);
-
   /**
    * Loads all lift systems.
    */
@@ -213,6 +179,40 @@ function ScenarioForm() {
       setLoading(false);
     }
   }, [id]);
+
+  useEffect(() => {
+    loadLiftSystems();
+  }, []);
+
+  useEffect(() => {
+    if (isEditMode) {
+      loadScenario();
+    }
+  }, [id, isEditMode, loadScenario]);
+
+  useEffect(() => {
+    if (selectedSystemId) {
+      loadVersions(selectedSystemId);
+    } else {
+      setVersions([]);
+      setSelectedVersionId('');
+      setFloorRange(null);
+    }
+  }, [selectedSystemId]);
+
+  useEffect(() => {
+    if (selectedVersionId && versions.length > 0) {
+      const selectedVersion = versions.find(v => v.id === parseInt(selectedVersionId, 10));
+      if (selectedVersion) {
+        const floorInfo = parseVersionConfig(selectedVersion.config);
+        setFloorRange(floorInfo);
+      } else {
+        setFloorRange(null);
+      }
+    } else {
+      setFloorRange(null);
+    }
+  }, [selectedVersionId, versions]);
 
   /**
    * Adapts passenger flows to fit within the valid floor range.


### PR DESCRIPTION
### Motivation
- Prevent the Create New Scenario route from rendering a blank page by ensuring the `loadScenario` callback is defined before effects run so the form initializes reliably when navigating to `/scenarios/new`.

### Description
- Reordered initialization in `frontend/src/pages/ScenarioForm.jsx` so `loadScenario` is declared before the `useEffect` hooks that invoke loading and version selection, and re-added the related `useEffect` blocks to run after the callback is available.
- Documented the regression fix in `CHANGELOG.md` and added a short note in `README.md` about stable navigation to the Create Scenario screen.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778f1964e88325a0388188b12abcea)