### PR TITLE
Fix simulation progress updates in async contexts with REQUIRES_NEW

### DIFF
--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -329,13 +329,14 @@ public class SimulationRunServiceTest {
     @Test
     public void testUpdateProgress_Success() {
         when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
-        when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
+        when(runRepository.saveAndFlush(any(SimulationRun.class))).thenReturn(mockRun);
 
         SimulationRun result = runService.updateProgress(1L, 500L);
 
         assertNotNull(result);
+        assertEquals(500L, mockRun.getCurrentTick());
         verify(runRepository).findById(1L);
-        verify(runRepository).save(any(SimulationRun.class));
+        verify(runRepository).saveAndFlush(any(SimulationRun.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR fixes an issue with simulation progress updates when called from async threads by changing the transaction propagation strategy and ensuring immediate database visibility.

## Key Changes
- Changed `updateProgress()` method's `@Transactional` annotation to use `Propagation.REQUIRES_NEW` to ensure a fresh transaction is created for each call, which is critical when invoked from async threads
- Replaced `runRepository.save()` with `runRepository.saveAndFlush()` to ensure updates are immediately written to the database, making them visible to other transactions (e.g., polling requests)
- Simplified progress update logic by directly calling `run.setCurrentTick()` instead of `run.updateProgress()`
- Updated corresponding unit test to verify the new behavior with `saveAndFlush()` and added assertion to confirm the current tick is properly set

## Implementation Details
The `REQUIRES_NEW` propagation ensures that each progress update gets its own transaction context, preventing issues where async threads might inherit or conflict with parent transaction contexts. Combined with `saveAndFlush()`, this guarantees that progress updates are immediately persisted and visible to concurrent polling requests, improving the responsiveness and reliability of the simulation progress tracking system.

https://claude.ai/code/session_01525Hn5ePTvvffyDNP6cEc4