### PR TITLE
Add API key authentication for runtime and simulation endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-02-15
+
+### Added
+- API key authentication for runtime configuration and simulation execution endpoints, including configurable header and environment-backed key support.
+
 ## [0.45.0] - 2026-02-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.45.0**
+Current version: **0.46.0**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history.
 
@@ -267,7 +267,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.45.0.jar
+java -jar target/lift-simulator-0.46.0.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api`.
@@ -288,7 +288,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.45.0.jar
+java -jar target/lift-simulator-0.46.0.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -839,7 +839,7 @@ All lift system configurations must conform to the following structure:
 }
 ```
 
-**Migration Guide (0.45.0 floor range update):**
+**Migration Guide (0.46.0 floor range update):**
 
 - Replace `floors` with explicit `minFloor` and `maxFloor`.
   - For existing configs, set `minFloor` to `0` and `maxFloor` to `floors - 1`.
@@ -902,6 +902,39 @@ When configuration validation fails:
 }
 ```
 
+#### API Key Authentication (Runtime & Simulation Execution)
+
+Runtime and simulation execution endpoints require an API key so they can be invoked from CLI tooling and automation.
+
+**Configuration:**
+- `api.auth.key` (required): API key value used for authentication
+- `api.auth.header` (optional, default: `X-API-Key`): Header name to read the key from
+
+You can configure the key via environment variables or `application.properties`:
+
+```properties
+api.auth.key=replace-with-secure-key
+api.auth.header=X-API-Key
+```
+
+```bash
+export API_AUTH_KEY="replace-with-secure-key"
+```
+
+**Example (Simulation Run):**
+```bash
+curl -H "X-API-Key: replace-with-secure-key" \\
+  -H "Content-Type: application/json" \\
+  -d '{"liftSystemId":1,"versionId":2,"scenarioId":3,"seed":12345}' \\
+  http://localhost:8080/api/simulation-runs
+```
+
+**Example (Runtime Config):**
+```bash
+curl -H "X-API-Key: replace-with-secure-key" \\
+  http://localhost:8080/api/runtime/systems/{systemKey}/config
+```
+
 
 #### Simulation Run APIs
 
@@ -923,6 +956,7 @@ The Simulation Run APIs enable UI to start simulations, poll their status, and a
 **Endpoint:** `POST /api/simulation-runs`
 
 Creates a new simulation run, sets up the artefact directory, and immediately starts execution.
+All simulation run endpoints require the configured API key header.
 
 **Request Body:**
 ```json
@@ -1266,7 +1300,7 @@ This section documents how to run simulations using both the command-line interf
 The Lift Simulator supports two primary workflows:
 
 1. **CLI Workflow (Backward Compatible)**: Run simulations directly from the command line using scenario files
-2. **UI-Driven Workflow (New in v0.45.0)**: Run simulations through the web interface with Version + Scenario selection
+2. **UI-Driven Workflow (New in v0.46.0)**: Run simulations through the web interface with Version + Scenario selection
 
 Both workflows produce the same simulation results and use the same underlying simulation engine.
 
@@ -1287,7 +1321,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -1301,12 +1335,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -1345,7 +1379,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -1358,7 +1392,7 @@ java -cp target/lift-simulator-0.45.0.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -1369,7 +1403,7 @@ java -cp target/lift-simulator-0.45.0.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -1382,7 +1416,7 @@ java -cp target/lift-simulator-0.45.0.jar \
 
 ---
 
-##### UI-Driven Run Workflow (New in v0.45.0)
+##### UI-Driven Run Workflow (New in v0.46.0)
 
 The web UI provides a streamlined workflow for running simulations with managed configurations and scenarios.
 
@@ -1643,7 +1677,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.45.0.jar \
+   java -cp target/lift-simulator-0.46.0.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -1688,7 +1722,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -1780,7 +1814,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar \
+java -cp target/lift-simulator-0.46.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```
@@ -2116,6 +2150,13 @@ seed must be a valid integer
 #### Runtime Configuration API
 
 The backend provides dedicated runtime APIs for retrieving published configurations. These APIs are read-only and return only configurations with `PUBLISHED` status.
+Runtime endpoints require the configured API key header (default `X-API-Key`).
+
+Example:
+```bash
+curl -H "X-API-Key: replace-with-secure-key" \\
+  http://localhost:8080/api/runtime/systems/building-a-lifts/config
+```
 
 - **Get Published Configuration**: `GET /api/runtime/systems/{systemKey}/config`
   - Retrieves the currently published configuration for a lift system by system key
@@ -2509,7 +2550,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.45.0.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.46.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -2754,7 +2795,7 @@ dropdb lift_simulator_test
 
 ## Features
 
-The current version (v0.45.0) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.46.0) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -2949,7 +2990,7 @@ To build a JAR package:
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.45.0.jar`.
+The packaged JAR will be in `target/lift-simulator-0.46.0.jar`.
 
 ## Running Tests
 
@@ -3003,7 +3044,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -3012,16 +3053,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -3035,7 +3076,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -3053,7 +3094,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -3062,13 +3103,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.45.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.46.0.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/docs/decisions/0018-api-key-authentication-runtime-simulation.md
+++ b/docs/decisions/0018-api-key-authentication-runtime-simulation.md
@@ -1,0 +1,36 @@
+# ADR-0018: API Key Authentication for Runtime & Simulation Execution
+
+**Date**: 2026-02-15
+
+**Status**: Accepted
+
+## Context
+
+Runtime configuration endpoints and simulation execution APIs are designed for non-interactive use
+cases (CLI tools, automation, and backend-to-backend integrations). These endpoints previously
+accepted unauthenticated requests, which is incompatible with the security posture expected for
+production runtime consumption and automated execution.
+
+We need a lightweight authentication mechanism that:
+- Works for CLI and automation use cases.
+- Does not require full user/session management.
+- Can be configured via application config or environment variables.
+- Avoids logging or leaking secrets.
+
+## Decision
+
+Introduce API key authentication for:
+- Runtime configuration APIs (`/api/runtime/**`)
+- Simulation execution APIs (`/api/simulation-runs/**`)
+
+Key characteristics:
+- API key is configured via `api.auth.key` (with environment variable support).
+- Header name is configurable via `api.auth.header` (default: `X-API-Key`).
+- Missing or invalid keys return HTTP 401.
+- The key value is never logged.
+
+## Consequences
+
+- Runtime and simulation execution clients must include the configured API key header.
+- Automated tooling can authenticate without interactive login flows.
+- Admin endpoints remain unaffected, preserving existing admin workflows.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.45.0</version>
+    <version>0.46.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/security/ApiKeyAuthConfiguration.java
+++ b/src/main/java/com/liftsimulator/admin/security/ApiKeyAuthConfiguration.java
@@ -1,0 +1,31 @@
+package com.liftsimulator.admin.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Registers API key authentication for runtime and simulation execution endpoints.
+ */
+@Configuration
+public class ApiKeyAuthConfiguration {
+
+    @Bean
+    public FilterRegistrationBean<ApiKeyAuthFilter> apiKeyAuthFilter(
+            @Value("${api.auth.key:}") String apiKey,
+            @Value("${api.auth.header:X-API-Key}") String headerName) {
+        FilterRegistrationBean<ApiKeyAuthFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new ApiKeyAuthFilter(apiKey, headerName));
+        registration.addUrlPatterns(
+                "/api/runtime/*",
+                "/api/runtime/*/*",
+                "/api/runtime/*/*/*",
+                "/api/runtime/*/*/*/*",
+                "/api/simulation-runs",
+                "/api/simulation-runs/*",
+                "/api/simulation-runs/*/*");
+        registration.setOrder(1);
+        return registration;
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/security/ApiKeyAuthFilter.java
+++ b/src/main/java/com/liftsimulator/admin/security/ApiKeyAuthFilter.java
@@ -1,0 +1,49 @@
+package com.liftsimulator.admin.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Enforces API key authentication for runtime and simulation execution endpoints.
+ */
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+    public static final String DEFAULT_HEADER = "X-API-Key";
+
+    private final String apiKey;
+    private final String headerName;
+
+    public ApiKeyAuthFilter(String apiKey) {
+        this(apiKey, DEFAULT_HEADER);
+    }
+
+    public ApiKeyAuthFilter(String apiKey, String headerName) {
+        this.apiKey = apiKey;
+        this.headerName = headerName;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        if (apiKey == null || apiKey.isBlank()) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "API key is not configured");
+            return;
+        }
+
+        String providedKey = request.getHeader(headerName);
+        if (providedKey == null || !providedKey.equals(apiKey)) {
+            response.sendError(HttpStatus.UNAUTHORIZED.value(), "Invalid API key");
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,3 +25,7 @@ management.health.defaults.enabled=true
 
 # Simulation Configuration
 simulation.artefacts.base-path=./simulation-runs
+
+# API Authentication (runtime/simulation execution)
+api.auth.key=
+api.auth.header=X-API-Key

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -37,6 +37,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 public class SimulationRunControllerTest extends LocalIntegrationTest {
 
+    private static final String API_KEY_HEADER = "X-API-Key";
+    private static final String API_KEY_VALUE = "test-api-key";
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -98,6 +101,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         );
 
         mockMvc.perform(post("/api/simulation-runs")
+                .header(API_KEY_HEADER, API_KEY_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
@@ -120,6 +124,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         );
 
         mockMvc.perform(post("/api/simulation-runs")
+                .header(API_KEY_HEADER, API_KEY_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isNotFound())
@@ -131,6 +136,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         String invalidRequest = "{}";
 
         mockMvc.perform(post("/api/simulation-runs")
+                .header(API_KEY_HEADER, API_KEY_VALUE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(invalidRequest))
             .andExpect(status().isBadRequest());
@@ -141,7 +147,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         SimulationRun run = new SimulationRun(testSystem, testVersion);
         run = runRepository.save(run);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId()))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId())
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(run.getId()))
             .andExpect(jsonPath("$.liftSystemId").value(testSystem.getId()))
@@ -151,7 +158,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
 
     @Test
     public void testGetSimulationRun_NotFound() throws Exception {
-        mockMvc.perform(get("/api/simulation-runs/999"))
+        mockMvc.perform(get("/api/simulation-runs/999")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message").value("Simulation run not found with id: 999"));
     }
@@ -162,7 +170,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         run.start();
         run = runRepository.save(run);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isConflict())
             .andExpect(jsonPath("$.runId").value(run.getId()))
             .andExpect(jsonPath("$.status").value("RUNNING"))
@@ -176,7 +185,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         run.fail("Test error message");
         run = runRepository.save(run);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.runId").value(run.getId()))
             .andExpect(jsonPath("$.status").value("FAILED"))
@@ -189,7 +199,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         SimulationRun run = new SimulationRun(testSystem, testVersion);
         run = runRepository.save(run);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.status").value("CREATED"));
     }
@@ -208,7 +219,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         Path resultsFile = artefactDir.resolve("results.json");
         Files.writeString(resultsFile, "{\"totalPassengersServed\": 100, \"averageWaitTime\": 15.5}");
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.runId").value(run.getId()))
             .andExpect(jsonPath("$.status").value("SUCCEEDED"))
@@ -230,7 +242,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         Path artefactDir = Paths.get(run.getArtefactBasePath());
         Files.createDirectories(artefactDir);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/results")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.runId").value(run.getId()))
             .andExpect(jsonPath("$.status").value("SUCCEEDED"))
@@ -244,7 +257,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         SimulationRun run = new SimulationRun(testSystem, testVersion);
         run = runRepository.save(run);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/logs"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/logs")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isInternalServerError())
             .andExpect(jsonPath("$.error").value("Failed to read logs: Artefact base path is not set for run "
                     + run.getId()));
@@ -262,7 +276,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         Path logFile = artefactDir.resolve("simulation.log");
         Files.writeString(logFile, "Line 1\nLine 2\nLine 3\n");
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/logs?tail=2"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/logs?tail=2")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.runId").value(run.getId().toString()))
             .andExpect(jsonPath("$.logs").value("Line 2\nLine 3"))
@@ -278,7 +293,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         // Create empty artefact directory
         Files.createDirectories(Paths.get(run.getArtefactBasePath()));
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
             .andExpect(jsonPath("$.length()").value(0));
@@ -296,7 +312,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         Files.writeString(artefactDir.resolve("results.json"), "{\"test\": \"data\"}");
         Files.writeString(artefactDir.resolve("simulation.log"), "Log content");
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").isArray())
             .andExpect(jsonPath("$.length()").value(2));
@@ -313,7 +330,8 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         Path resultsFile = artefactDir.resolve("results.json");
         Files.writeString(resultsFile, "{\"ok\": true}");
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts/results.json"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts/results.json")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isOk())
             .andExpect(header().string("Content-Disposition", "attachment; filename=\"results.json\""))
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -329,8 +347,22 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
         Path artefactDir = Paths.get(run.getArtefactBasePath());
         Files.createDirectories(artefactDir);
 
-        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts/missing.json"))
+        mockMvc.perform(get("/api/simulation-runs/" + run.getId() + "/artefacts/missing.json")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message").value("Artefact not found: missing.json"));
+    }
+
+    @Test
+    public void testSimulationRunEndpoints_RequiresApiKey() throws Exception {
+        mockMvc.perform(get("/api/simulation-runs"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    public void testSimulationRunEndpoints_InvalidApiKey() throws Exception {
+        mockMvc.perform(get("/api/simulation-runs")
+                .header(API_KEY_HEADER, "invalid-key"))
+            .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -41,6 +41,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest {
 
+    private static final String API_KEY_HEADER = "X-API-Key";
+    private static final String API_KEY_VALUE = "test-api-key";
+
     @TempDir
     static Path artefactsRoot;
 
@@ -98,6 +101,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
         );
 
         MvcResult createResult = mockMvc.perform(post("/api/simulation-runs")
+                        .header(API_KEY_HEADER, API_KEY_VALUE)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -134,7 +138,8 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
 
         boolean completed = false;
         for (int i = 0; i < 20; i++) {
-            MvcResult pollResult = mockMvc.perform(get("/api/simulation-runs/" + runId))
+            MvcResult pollResult = mockMvc.perform(get("/api/simulation-runs/" + runId)
+                    .header(API_KEY_HEADER, API_KEY_VALUE))
                     .andExpect(status().isOk())
                     .andReturn();
             JsonNode pollJson = objectMapper.readTree(pollResult.getResponse().getContentAsString());
@@ -149,7 +154,8 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
 
         assertTrue(completed, "Run should reach SUCCEEDED status while polling");
 
-        mockMvc.perform(get("/api/simulation-runs/" + runId + "/results"))
+        mockMvc.perform(get("/api/simulation-runs/" + runId + "/results")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("SUCCEEDED"))
                 .andExpect(jsonPath("$.results.runSummary.status").value("SUCCEEDED"))

--- a/src/test/java/com/liftsimulator/runtime/controller/RuntimeConfigControllerAuthTest.java
+++ b/src/test/java/com/liftsimulator/runtime/controller/RuntimeConfigControllerAuthTest.java
@@ -1,0 +1,78 @@
+package com.liftsimulator.runtime.controller;
+
+import com.liftsimulator.runtime.dto.RuntimeConfigDTO;
+import com.liftsimulator.runtime.dto.SimulationLaunchResponse;
+import com.liftsimulator.runtime.service.RuntimeConfigService;
+import com.liftsimulator.runtime.service.RuntimeSimulationService;
+import com.liftsimulator.admin.security.ApiKeyAuthConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RuntimeConfigController.class)
+@Import(ApiKeyAuthConfiguration.class)
+@TestPropertySource(properties = {
+        "api.auth.key=test-api-key",
+        "api.auth.header=X-API-Key"
+})
+class RuntimeConfigControllerAuthTest {
+
+    private static final String API_KEY_HEADER = "X-API-Key";
+    private static final String API_KEY_VALUE = "test-api-key";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RuntimeConfigService runtimeConfigService;
+
+    @MockBean
+    private RuntimeSimulationService runtimeSimulationService;
+
+    @Test
+    void runtimeEndpointsRequireApiKey() throws Exception {
+        mockMvc.perform(get("/api/runtime/systems/test-system/config"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void runtimeEndpointsAcceptValidApiKey() throws Exception {
+        when(runtimeConfigService.getPublishedConfig("test-system"))
+                .thenReturn(new RuntimeConfigDTO(
+                        "test-system",
+                        "Test System",
+                        2,
+                        "{\"minFloor\":0,\"maxFloor\":10}",
+                        OffsetDateTime.parse("2026-02-10T12:00:00Z")));
+
+        mockMvc.perform(get("/api/runtime/systems/test-system/config")
+                        .header(API_KEY_HEADER, API_KEY_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.systemKey").value("test-system"))
+                .andExpect(jsonPath("$.versionNumber").value(2));
+    }
+
+    @Test
+    void simulateEndpointAcceptsValidApiKey() throws Exception {
+        when(runtimeSimulationService.launchPublishedSimulation("test-system"))
+                .thenReturn(new SimulationLaunchResponse(true, "started", 42L));
+
+        mockMvc.perform(post("/api/runtime/systems/test-system/simulate")
+                        .header(API_KEY_HEADER, API_KEY_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.processId").value(42));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,3 +33,8 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+api:
+  auth:
+    key: test-api-key
+    header: X-API-Key


### PR DESCRIPTION
### Motivation
- Protect runtime configuration and simulation execution endpoints so they can be safely invoked non-interactively (CLI, automation) without exposing admin APIs.
- Make the API key configurable via environment or application configuration and ensure missing/invalid keys return HTTP 401.
- Keep the authentication mechanism lightweight for automation use and avoid logging or exposing the secret value.

### Description
- Add a servlet filter `ApiKeyAuthFilter` and registration `ApiKeyAuthConfiguration` under `com.liftsimulator.admin.security` to validate a configurable API key header for ` /api/runtime/**` and `/api/simulation-runs/**` requests.
- Introduce configurable properties `api.auth.key` and `api.auth.header` in `src/main/resources/application.properties` (and test configuration), and wire the filter to read those values via `@Value`.
- Update tests to exercise the auth behavior: integration tests in `SimulationRunControllerTest` and `SimulationRunLifecycleIntegrationTest` now include the API key header, and a new `RuntimeConfigControllerAuthTest` (`WebMvcTest`) verifies unauthorized and authorized flows.
- Document usage and examples in `README.md`, add ADR `docs/decisions/0018-api-key-authentication-runtime-simulation.md`, add a `0.46.0` entry to `CHANGELOG.md`, and bump project `pom.xml` and README version references to `0.46.0`.

### Testing
- Updated integration tests `src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java` and `SimulationRunLifecycleIntegrationTest.java` to send the header `X-API-Key: test-api-key` and added authentication assertions, and added `src/test/java/com/liftsimulator/runtime/controller/RuntimeConfigControllerAuthTest.java` for runtime endpoint auth checks; these tests verify both missing/invalid and valid-key cases (added/modified but not executed here).
- Test configuration was updated in `src/test/resources/application-test.yml` to set `api.auth.key=test-api-key` so CI/local runs will provide the key.
- No automated test suite was executed as part of this change from this environment (tests were added/updated and are expected to pass when run in CI or locally with the test DB and environment configured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e67db673483259a965718450dd9ce)