### PR TITLE
ci: package frontend assets in jar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,18 @@ jobs:
     - name: Run static analysis
       run: mvn -q spotbugs:check
 
-    - name: Package
-      run: mvn -q package -DskipTests
+    - name: Package deployable JAR with frontend profile
+      run: |
+        echo "Activating Maven frontend profile: mvn -Pfrontend package -DskipTests"
+        mvn -q -Pfrontend package -DskipTests
+
+    - name: Verify packaged frontend assets
+      run: |
+        JAR_FILE=$(find target -maxdepth 1 -name 'lift-simulator-*.jar' ! -name '*.original' | head -n 1)
+        test -n "$JAR_FILE"
+        echo "Verifying frontend assets in $JAR_FILE"
+        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/index.html$'
+        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/assets/'
 
   frontend:
     runs-on: ubuntu-latest
@@ -146,8 +156,18 @@ jobs:
       working-directory: frontend
       run: npx playwright install --with-deps chromium
 
-    - name: Package backend for E2E
-      run: mvn -q package -DskipTests
+    - name: Package deployable JAR for E2E with frontend profile
+      run: |
+        echo "Activating Maven frontend profile: mvn -Pfrontend package -DskipTests"
+        mvn -q -Pfrontend package -DskipTests
+
+    - name: Verify E2E packaged frontend assets
+      run: |
+        JAR_FILE=$(find target -maxdepth 1 -name 'lift-simulator-*.jar' ! -name '*.original' | head -n 1)
+        test -n "$JAR_FILE"
+        echo "Verifying frontend assets in $JAR_FILE"
+        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/index.html$'
+        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/assets/'
 
     - name: Create E2E database schema
       run: |
@@ -169,11 +189,12 @@ jobs:
         echo $! > backend-e2e.pid
 
         for i in {1..60}; do
-          if curl --fail --silent http://localhost:8080/api/v1/health > /dev/null; then
-            echo "Backend is ready for Playwright E2E tests."
+          if curl --fail --silent http://localhost:8080/api/v1/health > /dev/null \
+              && curl --fail --silent http://localhost:8080/ | grep '<div id="root">' > /dev/null; then
+            echo "Backend health check and packaged React UI are ready for Playwright E2E tests."
             exit 0
           fi
-          echo "Waiting for backend... ($i/60)"
+          echo "Waiting for backend health and packaged frontend UI... ($i/60)"
           sleep 2
         done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lift visits, per-lift config output, and idempotency of `recordTerminalRequests`.
 
 ### Fixed
+- **CI deployable JAR packaging**: GitHub Actions backend and E2E packaging steps now activate the Maven `frontend` profile, log profile activation, verify the produced Spring Boot JAR contains React assets under `BOOT-INF/classes/static/`, and confirm the packaged app serves the React root page during E2E startup.
 - **NPE prevention in scenario execution**: Added null check for `scenario.durationTicks()` in
   `SimulationRunExecutionService.runSimulation()`. The method now fails cleanly with a clear
   error message if the scenario has a null duration, preventing NullPointerException during

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lift visits, per-lift config output, and idempotency of `recordTerminalRequests`.
 
 ### Fixed
-- **CI deployable JAR packaging**: GitHub Actions backend and E2E packaging steps now activate the Maven `frontend` profile, log profile activation, verify the produced Spring Boot JAR contains React assets under `BOOT-INF/classes/static/`, and confirm the packaged app serves the React root page during E2E startup.
+- **CI deployable JAR packaging**: GitHub Actions backend and E2E packaging steps now activate the Maven `frontend` profile, log profile activation, install a Vite-compatible Node.js 20.19.0 runtime, verify the produced Spring Boot JAR contains React assets under `BOOT-INF/classes/static/`, and confirm the packaged app serves the React root page during E2E startup.
 - **NPE prevention in scenario execution**: Added null check for `scenario.durationTicks()` in
   `SimulationRunExecutionService.runSimulation()`. The method now fails cleanly with a clear
   error message if the scenario has a null duration, preventing NullPointerException during

--- a/README.md
+++ b/README.md
@@ -3233,13 +3233,23 @@ Compile the project using Maven:
 mvn clean compile
 ```
 
-To build a JAR package:
+To build a backend-only JAR package:
 
 ```bash
 mvn clean package
 ```
 
-The packaged JAR will be in `target/lift-simulator-0.46.0.jar`.
+To build a deployable Spring Boot JAR that also serves the React admin UI from `/`, activate the Maven frontend profile:
+
+```bash
+mvn -Pfrontend clean package
+```
+
+The frontend profile runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.47.0.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
+
+```bash
+jar tf target/lift-simulator-0.47.0.jar | grep '^BOOT-INF/classes/static/'
+```
 
 ## Running Tests
 
@@ -3278,7 +3288,7 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD=local-admin-password E2E_API_KEY=local-api-key npm test
 ```
 
-In CI, the `e2e-playwright` job provisions PostgreSQL, packages and starts the backend, waits for `/api/v1/health`, runs `npm test` in `frontend/`, injects test-only auth through Playwright and the Vite dev proxy, and uploads Playwright HTML reports plus failure artifacts.
+In CI, the `e2e-playwright` job provisions PostgreSQL, packages the backend with `mvn -Pfrontend package -DskipTests`, verifies the JAR contains `BOOT-INF/classes/static/` frontend assets, starts the packaged application, waits for both `/api/v1/health` and the packaged React root page at `/`, runs `npm test` in `frontend/`, injects test-only auth through Playwright and the Vite dev proxy, and uploads Playwright HTML reports plus failure artifacts.
 
 ## Quality Checks
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The simulation is text-based and designed for clarity over visual appeal.
 ### Prerequisites
 
 - **Java 17+** - [Download from Oracle](https://www.oracle.com/java/technologies/downloads/) or use OpenJDK
-- **Node.js 18+** and npm - [Download from nodejs.org](https://nodejs.org/)
+- **Node.js 20.19+ or 22.12+** and npm - [Download from nodejs.org](https://nodejs.org/)
 - **PostgreSQL 12+** - [Download from postgresql.org](https://www.postgresql.org/download/)
 - **Maven 3.6+** - Usually bundled with Java IDEs, or [download separately](https://maven.apache.org/download.cgi)
 
@@ -168,7 +168,7 @@ Use these as starting points or reference examples.
 - Verify `target/classes/static/index.html` exists after building the frontend bundle
 
 **Frontend won't start:**
-- Verify Node.js version: `node --version` (should be 18+)
+- Verify Node.js version: `node --version` (should be 20.19+ or 22.12+)
 - Delete `node_modules` and reinstall: `rm -rf node_modules && npm install`
 - Check port 3000 isn't already in use
 
@@ -3245,7 +3245,7 @@ To build a deployable Spring Boot JAR that also serves the React admin UI from `
 mvn -Pfrontend clean package
 ```
 
-The frontend profile runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.47.0.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
+The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.47.0.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
 
 ```bash
 jar tf target/lift-simulator-0.47.0.jar | grep '^BOOT-INF/classes/static/'

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Lift Simulator Admin UI
 
-![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)
+![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.19.0%20%7C%7C%20%3E%3D22.12.0-brightgreen)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 [![CI](https://github.com/manoj-bhaskaran/lift-simulator/actions/workflows/ci.yml/badge.svg)](https://github.com/manoj-bhaskaran/lift-simulator/actions/workflows/ci.yml)
 ![React](https://img.shields.io/badge/React-19.x-61DAFB?logo=react)
@@ -25,12 +25,12 @@ The footer displays the current UI version by reading the `version` field from `
 
 ## Tech Stack
 
-This project uses the following core dependencies (version ranges as specified in `package.json`):
+This project requires Node.js `^20.19.0 || >=22.12.0` for Vite 7 compatibility and uses the following core dependencies (version ranges as specified in `package.json`):
 
 - **React ^19.2.0** - UI library
-- **Vite ^7.2.4** - Build tool and dev server
-- **React Router ^7.12.0** - Client-side routing
-- **Axios ^1.13.2** - HTTP client for API calls
+- **Vite ^7.3.5** - Build tool and dev server
+- **React Router ^7.17.0** - Client-side routing
+- **Axios ^1.17.0** - HTTP client for API calls
 
 > **Note:** The caret (^) prefix allows npm to install compatible minor and patch updates. For example, `^19.2.0` allows versions `>=19.2.0` and `<20.0.0`. Run `npm list` to see the exact installed versions.
 
@@ -59,7 +59,7 @@ Shared interfaces include `LiftSystem`, `Version`, and `ValidationResult`.
 
 ## Prerequisites
 
-- Node.js 18+ and npm
+- Node.js 20.19+ (or 22.12+) and npm
 - Backend service running on `http://localhost:8080`
 
 ## Local Development Setup

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.45.1",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.45.1",
+      "version": "0.47.0",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",
@@ -24,6 +24,9 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "vite": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.47.0",
   "type": "module",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
                                     <goal>install-node-and-npm</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v20.11.1</nodeVersion>
+                                    <nodeVersion>v20.19.0</nodeVersion>
                                     <npmVersion>10.2.4</npmVersion>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
### Motivation
- Ensure CI-produced Spring Boot JARs include the React frontend so the app can serve the UI from `/` when deployed or used by E2E tests. 
- Make E2E startup more reliable by verifying the packaged UI is present and served before running Playwright tests. 
- Document the packaging change and verification steps for developers in `README.md` and record the fix in `CHANGELOG.md`.

### Description
- Updated `.github/workflows/ci.yml` backend and `e2e-playwright` packaging steps to run `mvn -Pfrontend package -DskipTests` and log profile activation. 
- Added CI verification steps that inspect the produced JAR and assert frontend assets exist under `BOOT-INF/classes/static/` (checks include `index.html` and `assets/`). 
- Extended E2E startup readiness checks to wait for both `GET /api/v1/health` and the packaged React root page at `/` (searching for `<div id="root">`). 
- Updated `README.md` to document `mvn -Pfrontend clean package` (deployable JAR that bundles the UI) and added a `jar tf` verification example, and added a matching note to `CHANGELOG.md`.

### Testing
- Verified CI workflow YAML parses successfully with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'` (passed). 
- Ran frontend build with `npm --prefix frontend run build` and confirmed `frontend/dist/index.html` and `frontend/dist/assets/*` were produced (build succeeded). 
- Performed `git diff --check` and repository diffs to validate changes (passed). 
- Attempted `mvn -Pfrontend package -DskipTests` locally but the build could not complete in this environment due to Maven Central returning HTTP 403 while resolving the Spring Boot parent POM; CI will run the packaging steps in its networked environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24e43e61e0832581b17c88181539c8)