### PR TITLE
Refactor API key configuration from security to api.auth namespace

### DIFF
--- a/src/main/java/com/liftsimulator/admin/config/SecurityConfig.java
+++ b/src/main/java/com/liftsimulator/admin/config/SecurityConfig.java
@@ -93,7 +93,7 @@ public class SecurityConfig {
     @Value("${security.admin.password:}")
     private String adminPassword;
 
-    @Value("${security.api-key:}")
+    @Value("${api.auth.key:}")
     private String apiKey;
 
     @Value("${api.auth.header:X-API-Key}")

--- a/src/main/resources/application-dev.yml.template
+++ b/src/main/resources/application-dev.yml.template
@@ -72,8 +72,17 @@ logging:
     org.flywaydb: INFO
     com.zaxxer.hikari: INFO
 
+# API Authentication (runtime/simulation execution)
+# API key for runtime endpoint authentication (X-API-Key header)
+# REQUIRED: Generate a secure random key (e.g., openssl rand -hex 32)
+# Override with: API_KEY environment variable
+api:
+  auth:
+    key: ${API_KEY:CHANGE_ME}
+    header: X-API-Key
+
 # Security Configuration
-# Override with environment variables: ADMIN_USERNAME, ADMIN_PASSWORD, API_KEY
+# Override with environment variables: ADMIN_USERNAME, ADMIN_PASSWORD
 security:
   admin:
     # Admin username for HTTP Basic authentication
@@ -84,11 +93,6 @@ security:
     # REQUIRED: Replace 'CHANGE_ME' with a secure password
     # Override with: ADMIN_PASSWORD environment variable
     password: ${ADMIN_PASSWORD:CHANGE_ME}
-
-  # API key for runtime endpoint authentication (X-API-Key header)
-  # REQUIRED: Generate a secure random key (e.g., openssl rand -hex 32)
-  # Override with: API_KEY environment variable
-  api-key: ${API_KEY:CHANGE_ME}
 
   # CORS configuration for frontend-backend interaction
   cors:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -32,11 +32,10 @@ simulation.artefacts.base-path=./simulation-runs
 security.admin.username=${ADMIN_USERNAME:admin}
 security.admin.password=${ADMIN_PASSWORD:}
 
-# API key for runtime endpoint authentication (override in application-dev.yml or environment)
-# SECURITY NOTE: Generate a secure random key for production!
-security.api-key=${API_KEY:}
 # API Authentication (runtime/simulation execution)
-api.auth.key=
+# SECURITY NOTE: Generate a secure random key for production!
+# Override with: API_KEY environment variable
+api.auth.key=${API_KEY:}
 api.auth.header=X-API-Key
 
 # CORS Configuration

--- a/src/test/java/com/liftsimulator/admin/config/SecurityConfigValidationTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/SecurityConfigValidationTest.java
@@ -21,7 +21,7 @@ public class SecurityConfigValidationTest {
             .withPropertyValues(
                 "security.admin.username=admin",
                 "security.admin.password=",
-                "security.api-key=test-key"
+                "api.auth.key=test-key"
             )
             .run(context -> {
                 assertThat(context).hasFailed();
@@ -39,7 +39,7 @@ public class SecurityConfigValidationTest {
             .withPropertyValues(
                 "security.admin.username=admin",
                 "security.admin.password=   ",
-                "security.api-key=test-key"
+                "api.auth.key=test-key"
             )
             .run(context -> {
                 assertThat(context).hasFailed();
@@ -56,7 +56,7 @@ public class SecurityConfigValidationTest {
         contextRunner
             .withPropertyValues(
                 "security.admin.username=admin",
-                "security.api-key=test-key"
+                "api.auth.key=test-key"
                 // security.admin.password not set - defaults to empty
             )
             .run(context -> {
@@ -75,7 +75,7 @@ public class SecurityConfigValidationTest {
             .withPropertyValues(
                 "security.admin.username=admin",
                 "security.admin.password=securepassword123",
-                "security.api-key=test-key"
+                "api.auth.key=test-key"
             )
             .run(context -> {
                 assertThat(context).hasNotFailed();

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -42,7 +42,6 @@ api:
 # Security configuration for tests
 # Multi-user configuration with ADMIN and VIEWER roles for RBAC testing
 security:
-  api-key: test-api-key
   users:
     - username: testadmin
       password: testpassword


### PR DESCRIPTION
## Summary
Reorganized API key configuration to follow a clearer separation of concerns by moving it from the `security` namespace to the `api.auth` namespace. This change improves configuration clarity by distinguishing between admin authentication (security) and API runtime authentication (api.auth).

## Key Changes
- **Configuration Property Migration**: Moved `security.api-key` to `api.auth.key` across all configuration files
  - Updated `SecurityConfig.java` to inject from the new property path
  - Reorganized `application-dev.yml.template` with dedicated API Authentication section
  - Updated `application.properties` with improved comments and organization
  
- **Test Updates**: Updated all test files to use the new property path
  - Modified `SecurityConfigValidationTest.java` to reference `api.auth.key`
  - Updated `application-test.yml` to remove the old `security.api-key` property

## Implementation Details
- The API key functionality remains unchanged; this is purely a configuration namespace refactoring
- Environment variable override (`API_KEY`) continues to work as before
- Configuration comments have been improved to clarify that `api.auth.key` is for runtime/simulation execution, while `security.admin.*` properties are for admin HTTP Basic authentication
- The `api.auth.header` property remains in the `api.auth` namespace (already correctly positioned)
- All security validation logic continues to work without modification

https://claude.ai/code/session_011Fyhk3c6vMkBR4s1hKUV3b