### PR TITLE
Fix UI hang when clicking Start Run multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add database-level ON DELETE CASCADE constraint to SimulationRun foreign keys (lift_system_id and version_id) via Hibernate's @OnDelete annotation. This ensures SimulationRun records are automatically deleted when their parent LiftSystem or LiftSystemVersion is deleted, matching the existing database schema and preventing constraint violations.
 - Align the "Use Random Seed (for reproducibility)" checkbox with its label on the Create Scenario screen.
 - Align README schema/entity references to the `scenario` table after legacy `simulation_scenario` removal.
+- **Run Simulator**: Fixed UI hang when clicking Start Run multiple times before a previous run completes. The Start Run button is now disabled while a run is in progress (RUNNING or CREATED status), preventing duplicate run requests and state conflicts. Button text changes to "Run in Progress" and a hint message guides users to wait for completion or cancel the current run before starting a new one.
 
 ## [0.44.0] - 2026-01-20
 

--- a/frontend/src/pages/Simulator.css
+++ b/frontend/src/pages/Simulator.css
@@ -60,6 +60,15 @@
   color: #374151;
 }
 
+.run-in-progress-hint {
+  color: #0369a1;
+  background: #e0f2fe;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  display: block;
+}
+
 .status-header {
   display: flex;
   align-items: center;

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -477,18 +477,24 @@ function Simulator() {
                 onClick={handleStartRun}
                 disabled={
                   isStarting ||
+                  (runInfo && !isTerminal) ||
                   !selectedSystemId ||
                   !selectedVersionId ||
                   !selectedScenarioId
                 }
               >
-                {isStarting ? 'Starting...' : 'Start Run'}
+                {isStarting ? 'Starting...' : (runInfo && !isTerminal) ? 'Run in Progress' : 'Start Run'}
               </button>
               {selectedSystem && selectedVersion && selectedScenario && (
                 <div className="selection-summary">
                   <strong>Selected:</strong> {selectedSystem.displayName} · Version{' '}
                   {selectedVersion.versionNumber} · {selectedScenario.name}
                 </div>
+              )}
+              {runInfo && !isTerminal && (
+                <small className="run-in-progress-hint">
+                  A simulation run is in progress. Wait for it to complete or cancel it to start a new run.
+                </small>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
Fixed a UI hang issue in the Run Simulator page that occurred when users clicked the "Start Run" button multiple times before a previous simulation run completed. The Start Run button is now properly disabled during active runs, preventing duplicate run requests and state conflicts.

## Changes Made
- **Button State Management**: The Start Run button is now disabled when a run is in RUNNING or CREATED status, in addition to the existing checks for required selections and the starting state
- **Dynamic Button Text**: Button text changes to "Run in Progress" when a simulation is actively running, providing clear visual feedback to users
- **User Guidance**: Added a hint message below the button that appears during active runs, instructing users to wait for completion or cancel the current run before starting a new one
- **Styling**: Added `.run-in-progress-hint` CSS class with a light blue background and appropriate padding for the informational message
- **Documentation**: Updated CHANGELOG.md to document this fix

## Implementation Details
- The disable condition now checks `(runInfo && !isTerminal)` to prevent button clicks while a run is in progress
- The hint message uses the same condition to display contextual help text
- The solution leverages existing `runInfo` state and `isTerminal` helper to determine run status
- All changes are backward compatible and don't affect the existing run completion flow

https://claude.ai/code/session_01LQryBmWo93XbWhGVHvTK1h