### PR TITLE
Fix simulation progress reporting and restore docs to 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
 ## [0.45.0] - 2026-02-01
 
 ### Added
@@ -97,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Run Simulator Artefacts**: Added a dedicated artefact download endpoint with secure path validation and improved UI error feedback when downloads fail.
+- Ensure simulation run progress ticks update during execution so the UI progress bar and tick counter advance while runs are active.
 - **Run Simulator**: Fixed scenario dropdown to only show scenarios belonging to the selected Lift System Version. Previously, all scenarios were shown regardless of version compatibility, leading to backend validation errors when incompatible scenarios were selected. The dropdown now filters scenarios by `liftSystemVersionId` and automatically clears the selection when switching to a version that doesn't have the currently selected scenario. Added helpful messages when no version is selected or no scenarios are available for the selected version.
 - **Scenario Builder - Advanced JSON Mode**: Fixed critical bug where updates made in Advanced JSON Mode were not persisted after clicking "Validate" then "Update Scenario". The form state was not synchronized with the JSON text editor, causing old values to be sent to the backend. Now `buildScenarioJson()` correctly parses the JSON text when in Advanced JSON Mode, and both validate and save operations sync the parsed JSON back to form state for consistency.
 - **Scenario Builder**: Add clear selection styling for quick start templates on the Create Scenario screen.

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -296,12 +296,13 @@ public class SimulationRunExecutionService {
             engine.tick();
             metrics.recordTerminalRequests(currentTick);
 
+            long progressTick = tick + 1L;
             if (tick % PROGRESS_UPDATE_INTERVAL == 0) {
-                runService.updateProgress(runId, engine.getCurrentTick());
+                runService.updateProgress(runId, progressTick);
             }
         }
 
-        runService.updateProgress(runId, engine.getCurrentTick());
+        runService.updateProgress(runId, (long) scenario.durationTicks());
         log(logWriter, "Simulation completed at tick " + engine.getCurrentTick());
         metrics.recordTerminalRequests(engine.getCurrentTick());
         return metrics;


### PR DESCRIPTION
### Motivation
- Ensure the frontend receives advancing tick values during a simulation run so the UI progress bar and tick counter advance while runs are active.
- Keep project documentation and changelog versioning consistent by retaining `0.45.0` as the current version and placing the progress-fix note under that entry.

### Description
- Report a deterministic progress tick inside the simulation loop by computing `progressTick = tick + 1` and calling `runService.updateProgress(runId, progressTick)` at `PROGRESS_UPDATE_INTERVAL` boundaries in `SimulationRunExecutionService.runSimulation(...)`.
- Ensure final progress is set to the scenario duration by calling `runService.updateProgress(runId, (long) scenario.durationTicks())` after the simulation loop completes.
- Move the changelog entry for the progress update under the `0.45.0` `Fixed` section and remove the separate `0.45.1` heading.
- Revert the `README.md` `Current version:` string back to `0.45.0`.

### Testing
- No automated tests were run for these documentation and service-reporting changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c116ad2f48325a364f36ad7a19caf)