### PR TITLE
Add Testcontainers-backed integration tests with Flyway migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   API or behaviour changes.
 
 ### Added
+- **Testcontainers-backed integration tests**: Integration and repository tests now provision a
+  throwaway `postgres:15-alpine` instance on demand via Testcontainers, so `mvn test` runs without
+  a pre-existing PostgreSQL database (a running Docker daemon is the only prerequisite). A single
+  container is shared across the suite via a globally-registered Spring `ContextCustomizerFactory`,
+  covering both `@SpringBootTest` and `@DataJpaTest` slices.
+- **Flyway migrations exercised by tests**: The test profile now runs the real `db/migration`
+  scripts at startup and Hibernate runs in `validate` mode (instead of `ddl-auto: update`), so
+  migration bugs and entity/schema drift are caught by the test suite.
+- **Migration verification test**: Added `FlywayMigrationIntegrationTest`, which asserts the Flyway
+  schema history is populated, all migrations succeeded, and migrated tables exist.
 - **Unit tests for RunMetrics**: Added `RunMetricsTest` covering KPI computation (completed/
   cancelled counts, average and max wait ticks, utilisation), per-floor passenger flows and
   lift visits, per-lift config output, and idempotency of `recordTerminalRequests`.

--- a/README.md
+++ b/README.md
@@ -2821,13 +2821,19 @@ The verification runner is located at `com.liftsimulator.admin.runner.JpaVerific
 Integration tests for the repositories are available:
 - `LiftSystemRepositoryTest`: Tests CRUD operations, queries, and updates
 - `LiftSystemVersionRepositoryTest`: Tests version operations, JSONB mapping, and relationships
+- `FlywayMigrationIntegrationTest`: Verifies that Flyway migrations are executed at startup
 
 **Test Database Configuration:**
-- Tests use **H2 in-memory database** with PostgreSQL compatibility mode
-- The H2 test database initializes the `lift_simulator` schema automatically for integration tests
-- No external database required for running tests
-- Schema is automatically created via JPA's `ddl-auto: create-drop`
-- Flyway is disabled for tests (schema created from JPA entities)
+- Integration tests run against a **real PostgreSQL** instance provisioned on demand by
+  [Testcontainers](https://java.testcontainers.org/) — **no pre-existing database is required**.
+- The only prerequisite is a running **Docker** daemon (Testcontainers starts and tears down a
+  `postgres:15-alpine` container automatically). A single container is shared across the suite to
+  keep startup fast.
+- **Flyway migrations run during test startup**, so migration bugs are caught by the test suite.
+- Hibernate runs in **`validate`** mode (not `ddl-auto: update`), so the entity mappings are
+  checked against the migrated schema and any drift fails the build.
+- In CI, where the workflow provides a PostgreSQL service container via `SPRING_DATASOURCE_URL`,
+  Testcontainers stands aside and that database is used instead.
 
 Run the tests:
 ```bash
@@ -3241,6 +3247,11 @@ Run the test suite with Maven:
 ```bash
 mvn test
 ```
+
+> **No local PostgreSQL needed.** Integration tests provision a throwaway PostgreSQL container via
+> [Testcontainers](https://java.testcontainers.org/) and run the real Flyway migrations against it.
+> The only requirement is a running **Docker** daemon. (CI continues to use its PostgreSQL service
+> container — see `.github/workflows/ci.yml`.)
 
 The test suite includes integration coverage for the scenario system using fixtures in
 `src/test/resources/scenarios`.

--- a/src/test/java/com/liftsimulator/BaseIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/BaseIntegrationTest.java
@@ -7,12 +7,23 @@ import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Base class for integration tests that need a real PostgreSQL database.
- * 
- * Explicitly registers environment variables as Spring properties so they
- * override application-test.yml defaults in CI/CD environments.
- * 
- * Uses application-test.yml configuration which defaults to localhost:5432
- * for local development, but can be overridden via SPRING_DATASOURCE_* env vars.
+ *
+ * <p>Database wiring is supplied automatically by
+ * {@code com.liftsimulator.testsupport.TestcontainersContextCustomizerFactory}
+ * (registered globally in {@code META-INF/spring.factories}):
+ * <ul>
+ *   <li><b>Local dev:</b> a shared Testcontainers PostgreSQL instance is started
+ *       on demand, so {@code mvn test} runs without any pre-existing database.</li>
+ *   <li><b>CI/CD:</b> when {@code SPRING_DATASOURCE_URL} is set, the customizer
+ *       stands aside and the workflow's service-container datasource is used.</li>
+ * </ul>
+ *
+ * <p>In both environments Flyway migrations run during startup and Hibernate is
+ * in {@code validate} mode (see {@code application-test.yml}).
+ *
+ * <p>The {@link DynamicPropertySource} below is retained only as a defensive
+ * override for explicit {@code SPRING_DATASOURCE_*} environment variables; the
+ * Testcontainers customizer handles the local case.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -20,8 +31,8 @@ public abstract class BaseIntegrationTest {
 
     @DynamicPropertySource
     static void registerEnvironmentProperties(DynamicPropertyRegistry registry) {
-        // Explicitly register environment variables as Spring properties
-        // This ensures CI/CD environment variables override YAML defaults
+        // Explicitly register environment variables as Spring properties so that
+        // CI/CD environment variables override YAML defaults.
         String datasourceUrl = System.getenv("SPRING_DATASOURCE_URL");
         String datasourceUsername = System.getenv("SPRING_DATASOURCE_USERNAME");
         String datasourcePassword = System.getenv("SPRING_DATASOURCE_PASSWORD");

--- a/src/test/java/com/liftsimulator/admin/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/FlywayMigrationIntegrationTest.java
@@ -1,0 +1,70 @@
+package com.liftsimulator.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.liftsimulator.LocalIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Verifies that the Flyway migrations are actually executed during test startup
+ * (rather than the schema being created by Hibernate {@code ddl-auto}).
+ *
+ * <p>Runs against the shared Testcontainers PostgreSQL instance locally and the
+ * service-container database in CI, so a broken migration fails the build in
+ * either environment.
+ *
+ * <p>Lives in {@code com.liftsimulator.admin} so {@code @SpringBootTest} (via
+ * {@link LocalIntegrationTest}) discovers the {@code LiftConfigServiceApplication}
+ * configuration class.
+ */
+class FlywayMigrationIntegrationTest extends LocalIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void flywaySchemaHistoryIsPopulated() {
+        Integer applied = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM lift_simulator.flyway_schema_history "
+                        + "WHERE type = 'SQL'",
+                Integer.class);
+        assertTrue(applied != null && applied >= 1,
+                "Expected Flyway to record applied SQL migrations");
+    }
+
+    @Test
+    void allMigrationsSucceeded() {
+        Integer failures = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM lift_simulator.flyway_schema_history "
+                        + "WHERE success = false",
+                Integer.class);
+        assertEquals(0, failures, "No Flyway migration should be marked as failed");
+    }
+
+    @Test
+    void baselineAndLatestMigrationsAreApplied() {
+        assertMigrationApplied("1");
+        assertMigrationApplied("9");
+    }
+
+    @Test
+    void migratedTablesExist() {
+        // lift_system is created by V1; its presence proves the migration ran.
+        Integer tableCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM information_schema.tables "
+                        + "WHERE table_schema = 'lift_simulator' AND table_name = 'lift_system'",
+                Integer.class);
+        assertEquals(1, tableCount, "Expected lift_system table created by migration V1");
+    }
+
+    private void assertMigrationApplied(String version) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM lift_simulator.flyway_schema_history "
+                        + "WHERE version = ? AND success = true",
+                Integer.class, version);
+        assertEquals(1, count, "Expected migration version " + version + " to be applied successfully");
+    }
+}

--- a/src/test/java/com/liftsimulator/testsupport/SharedPostgresContainer.java
+++ b/src/test/java/com/liftsimulator/testsupport/SharedPostgresContainer.java
@@ -1,0 +1,59 @@
+package com.liftsimulator.testsupport;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Lazily-started singleton PostgreSQL container shared by every Spring test
+ * context in the suite.
+ *
+ * <p>Using a single shared container (rather than one per test class) keeps the
+ * suite fast: the container is created on first use and reused for the lifetime
+ * of the JVM. Testcontainers' Ryuk reaper stops and removes it once the JVM
+ * exits, so no explicit shutdown hook is required.
+ *
+ * <p>The image and credentials mirror the GitHub Actions service container in
+ * {@code .github/workflows/ci.yml} so local runs and CI exercise the same
+ * PostgreSQL version.
+ */
+final class SharedPostgresContainer {
+
+    /** Matches the {@code postgres:15-alpine} service container used in CI. */
+    private static final DockerImageName IMAGE = DockerImageName.parse("postgres:15-alpine");
+
+    private static final String DATABASE = "lift_simulator_test";
+    private static final String USERNAME = "lift_admin";
+    private static final String PASSWORD = "liftpassword";
+
+    /** Schema the migrations and entity mappings live in. */
+    static final String SCHEMA = "lift_simulator";
+
+    private static volatile PostgreSQLContainer<?> container;
+
+    private SharedPostgresContainer() {
+    }
+
+    /**
+     * Returns the running shared container, starting it on first call.
+     */
+    static PostgreSQLContainer<?> getStarted() {
+        PostgreSQLContainer<?> local = container;
+        if (local == null) {
+            synchronized (SharedPostgresContainer.class) {
+                local = container;
+                if (local == null) {
+                    local = new PostgreSQLContainer<>(IMAGE)
+                            .withDatabaseName(DATABASE)
+                            .withUsername(USERNAME)
+                            .withPassword(PASSWORD)
+                            // Resolve the connection against the application schema so
+                            // Flyway/Hibernate operate on lift_simulator, not public.
+                            .withUrlParam("currentSchema", SCHEMA);
+                    local.start();
+                    container = local;
+                }
+            }
+        }
+        return local;
+    }
+}

--- a/src/test/java/com/liftsimulator/testsupport/TestcontainersContextCustomizerFactory.java
+++ b/src/test/java/com/liftsimulator/testsupport/TestcontainersContextCustomizerFactory.java
@@ -1,0 +1,95 @@
+package com.liftsimulator.testsupport;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.liftsimulator.BaseIntegrationTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+/**
+ * Globally-registered factory (see {@code META-INF/spring.factories}) that
+ * points database-backed Spring test contexts at the shared Testcontainers
+ * PostgreSQL instance when no external database is configured.
+ *
+ * <p>Applying the wiring through a {@link ContextCustomizerFactory} rather than
+ * a per-class {@code @DynamicPropertySource} means it covers the DB-backed test
+ * slices uniformly — {@code @SpringBootTest} integration tests (subclasses of
+ * {@link BaseIntegrationTest}) and the {@code @DataJpaTest} repository tests
+ * alike — so {@code mvn test} runs with no pre-existing PostgreSQL. Web/unit
+ * slices that need no datasource are skipped.
+ *
+ * <p>When {@code SPRING_DATASOURCE_URL} is set (as in CI) the customizer is a
+ * no-op: the workflow's service-container datasource flows through the
+ * {@code application-test.yml} placeholders unchanged.
+ */
+public class TestcontainersContextCustomizerFactory implements ContextCustomizerFactory {
+
+    @Override
+    public ContextCustomizer createContextCustomizer(
+            Class<?> testClass, List<ContextConfigurationAttributes> configAttributes) {
+        // Defer to the externally-configured datasource (e.g. the CI service container).
+        if (System.getenv("SPRING_DATASOURCE_URL") != null) {
+            return null;
+        }
+        // Only DB-backed slices get the container, so web/unit Spring contexts
+        // (e.g. @WebMvcTest) don't pay the cost of starting PostgreSQL.
+        if (!requiresDatabase(testClass)) {
+            return null;
+        }
+        return TestcontainersDatasourceCustomizer.INSTANCE;
+    }
+
+    private static boolean requiresDatabase(Class<?> testClass) {
+        return BaseIntegrationTest.class.isAssignableFrom(testClass)
+                || AnnotatedElementUtils.hasAnnotation(testClass, DataJpaTest.class);
+    }
+
+    /**
+     * Adds a high-precedence property source pointing the datasource at the
+     * shared container, starting it on first use.
+     */
+    static final class TestcontainersDatasourceCustomizer implements ContextCustomizer {
+
+        static final TestcontainersDatasourceCustomizer INSTANCE = new TestcontainersDatasourceCustomizer();
+
+        private static final String SOURCE_NAME = "testcontainers-postgres";
+
+        private TestcontainersDatasourceCustomizer() {
+        }
+
+        @Override
+        public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+            var propertySources = context.getEnvironment().getPropertySources();
+            if (propertySources.contains(SOURCE_NAME)) {
+                return;
+            }
+            PostgreSQLContainer<?> postgres = SharedPostgresContainer.getStarted();
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("spring.datasource.url", postgres.getJdbcUrl());
+            properties.put("spring.datasource.username", postgres.getUsername());
+            properties.put("spring.datasource.password", postgres.getPassword());
+            propertySources.addFirst(new MapPropertySource(SOURCE_NAME, properties));
+        }
+
+        // Equal for all instances so Spring's context cache treats contexts that
+        // differ only by this customizer as identical (single shared container).
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof TestcontainersDatasourceCustomizer;
+        }
+
+        @Override
+        public int hashCode() {
+            return TestcontainersDatasourceCustomizer.class.hashCode();
+        }
+    }
+}

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.test.context.ContextCustomizerFactory=\
+com.liftsimulator.testsupport.TestcontainersContextCustomizerFactory

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,7 +16,10 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update
+      # Flyway owns the schema; Hibernate only validates entity mappings
+      # against the migrated schema so drift is caught instead of silently
+      # patched (the previous `update` mode hid migration bugs).
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -26,8 +29,15 @@ spring:
           create_namespaces: false
 
   flyway:
-    enabled: false
+    # Run the real V1..Vn migrations during test startup so migration bugs
+    # are caught by the test suite. Schema settings are inherited from the
+    # base application.properties (schemas/default-schema/create-schemas).
+    enabled: true
     locations: classpath:db/migration
+    schemas:
+      - lift_simulator
+    default-schema: lift_simulator
+    create-schemas: true
 
 logging:
   level:


### PR DESCRIPTION
## Summary
Refactored the test infrastructure to provision a real PostgreSQL database on demand via Testcontainers, eliminating the need for a pre-existing database in local development. Integration tests now run the actual Flyway migrations and validate the schema, catching migration bugs and entity/schema drift that were previously hidden by Hibernate's `ddl-auto: update` mode.

## Key Changes

- **Testcontainers integration**: Added `SharedPostgresContainer` singleton that lazily starts a shared `postgres:15-alpine` container on first use, reused across the entire test suite for performance.

- **Global context customizer**: Implemented `TestcontainersContextCustomizerFactory` (registered via `META-INF/spring.factories`) that automatically wires database-backed test slices (`@SpringBootTest` and `@DataJpaTest`) to the shared container. Respects `SPRING_DATASOURCE_URL` environment variable for CI environments, allowing the workflow's service container to be used instead.

- **Flyway migrations in tests**: Enabled Flyway in the test profile (`application-test.yml`) so real migrations run during startup. Changed Hibernate from `ddl-auto: update` to `ddl-auto: validate`, ensuring entity mappings are checked against the migrated schema rather than silently patched.

- **Migration verification test**: Added `FlywayMigrationIntegrationTest` that asserts Flyway schema history is populated, all migrations succeeded, and migrated tables exist.

- **Updated documentation**: Modified `README.md` and `CHANGELOG.md` to reflect the new test infrastructure and its benefits (no pre-existing database required, Docker daemon only prerequisite, real migrations exercised).

## Implementation Details

- The `TestcontainersContextCustomizerFactory` uses double-checked locking in `SharedPostgresContainer.getStarted()` to safely initialize the container on first access.
- The customizer adds a high-precedence `MapPropertySource` to override datasource properties, ensuring Spring's context cache treats contexts differing only by this customizer as identical (single shared container).
- The `equals()` and `hashCode()` methods on `TestcontainersDatasourceCustomizer` are implemented to support Spring's context caching strategy.
- CI workflows continue to use their PostgreSQL service container when `SPRING_DATASOURCE_URL` is set, maintaining compatibility with existing CI/CD pipelines.

https://claude.ai/code/session_01PJRmHRz7kPas8S5ye55Fqs