### PR TITLE
Fix artefact path duplication and directory orphaning in simulation runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Unified artefact path configuration**: Removed the duplicate `simulation.runs.artefacts-root`
+  config key from `SimulationRunExecutionService`. All artefact storage now uses the single
+  `simulation.artefacts.base-path` property (default: `./simulation-runs`) that was already
+  present in `application.properties`.
+- **Directory orphaning eliminated**: `SimulationRunExecutionService.executeRun()` no longer
+  creates a second run directory and overwrites the persisted path. The execution service now
+  reads `artefactBasePath` from the run entity (set once by `SimulationRunService`) and writes
+  all artefacts to that directory.
+- Added `simulation.artefacts.base-path` to `application-dev.yml.template` so developers have
+  an explicit reference for the configuration key.
+- Updated README to document `simulation.artefacts.base-path` as the single configuration key
+  for artefact storage.
+- Added integration tests (`SimulationRunDirectoryIntegrationTest`) verifying that exactly one
+  artefact directory is created per run and that it matches the persisted `artefactBasePath`.
+
 ## [0.47.0] - 2026-06-06
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -658,15 +658,15 @@ Simulation runs execute asynchronously using stored lift system configurations a
       "currentTick": 0,
       "seed": null,
       "errorMessage": null,
-      "artefactBasePath": "run-artefacts/run-42"
+      "artefactBasePath": "./simulation-runs/run-42"
     }
     ```
 
 - **Get Simulation Run**: `GET /api/v1/simulation-runs/{id}`
   - Returns the current status, progress, and artefact location.
 
-Run artefacts are stored on disk using the configured `simulation.runs.artefacts-root` directory
-(defaults to `run-artefacts/`). Each run folder contains:
+Run artefacts are stored on disk using the configured `simulation.artefacts.base-path` property
+(defaults to `./simulation-runs`). Each run folder is created at `{base-path}/run-{id}/` and contains:
 
 - `config.json` - exact configuration payload used
 - `scenario.json` - scenario payload for passenger flows

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -38,7 +38,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -61,7 +60,6 @@ public class SimulationRunExecutionService {
     private final ScenarioValidationService scenarioValidationService;
     private final ObjectMapper objectMapper;
     private final ExecutorService executor;
-    private final Path artefactsRoot;
     private final Map<Long, Future<?>> runningTasks = new ConcurrentHashMap<>();
     private final Map<Long, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
 
@@ -73,34 +71,12 @@ public class SimulationRunExecutionService {
             SimulationRunService runService,
             ConfigValidationService configValidationService,
             ScenarioValidationService scenarioValidationService,
-            ObjectMapper objectMapper,
-            @Value("${simulation.runs.artefacts-root:run-artefacts}") String artefactsRoot) {
+            ObjectMapper objectMapper) {
         this.runService = runService;
         this.configValidationService = configValidationService;
         this.scenarioValidationService = scenarioValidationService;
         this.objectMapper = objectMapper;
         this.executor = Executors.newCachedThreadPool(new SimulationRunnerThreadFactory());
-        this.artefactsRoot = Paths.get(artefactsRoot);
-    }
-
-    /**
-     * Creates a simulation run and executes it asynchronously.
-     *
-     * @param liftSystemId the lift system id
-     * @param versionId the version id
-     * @param scenarioId the scenario id (optional)
-     * @return the created simulation run (CREATED)
-     */
-    @Transactional
-    public SimulationRun startAsyncRun(Long liftSystemId, Long versionId, Long scenarioId) {
-        SimulationRun run = runService.createRun(liftSystemId, versionId, scenarioId);
-
-        String configJson = run.getVersion().getConfig();
-        String scenarioJson = run.getScenario() != null ? run.getScenario().getScenarioJson() : null;
-
-        RunExecutionRequest request = new RunExecutionRequest(run.getId(), configJson, scenarioJson);
-        submitExecution(request);
-        return run;
     }
 
     /**
@@ -134,24 +110,30 @@ public class SimulationRunExecutionService {
     }
 
     private void executeRun(RunExecutionRequest request) {
-        Path runDir = buildRunDirectory(request.runId());
-        Path logPath = runDir.resolve(LOG_FILE_NAME);
-        boolean started = false;
         CancellationToken cancelToken = cancellationTokens.computeIfAbsent(request.runId(), id -> new CancellationToken());
+        boolean started = false;
 
+        SimulationRun runEntity;
         try {
-            Files.createDirectories(runDir);
-            runService.configureRun(request.runId(), null, null, runDir.toAbsolutePath().toString());
+            runEntity = runService.getRunById(request.runId());
         } catch (Exception ex) {
-            logger.error("Failed to create run artefact directory for run {}", request.runId(), ex);
-            failRunWithMessage(request.runId(),
-                "Failed to initialize run artefacts: " + safeMessage(ex),
-                false);
+            logger.error("Failed to load run {} for execution", request.runId(), ex);
             return;
         }
 
+        String artefactPath = runEntity.getArtefactBasePath();
+        if (artefactPath == null || artefactPath.isBlank()) {
+            logger.error("Run {} has no artefact path configured; cannot execute", request.runId());
+            failRunWithMessage(request.runId(), "Artefact path not configured for run.", false);
+            return;
+        }
+
+        Path runDir = Paths.get(artefactPath);
+        Path logPath = runDir.resolve(LOG_FILE_NAME);
+        logger.info("Run {} using artefact directory: {}", request.runId(), runDir);
+
         try (BufferedWriter logWriter = Files.newBufferedWriter(logPath, StandardCharsets.UTF_8)) {
-            log(logWriter, "Run directory initialized at " + runDir.toAbsolutePath());
+            log(logWriter, "Run directory: " + runDir.toAbsolutePath());
             writeInputFiles(request, runDir, logWriter);
 
             if (request.scenarioJson() == null) {
@@ -186,7 +168,7 @@ public class SimulationRunExecutionService {
                 request.runId(),
                 scenario.durationTicks() != null ? scenario.durationTicks().longValue() : null,
                 scenario.seed() != null ? scenario.seed().longValue() : null,
-                runDir.toAbsolutePath().toString()
+                null
             );
 
             // Start the run if not already started (it may have been started by createAndStartRun)
@@ -422,10 +404,6 @@ public class SimulationRunExecutionService {
 
         objectMapper.writerWithDefaultPrettyPrinter()
             .writeValue(runDir.resolve(RESULTS_FILE_NAME).toFile(), results);
-    }
-
-    private Path buildRunDirectory(Long runId) {
-        return artefactsRoot.resolve("run-" + runId);
     }
 
     private void log(BufferedWriter writer, String message) throws IOException {

--- a/src/main/resources/application-dev.yml.template
+++ b/src/main/resources/application-dev.yml.template
@@ -72,6 +72,13 @@ logging:
     org.flywaydb: INFO
     com.zaxxer.hikari: INFO
 
+# Simulation Configuration
+# Directory where simulation run artefacts (logs, results, config snapshots) are stored.
+# Each run creates a subdirectory: {base-path}/run-{id}/
+simulation:
+  artefacts:
+    base-path: ${SIMULATION_ARTEFACTS_PATH:./simulation-runs}
+
 # API Authentication (runtime/simulation execution)
 # API key for runtime endpoint authentication (X-API-Key header)
 #

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunDirectoryIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunDirectoryIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.LocalIntegrationTest;
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test verifying that a single artefact directory is created per run
+ * and no orphaned directories are left behind (issue #377).
+ */
+public class SimulationRunDirectoryIntegrationTest extends LocalIntegrationTest {
+
+    @TempDir
+    static Path artefactsRoot;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("simulation.artefacts.base-path", () -> artefactsRoot.toString());
+    }
+
+    @Autowired
+    private SimulationRunService runService;
+
+    @Autowired
+    private LiftSystemRepository liftSystemRepository;
+
+    @Autowired
+    private LiftSystemVersionRepository versionRepository;
+
+    @Autowired
+    private SimulationRunRepository runRepository;
+
+    private LiftSystem testSystem;
+    private LiftSystemVersion testVersion;
+
+    private static final String VALID_CONFIG = "{\"minFloor\": 0, \"maxFloor\": 5, " +
+            "\"travelTicksPerFloor\": 1, \"doorTransitionTicks\": 1, \"doorDwellTicks\": 2, " +
+            "\"doorReopenWindowTicks\": 1, \"homeFloor\": 0, \"idleTimeoutTicks\": 3, " +
+            "\"controllerStrategy\": \"NEAREST_REQUEST_ROUTING\", " +
+            "\"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}";
+
+    @BeforeEach
+    void setUp() {
+        runRepository.deleteAll();
+        versionRepository.deleteAll();
+        liftSystemRepository.deleteAll();
+
+        testSystem = liftSystemRepository.save(new LiftSystem("dir-test-system", "Dir Test System", ""));
+        testVersion = new LiftSystemVersion(testSystem, 1, VALID_CONFIG);
+        testVersion.setStatus(VersionStatus.PUBLISHED);
+        testVersion = versionRepository.save(testVersion);
+    }
+
+    @Test
+    void createAndStartRun_createsExactlyOneDirectory() throws IOException {
+        SimulationRun run = runService.createAndStartRun(testSystem.getId(), testVersion.getId(), null, 1L);
+
+        // The persisted path must be inside artefactsRoot
+        Path runDir = Path.of(run.getArtefactBasePath());
+        assertTrue(runDir.startsWith(artefactsRoot),
+                "artefactBasePath should be under the configured base path");
+        assertTrue(Files.isDirectory(runDir),
+                "artefact directory must exist on disk");
+
+        // Exactly one subdirectory should exist under artefactsRoot (no orphans)
+        List<Path> dirs = Files.walk(artefactsRoot, 1)
+                .filter(p -> !p.equals(artefactsRoot))
+                .filter(Files::isDirectory)
+                .collect(Collectors.toList());
+        assertEquals(1, dirs.size(),
+                "Exactly one run directory should exist; found: " + dirs);
+        assertEquals(runDir.toAbsolutePath(), dirs.get(0).toAbsolutePath(),
+                "The directory on disk must match the persisted artefactBasePath");
+    }
+
+    @Test
+    void createAndStartRun_directoryNameMatchesRunId() throws IOException {
+        SimulationRun run = runService.createAndStartRun(testSystem.getId(), testVersion.getId(), null, 2L);
+
+        Path runDir = Path.of(run.getArtefactBasePath());
+        assertEquals("run-" + run.getId(), runDir.getFileName().toString(),
+                "Run directory name must be run-{id}");
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunDirectoryIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunDirectoryIntegrationTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.DynamicPropertySource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -60,10 +61,19 @@ public class SimulationRunDirectoryIntegrationTest extends LocalIntegrationTest 
             "\"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}";
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         runRepository.deleteAll();
         versionRepository.deleteAll();
         liftSystemRepository.deleteAll();
+
+        // Remove any run directories left by a previous test so each test starts clean
+        try (var entries = Files.newDirectoryStream(artefactsRoot)) {
+            for (Path entry : entries) {
+                Files.walk(entry)
+                        .sorted(Comparator.reverseOrder())
+                        .forEach(p -> { try { Files.delete(p); } catch (IOException ignored) { } });
+            }
+        }
 
         testSystem = liftSystemRepository.save(new LiftSystem("dir-test-system", "Dir Test System", ""));
         testVersion = new LiftSystemVersion(testSystem, 1, VALID_CONFIG);


### PR DESCRIPTION
## Summary
This PR eliminates duplicate artefact path configuration and fixes a critical bug where simulation run directories were being created twice, causing the persisted path to be overwritten. All artefact storage now uses a single, unified configuration property.

## Key Changes

- **Removed duplicate configuration**: Eliminated the `simulation.runs.artefacts-root` property from `SimulationRunExecutionService` constructor. The service now relies solely on `simulation.artefacts.base-path` (already present in `application.properties`).

- **Fixed directory orphaning bug**: Modified `SimulationRunExecutionService.executeRun()` to read the `artefactBasePath` from the persisted `SimulationRun` entity instead of creating a new directory path. This prevents the second directory creation that was overwriting the original persisted path.

- **Removed duplicate directory creation logic**: Deleted the `startAsyncRun()` method and the `buildRunDirectory()` helper method from `SimulationRunExecutionService`. Directory creation is now exclusively handled by `SimulationRunService.createAndStartRun()`.

- **Updated configuration documentation**: Added `simulation.artefacts.base-path` to `application-dev.yml.template` with clear documentation and environment variable override support.

- **Updated README**: Changed documentation to reference the single `simulation.artefacts.base-path` configuration key and clarified the directory structure as `{base-path}/run-{id}/`.

- **Added integration tests**: Created `SimulationRunDirectoryIntegrationTest` with two test cases:
  - Verifies that exactly one artefact directory is created per run (no orphans)
  - Verifies that the directory name matches the run ID format (`run-{id}`)

## Implementation Details

The fix ensures a clear separation of concerns:
- `SimulationRunService.createAndStartRun()` creates the directory once and persists the path
- `SimulationRunExecutionService.executeRun()` reads the persisted path and uses it for all artefact operations
- No duplicate directory creation or path overwrites occur

The integration tests use `@TempDir` to provide an isolated filesystem and `@DynamicPropertySource` to inject the test directory path, ensuring tests don't interfere with actual simulation runs.

https://claude.ai/code/session_0181V6zZLzeqdvvaFxc4FNwZ