### PR TITLE
Fix NPE in scenario execution and remove dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **NPE prevention in scenario execution**: Added null check for `scenario.durationTicks()` in
+  `SimulationRunExecutionService.runSimulation()`. The method now fails cleanly with a clear
+  error message if the scenario has a null duration, preventing NullPointerException during
+  unboxing to primitive int.
+- **Removed dead code**: Eliminated duplicate `SimulationRunService.getAllRuns()` method which
+  was superseded by the more efficient `getAllRunsWithDetails()` that eagerly loads related
+  entities (lift system, version, scenario).
 - **Unified artefact path configuration**: Removed the duplicate `simulation.runs.artefacts-root`
   config key from `SimulationRunExecutionService`. All artefact storage now uses the single
   `simulation.artefacts.base-path` property (default: `./simulation-runs`) that was already

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -166,7 +166,9 @@ public class SimulationRunExecutionService {
 
             if (scenario.durationTicks() == null) {
                 log(logWriter, "Scenario has null durationTicks");
-                failRunWithMessage(request.runId(), logWriter, "Scenario must have a valid durationTicks value.", false);
+                SimulationRun runAtCheck = runService.getRunById(request.runId());
+                boolean runAlreadyStarted = runAtCheck.getStatus() == SimulationRun.RunStatus.RUNNING;
+                failRunWithMessage(request.runId(), logWriter, "Scenario must have a valid durationTicks value.", runAlreadyStarted);
                 writeResults(request.runId(), runDir, null, null, null, "FAILED", "Scenario must have a valid durationTicks value.");
                 return;
             }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -164,9 +164,16 @@ public class SimulationRunExecutionService {
             ScenarioDefinitionDTO scenario = objectMapper.readerFor(ScenarioDefinitionDTO.class)
                 .readValue(scenarioNode);
 
+            if (scenario.durationTicks() == null) {
+                log(logWriter, "Scenario has null durationTicks");
+                failRunWithMessage(request.runId(), logWriter, "Scenario must have a valid durationTicks value.", false);
+                writeResults(request.runId(), runDir, null, null, null, "FAILED", "Scenario must have a valid durationTicks value.");
+                return;
+            }
+
             runService.configureRun(
                 request.runId(),
-                scenario.durationTicks() != null ? scenario.durationTicks().longValue() : null,
+                scenario.durationTicks().longValue(),
                 scenario.seed() != null ? scenario.seed().longValue() : null,
                 null
             );

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -169,15 +169,6 @@ public class SimulationRunService {
     }
 
     /**
-     * Get all simulation runs.
-     *
-     * @return list of all runs
-     */
-    public List<SimulationRun> getAllRuns() {
-        return runRepository.findAll();
-    }
-
-    /**
      * Get all simulation runs with their related entities (lift system, version, scenario).
      *
      * @return list of all runs with details, ordered by creation date descending

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -163,20 +163,6 @@ public class SimulationRunServiceTest {
     }
 
     @Test
-    public void testGetAllRuns() {
-        SimulationRun run1 = new SimulationRun();
-        SimulationRun run2 = new SimulationRun();
-        List<SimulationRun> runs = Arrays.asList(run1, run2);
-
-        when(runRepository.findAll()).thenReturn(runs);
-
-        List<SimulationRun> result = runService.getAllRuns();
-
-        assertEquals(2, result.size());
-        verify(runRepository).findAll();
-    }
-
-    @Test
     public void testGetRunById_Success() {
         when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
 
@@ -424,5 +410,20 @@ public class SimulationRunServiceTest {
 
         assertEquals("Simulation run not found with id: 999", exception.getMessage());
         verify(runRepository).existsById(999L);
+    }
+
+    @Test
+    public void testConfigureRun_WithNullDurationTicks() {
+        mockRun.setTotalTicks(null);
+        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SimulationRun result = runService.configureRun(1L, null, 12345L, "/path/to/artefacts");
+
+        assertNotNull(result);
+        // Verify that the run can be configured even with null durationTicks
+        // The null check occurs during execution, not configuration
+        verify(runRepository).findById(1L);
+        verify(runRepository).save(any(SimulationRun.class));
     }
 }


### PR DESCRIPTION
## Summary
This PR improves the robustness of scenario execution by adding explicit null validation for scenario duration, and removes duplicate/dead code from the service layer.

## Key Changes
- **Added null check for scenario duration**: In `SimulationRunExecutionService.executeRun()`, added validation to ensure `scenario.durationTicks()` is not null before attempting to unbox it to a primitive `long`. If null, the run now fails cleanly with a descriptive error message instead of throwing a NullPointerException.
- **Removed duplicate `getAllRuns()` method**: Eliminated the `SimulationRunService.getAllRuns()` method which was superseded by `getAllRunsWithDetails()`. The latter provides the same functionality with the added benefit of eagerly loading related entities (lift system, version, scenario), making it more efficient for typical use cases.
- **Updated test coverage**: Removed the test for the deleted `getAllRuns()` method and added a new test `testConfigureRun_WithNullDurationTicks()` to verify that configuration can handle null duration values (validation occurs during execution, not configuration).

## Implementation Details
- The null check for `durationTicks` is performed early in the execution flow, before the run is configured, allowing for immediate failure with a clear error message.
- The error is logged and written to the run results with status "FAILED", providing full traceability.
- The removal of `getAllRuns()` consolidates the API surface and encourages use of the more feature-rich `getAllRunsWithDetails()` method.

https://claude.ai/code/session_01TWkz5iwzX4Z5Rfjwyp7MBg