### PR TITLE
Add polling for active simulation runs and improve configuration updates

### DIFF
--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -325,20 +325,27 @@ public class SimulationRunService {
 
     /**
      * Set configuration for a run before starting.
+     * Only updates non-null values, preserving existing configuration.
      *
      * @param id the run id
-     * @param totalTicks total number of ticks for the simulation
-     * @param seed random seed for reproducibility
-     * @param artefactBasePath base path for output artefacts
+     * @param totalTicks total number of ticks for the simulation (null to keep existing)
+     * @param seed random seed for reproducibility (null to keep existing)
+     * @param artefactBasePath base path for output artefacts (null to keep existing)
      * @return the updated run
      * @throws ResourceNotFoundException if the run is not found
      */
     @Transactional
     public SimulationRun configureRun(Long id, Long totalTicks, Long seed, String artefactBasePath) {
         SimulationRun run = getRunById(id);
-        run.setTotalTicks(totalTicks);
-        run.setSeed(seed);
-        run.setArtefactBasePath(artefactBasePath);
+        if (totalTicks != null) {
+            run.setTotalTicks(totalTicks);
+        }
+        if (seed != null) {
+            run.setSeed(seed);
+        }
+        if (artefactBasePath != null) {
+            run.setArtefactBasePath(artefactBasePath);
+        }
         return runRepository.save(run);
     }
 

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -351,6 +351,50 @@ public class SimulationRunServiceTest {
     }
 
     @Test
+    public void testConfigureRun_PreservesExistingValuesWhenNullPassed() {
+        // Set up a run with existing configuration
+        mockRun.setTotalTicks(5000L);
+        mockRun.setSeed(99999L);
+        mockRun.setArtefactBasePath("/original/path");
+        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Configure with only artefactBasePath, keeping other values null
+        SimulationRun result = runService.configureRun(1L, null, null, "/new/path");
+
+        assertNotNull(result);
+        // Existing values should be preserved
+        assertEquals(5000L, result.getTotalTicks());
+        assertEquals(99999L, result.getSeed());
+        // New value should be updated
+        assertEquals("/new/path", result.getArtefactBasePath());
+        verify(runRepository).findById(1L);
+        verify(runRepository).save(any(SimulationRun.class));
+    }
+
+    @Test
+    public void testConfigureRun_PartialUpdate() {
+        // Set up a run with existing configuration
+        mockRun.setTotalTicks(5000L);
+        mockRun.setSeed(99999L);
+        mockRun.setArtefactBasePath("/original/path");
+        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Update only totalTicks, keeping seed null
+        SimulationRun result = runService.configureRun(1L, 10000L, null, null);
+
+        assertNotNull(result);
+        // New value should be updated
+        assertEquals(10000L, result.getTotalTicks());
+        // Existing values should be preserved
+        assertEquals(99999L, result.getSeed());
+        assertEquals("/original/path", result.getArtefactBasePath());
+        verify(runRepository).findById(1L);
+        verify(runRepository).save(any(SimulationRun.class));
+    }
+
+    @Test
     public void testDeleteRun_Success() {
         when(runRepository.existsById(1L)).thenReturn(true);
 


### PR DESCRIPTION
## Summary
This PR enhances the simulation runs feature with automatic polling for active runs and improves the configuration API to support partial updates.

## Key Changes

### Frontend (SimulationRuns.jsx)
- **Added polling mechanism**: Automatically polls for updates every 3 seconds when there are active runs (status: RUNNING or CREATED)
- **Optimized loading state**: Polling requests no longer trigger the loading spinner, only initial loads do
- **Added useMemo hook**: Efficiently tracks whether any runs are currently active
- **Improved UX**: Users now see real-time updates for in-progress simulations without manual refresh

### Backend (SimulationRunService.java)
- **Enhanced configureRun method**: Now supports partial updates by only modifying non-null values
- **Preserved backward compatibility**: Existing configuration values are maintained when null is passed
- **Updated documentation**: Clarified that null values preserve existing configuration

### Tests (SimulationRunServiceTest.java)
- **Added comprehensive test coverage**: Two new test cases verify the partial update behavior
  - `testConfigureRun_PreservesExistingValuesWhenNullPassed`: Validates that existing values are preserved when null is passed
  - `testConfigureRun_PartialUpdate`: Ensures selective field updates work correctly

## Implementation Details
- The polling interval is set to 3 seconds for responsive updates
- Active status detection uses a Set for O(1) lookup performance
- The polling effect properly cleans up intervals to prevent memory leaks
- Null-safe configuration updates allow flexible API usage without overwriting unspecified fields

https://claude.ai/code/session_01AhtNLP2AYY4DxC8RjuvYf1