### PR TITLE
refactor: decouple circular service dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Refactored
+- **Decoupled simulation run execution wiring**: Removed the lazy circular dependency between `SimulationRunService` and `SimulationRunExecutionService`; the execution service now updates run lifecycle state and progress through `SimulationRunRepository` directly.
 - **Extract RunMetrics to `metrics` sub-package**: Decomposed `SimulationRunExecutionService`
   by moving `RunMetrics`, `FloorMetrics`, and `RequestLifecycle` inner classes into a new
   `com.liftsimulator.admin.service.metrics` package. The execution service is reduced from

--- a/README.md
+++ b/README.md
@@ -2749,7 +2749,7 @@ The backend includes JPA entities and Spring Data repositories for database acce
   - Run status enum: CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED
   - Relationships: Many-to-one with LiftSystem, LiftSystemVersion, and Scenario
   - Status transition methods: `start()`, `succeed()`, `fail()`, `cancel()`
-  - Progress tracking via `updateProgress(Long tick)`
+  - Progress tracking via repository-backed current tick updates
 
 #### Repositories
 
@@ -2772,6 +2772,8 @@ The backend includes JPA entities and Spring Data repositories for database acce
   - Standard CRUD operations via `JpaRepository`
 
 - **SimulationRunRepository** (`com.liftsimulator.admin.repository.SimulationRunRepository`)
+  - Persists simulation run lifecycle changes for both API orchestration and asynchronous execution, avoiding service-to-service circular dependencies
+  - Update run progress directly: `updateCurrentTick(Long id, Long currentTick)`
   - Find runs by lift system: `findByLiftSystemIdOrderByCreatedAtDesc(Long liftSystemId)`
   - Find runs by version: `findByVersionIdOrderByCreatedAtDesc(Long versionId)`
   - Find runs by scenario: `findByScenarioIdOrderByCreatedAtDesc(Long scenarioId)`

--- a/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -149,6 +151,7 @@ public interface SimulationRunRepository extends JpaRepository<SimulationRun, Lo
      * @param currentTick the current tick
      * @return number of rows updated
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE SimulationRun r SET r.currentTick = :currentTick WHERE r.id = :id")
     int updateCurrentTick(@Param("id") Long id, @Param("currentTick") Long currentTick);

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -9,6 +9,7 @@ import com.liftsimulator.admin.dto.PassengerFlowDTO;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
 import com.liftsimulator.admin.dto.ScenarioValidationResponse;
 import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
 import com.liftsimulator.admin.service.metrics.RunMetrics;
 import com.liftsimulator.domain.Direction;
 import com.liftsimulator.domain.LiftRequest;
@@ -53,7 +54,7 @@ public class SimulationRunExecutionService {
     private static final String LOG_FILE_NAME = "run.log";
     private static final String RESULTS_FILE_NAME = "results.json";
 
-    private final SimulationRunService runService;
+    private final SimulationRunRepository runRepository;
     private final ConfigValidationService configValidationService;
     private final ScenarioValidationService scenarioValidationService;
     private final ObjectMapper objectMapper;
@@ -66,11 +67,11 @@ public class SimulationRunExecutionService {
         justification = "Injected dependencies and configuration managed by Spring."
     )
     public SimulationRunExecutionService(
-            SimulationRunService runService,
+            SimulationRunRepository runRepository,
             ConfigValidationService configValidationService,
             ScenarioValidationService scenarioValidationService,
             ObjectMapper objectMapper) {
-        this.runService = runService;
+        this.runRepository = runRepository;
         this.configValidationService = configValidationService;
         this.scenarioValidationService = scenarioValidationService;
         this.objectMapper = objectMapper;
@@ -85,7 +86,7 @@ public class SimulationRunExecutionService {
      */
     @Transactional
     public void submitRunForExecution(Long runId) {
-        SimulationRun run = runService.getRunById(runId);
+        SimulationRun run = getRunById(runId);
         String configJson = run.getVersion().getConfig();
         String scenarioJson = run.getScenario() != null ? run.getScenario().getScenarioJson() : null;
 
@@ -101,7 +102,7 @@ public class SimulationRunExecutionService {
      */
     @Transactional
     public SimulationRun cancelRun(Long runId) {
-        SimulationRun run = runService.cancelRun(runId);
+        SimulationRun run = cancelRunStatus(runId);
         CancellationToken token = cancellationTokens.computeIfAbsent(runId, id -> new CancellationToken());
         token.cancel();
         return run;
@@ -113,7 +114,7 @@ public class SimulationRunExecutionService {
 
         SimulationRun runEntity;
         try {
-            runEntity = runService.getRunById(request.runId());
+            runEntity = getRunById(request.runId());
         } catch (Exception ex) {
             logger.error("Failed to load run {} for execution", request.runId(), ex);
             return;
@@ -164,14 +165,14 @@ public class SimulationRunExecutionService {
 
             if (scenario.durationTicks() == null) {
                 log(logWriter, "Scenario has null durationTicks");
-                SimulationRun runAtCheck = runService.getRunById(request.runId());
+                SimulationRun runAtCheck = getRunById(request.runId());
                 boolean runAlreadyStarted = runAtCheck.getStatus() == SimulationRun.RunStatus.RUNNING;
                 failRunWithMessage(request.runId(), logWriter, "Scenario must have a valid durationTicks value.", runAlreadyStarted);
                 writeResults(request.runId(), runDir, null, null, null, "FAILED", "Scenario must have a valid durationTicks value.");
                 return;
             }
 
-            runService.configureRun(
+            configureRun(
                 request.runId(),
                 scenario.durationTicks().longValue(),
                 scenario.seed() != null ? scenario.seed().longValue() : null,
@@ -179,7 +180,7 @@ public class SimulationRunExecutionService {
             );
 
             // Start the run if not already started (it may have been started by createAndStartRun)
-            SimulationRun currentRun = runService.getRunById(request.runId());
+            SimulationRun currentRun = getRunById(request.runId());
             if (currentRun.getStatus() == SimulationRun.RunStatus.CANCELLED || cancelToken.isCancelled()) {
                 log(logWriter, "Run cancelled before start for run " + request.runId());
                 cancelRunSafely(request.runId(), logWriter, "Run cancelled before start.");
@@ -187,19 +188,19 @@ public class SimulationRunExecutionService {
                 return;
             }
             if (currentRun.getStatus() != SimulationRun.RunStatus.RUNNING) {
-                runService.startRun(request.runId());
+                startRun(request.runId());
             }
             started = true;
             log(logWriter, "Simulation started for run " + request.runId());
 
             RunMetrics metrics = runSimulation(request.runId(), config, scenario, logWriter, cancelToken);
 
-            if (cancelToken.isCancelled() || runService.getRunById(request.runId()).getStatus() == SimulationRun.RunStatus.CANCELLED) {
+            if (cancelToken.isCancelled() || getRunById(request.runId()).getStatus() == SimulationRun.RunStatus.CANCELLED) {
                 log(logWriter, "Run cancelled for run " + request.runId());
                 writeResults(request.runId(), runDir, config, scenario, metrics, "CANCELLED", "Run cancelled.");
                 return;
             }
-            runService.succeedRun(request.runId());
+            succeedRun(request.runId());
             log(logWriter, "Simulation succeeded for run " + request.runId());
             writeResults(request.runId(), runDir, config, scenario, metrics, "SUCCEEDED", null);
         } catch (RunCancelledException ex) {
@@ -287,11 +288,11 @@ public class SimulationRunExecutionService {
 
             long progressTick = tick + 1L;
             if (tick % PROGRESS_UPDATE_INTERVAL == 0) {
-                runService.updateProgress(runId, progressTick);
+                updateProgress(runId, progressTick);
             }
         }
 
-        runService.updateProgress(runId, (long) scenario.durationTicks());
+        updateProgress(runId, (long) scenario.durationTicks());
         log(logWriter, "Simulation completed at tick " + engine.getCurrentTick());
         metrics.recordTerminalRequests(engine.getCurrentTick());
         return metrics;
@@ -308,6 +309,58 @@ public class SimulationRunExecutionService {
             flowsByTick.computeIfAbsent(tick, key -> new ArrayList<>()).add(flow);
         }
         return flowsByTick;
+    }
+
+    private SimulationRun getRunById(Long runId) {
+        return runRepository.findById(runId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Simulation run not found with id: " + runId));
+    }
+
+    private SimulationRun configureRun(Long runId, Long totalTicks, Long seed, String artefactBasePath) {
+        SimulationRun run = getRunById(runId);
+        if (totalTicks != null) {
+            run.setTotalTicks(totalTicks);
+        }
+        if (seed != null) {
+            run.setSeed(seed);
+        }
+        if (artefactBasePath != null) {
+            run.setArtefactBasePath(artefactBasePath);
+        }
+        return runRepository.save(run);
+    }
+
+    private SimulationRun startRun(Long runId) {
+        SimulationRun run = getRunById(runId);
+        run.start();
+        return runRepository.save(run);
+    }
+
+    private SimulationRun succeedRun(Long runId) {
+        SimulationRun run = getRunById(runId);
+        run.succeed();
+        return runRepository.save(run);
+    }
+
+    private SimulationRun failRun(Long runId, String message) {
+        SimulationRun run = getRunById(runId);
+        run.fail(message);
+        return runRepository.save(run);
+    }
+
+    private SimulationRun cancelRunStatus(Long runId) {
+        SimulationRun run = getRunById(runId);
+        run.cancel();
+        return runRepository.save(run);
+    }
+
+    private SimulationRun updateProgress(Long runId, Long currentTick) {
+        int updated = runRepository.updateCurrentTick(runId, currentTick);
+        if (updated == 0) {
+            throw new ResourceNotFoundException("Simulation run not found with id: " + runId);
+        }
+        return getRunById(runId);
     }
 
     private void writeInputFiles(RunExecutionRequest request, Path runDir, BufferedWriter logWriter) throws IOException {
@@ -337,9 +390,9 @@ public class SimulationRunExecutionService {
     private void failRunWithMessage(Long runId, String message, boolean started) {
         try {
             if (!started) {
-                runService.startRun(runId);
+                startRun(runId);
             }
-            runService.failRun(runId, message);
+            failRun(runId, message);
         } catch (Exception ex) {
             logger.error("Failed to mark run {} as failed", runId, ex);
         }
@@ -361,11 +414,11 @@ public class SimulationRunExecutionService {
 
     private void cancelRunSafely(Long runId, String message) {
         try {
-            SimulationRun run = runService.getRunById(runId);
+            SimulationRun run = getRunById(runId);
             if (run.getStatus() == SimulationRun.RunStatus.CANCELLED) {
                 return;
             }
-            runService.cancelRun(runId);
+            cancelRunStatus(runId);
         } catch (Exception ex) {
             logger.error("Failed to mark run {} as cancelled", runId, ex);
         }
@@ -396,7 +449,7 @@ public class SimulationRunExecutionService {
             runSummary.put("ticks", metrics.totalTicks());
         }
         try {
-            SimulationRun run = runService.getRunById(runId);
+            SimulationRun run = getRunById(runId);
             runSummary.put("liftSystemId", run.getLiftSystem().getId());
             runSummary.put("versionId", run.getVersion().getId());
         } catch (Exception ex) {

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -13,7 +13,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,7 +50,7 @@ public class SimulationRunService {
             LiftSystemRepository liftSystemRepository,
             LiftSystemVersionRepository versionRepository,
             ScenarioRepository scenarioRepository,
-            @Lazy SimulationRunExecutionService executionService,
+            SimulationRunExecutionService executionService,
             @Value("${simulation.artefacts.base-path:./simulation-runs}") String artefactsBasePath) {
         this.runRepository = runRepository;
         this.liftSystemRepository = liftSystemRepository;

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -1,0 +1,71 @@
+package com.liftsimulator.admin.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for SimulationRunExecutionService.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SimulationRunExecutionServiceTest {
+
+    @Mock
+    private SimulationRunRepository runRepository;
+
+    @Mock
+    private ConfigValidationService configValidationService;
+
+    @Mock
+    private ScenarioValidationService scenarioValidationService;
+
+    private SimulationRunExecutionService executionService;
+
+    @BeforeEach
+    public void setUp() {
+        executionService = new SimulationRunExecutionService(
+                runRepository,
+                configValidationService,
+                scenarioValidationService,
+                new ObjectMapper()
+        );
+    }
+
+    @AfterEach
+    public void tearDown() {
+        executionService.shutdownExecutor();
+    }
+
+    @Test
+    public void testUpdateProgressUsesRepositoryDirectly() throws Exception {
+        SimulationRun run = new SimulationRun();
+        run.setId(1L);
+        run.setCurrentTick(500L);
+        when(runRepository.updateCurrentTick(1L, 500L)).thenReturn(1);
+        when(runRepository.findById(1L)).thenReturn(Optional.of(run));
+
+        Method updateProgress = SimulationRunExecutionService.class.getDeclaredMethod(
+                "updateProgress", Long.class, Long.class);
+        updateProgress.setAccessible(true);
+        SimulationRun result = (SimulationRun) updateProgress.invoke(executionService, 1L, 500L);
+
+        assertNotNull(result);
+        assertEquals(500L, result.getCurrentTick());
+        verify(runRepository).updateCurrentTick(1L, 500L);
+        verify(runRepository).findById(1L);
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove the lazy circular dependency between `SimulationRunService` and `SimulationRunExecutionService` so asynchronous execution does not rely on the service-to-service wiring and to simplify lifecycle/progress updates.
- Ensure progress updates from async simulation threads are persisted reliably by pushing the update logic down to the repository with an appropriate transactional boundary.

### Description
- `SimulationRunExecutionService` now depends on `SimulationRunRepository` instead of `SimulationRunService` and implements repository-backed helpers: `getRunById`, `configureRun`, `startRun`, `succeedRun`, `failRun`, `cancelRunStatus`, and `updateProgress` for lifecycle and progress operations.
- `SimulationRunRepository.updateCurrentTick(...)` was annotated with `@Transactional(propagation = Propagation.REQUIRES_NEW)` and remains a `@Modifying` query so asynchronous progress updates use a fresh transaction.
- Removed the `@Lazy` injection from `SimulationRunService` constructor so the circular injection is eliminated, and adjusted `SimulationRunService` constructor signature accordingly.
- Added `SimulationRunExecutionServiceTest` unit test that verifies the execution service updates progress via `SimulationRunRepository.updateCurrentTick(...)` and updated `CHANGELOG.md` and `README.md` to document the refactor and repository-backed progress updates.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch errors and it completed cleanly.
- Attempted to run the unit tests with `mvn -q -Dtest=SimulationRunServiceTest,SimulationRunExecutionServiceTest test`, but the Maven build failed to resolve the Spring Boot parent POM from Maven Central (HTTP 403) so the tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23eba0b5f88325a364ba2c974f413f)