### PR TITLE
Add pagination support to simulation runs list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.48.0] - 2026-06-07
+
+### Added
+- **Paginated simulation run list endpoint**: `GET /api/v1/simulation-runs` now accepts `?page=0&size=20&sort=createdAt,desc` query parameters and returns a Spring Data `Page` envelope with `content`, `totalElements`, and `totalPages`. Default page size is 20; the API enforces a maximum of 100 per request. Filter parameters (`systemId`, `status`) continue to work alongside pagination. The frontend API client (`simulationRunsApi.js`) is updated to pass page, size, and sort on every call.
+
 ## [Unreleased]
 
 ### Changed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/api/simulationRunsApi.js
+++ b/frontend/src/api/simulationRunsApi.js
@@ -2,18 +2,23 @@ import apiClient from './client';
 
 export const simulationRunsApi = {
   /**
-   * Lists all simulation runs with optional filtering.
-   * @param {Object} params - Optional filter parameters
+   * Lists simulation runs with optional filtering and pagination.
+   * @param {Object} params - Optional filter and pagination parameters
    * @param {number} [params.systemId] - Filter by lift system ID
    * @param {string} [params.status] - Filter by status (CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED)
-   * @returns {Promise} API response with list of simulation runs
+   * @param {number} [params.page=0] - Zero-based page number
+   * @param {number} [params.size=20] - Page size (max 100)
+   * @param {string} [params.sort='createdAt,desc'] - Sort field and direction
+   * @returns {Promise} API response with paginated simulation runs (content, totalElements, totalPages)
    */
   listRuns: (params = {}) => {
     const queryParams = new URLSearchParams();
     if (params.systemId) queryParams.append('systemId', params.systemId);
     if (params.status) queryParams.append('status', params.status);
-    const queryString = queryParams.toString();
-    return apiClient.get(`/simulation-runs${queryString ? `?${queryString}` : ''}`);
+    queryParams.append('page', params.page ?? 0);
+    queryParams.append('size', params.size ?? 20);
+    queryParams.append('sort', params.sort ?? 'createdAt,desc');
+    return apiClient.get(`/simulation-runs?${queryParams.toString()}`);
   },
   createRun: (payload) => apiClient.post('/simulation-runs', payload),
   getRun: (id) => apiClient.get(`/simulation-runs/${id}`),

--- a/frontend/src/pages/SimulationRuns.css
+++ b/frontend/src/pages/SimulationRuns.css
@@ -204,3 +204,21 @@
     min-width: 100%;
   }
 }
+
+.simulation-runs .pagination-summary {
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 0.5rem;
+}
+
+.simulation-runs .pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.simulation-runs .pagination-info {
+  font-size: 0.875rem;
+  color: #555;
+}

--- a/frontend/src/pages/SimulationRuns.jsx
+++ b/frontend/src/pages/SimulationRuns.jsx
@@ -27,6 +27,9 @@ function SimulationRuns() {
   const [systems, setSystems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
 
   const [selectedSystemId, setSelectedSystemId] = useState(
     searchParams.get('systemId') || ''
@@ -48,12 +51,12 @@ function SimulationRuns() {
   }, []);
 
   const loadRuns = useCallback(
-    async (isPolling = false) => {
+    async (isPolling = false, page = currentPage) => {
       try {
         if (!isPolling) {
           setLoading(true);
         }
-        const params = {};
+        const params = { page };
         if (selectedSystemId) {
           params.systemId = selectedSystemId;
         }
@@ -61,7 +64,11 @@ function SimulationRuns() {
           params.status = selectedStatus;
         }
         const response = await simulationRunsApi.listRuns(params);
-        setRuns(response.data);
+        const pageData = response.data;
+        setRuns(pageData.content);
+        setTotalPages(pageData.totalPages);
+        setTotalElements(pageData.totalElements);
+        setCurrentPage(pageData.number);
         setError(null);
       } catch (err) {
         handleApiError(err, setError, 'Failed to load simulation runs');
@@ -71,7 +78,7 @@ function SimulationRuns() {
         }
       }
     },
-    [selectedSystemId, selectedStatus]
+    [selectedSystemId, selectedStatus, currentPage]
   );
 
   useEffect(() => {
@@ -169,16 +176,23 @@ function SimulationRuns() {
   };
 
   const handleSystemChange = (event) => {
+    setCurrentPage(0);
     setSelectedSystemId(event.target.value);
   };
 
   const handleStatusChange = (event) => {
+    setCurrentPage(0);
     setSelectedStatus(event.target.value);
   };
 
   const handleClearFilters = () => {
+    setCurrentPage(0);
     setSelectedSystemId('');
     setSelectedStatus('ALL');
+  };
+
+  const handlePageChange = (newPage) => {
+    loadRuns(false, newPage);
   };
 
   const hasFilters = selectedSystemId || (selectedStatus && selectedStatus !== 'ALL');
@@ -257,6 +271,11 @@ function SimulationRuns() {
         </div>
       ) : (
         <div className="runs-table-container">
+          {totalElements > 0 && (
+            <p className="pagination-summary">
+              Showing {currentPage * 20 + 1}–{Math.min((currentPage + 1) * 20, totalElements)} of {totalElements} runs
+            </p>
+          )}
           <table className="runs-table">
             <thead>
               <tr>
@@ -316,6 +335,27 @@ function SimulationRuns() {
               ))}
             </tbody>
           </table>
+          {totalPages > 1 && (
+            <div className="pagination-controls">
+              <button
+                className="btn-secondary"
+                onClick={() => handlePageChange(currentPage - 1)}
+                disabled={currentPage === 0}
+              >
+                ← Previous
+              </button>
+              <span className="pagination-info">
+                Page {currentPage + 1} of {totalPages}
+              </span>
+              <button
+                className="btn-secondary"
+                onClick={() => handlePageChange(currentPage + 1)}
+                disabled={currentPage >= totalPages - 1}
+              >
+                Next →
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.47.1</version>
+    <version>0.48.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
@@ -36,6 +36,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 
 /**
  * REST controller for managing simulation runs.
@@ -65,28 +69,30 @@ public class SimulationRunController {
     }
 
     /**
-     * Lists all simulation runs with optional filtering.
-     * Endpoint: GET /api/simulation-runs
+     * Lists simulation runs with optional filtering and pagination.
+     * Endpoint: GET /api/v1/simulation-runs
      *
      * @param systemId optional filter by lift system ID
      * @param status optional filter by run status (CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED)
-     * @return list of simulation runs with their details
+     * @param pageable pagination parameters: page (0-based), size (default 20, max 100), sort
+     * @return paginated simulation runs with totalElements and totalPages metadata
      */
     @Operation(
         summary = "List simulation runs",
-        description = "Retrieves all simulation runs with optional filtering by system ID or status"
+        description = "Retrieves simulation runs with optional filtering by system ID or status. "
+            + "Supports pagination via ?page=0&size=20&sort=createdAt,desc. "
+            + "Default page size is 20; maximum is 100."
     )
     @ApiResponse(responseCode = "200", description = "Successfully retrieved simulation runs")
     @ApiResponse(responseCode = "401", description = "Unauthorized - valid API key required")
     @GetMapping
-    public ResponseEntity<List<SimulationRunListResponse>> listSimulationRuns(
+    public ResponseEntity<Page<SimulationRunListResponse>> listSimulationRuns(
             @RequestParam(required = false) Long systemId,
-            @RequestParam(required = false) RunStatus status
+            @RequestParam(required = false) RunStatus status,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<SimulationRun> runs = simulationRunService.getRunsWithDetails(systemId, status);
-        List<SimulationRunListResponse> responses = runs.stream()
-                .map(SimulationRunListResponse::fromEntity)
-                .toList();
+        Page<SimulationRun> page = simulationRunService.getPagedRunsWithDetails(systemId, status, pageable);
+        Page<SimulationRunListResponse> responses = page.map(SimulationRunListResponse::fromEntity);
         return ResponseEntity.ok(responses);
     }
 

--- a/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
@@ -2,6 +2,8 @@ package com.liftsimulator.admin.repository;
 
 import com.liftsimulator.admin.entity.SimulationRun;
 import com.liftsimulator.admin.entity.SimulationRun.RunStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -74,6 +76,69 @@ public interface SimulationRunRepository extends JpaRepository<SimulationRun, Lo
     List<SimulationRun> findByLiftSystemIdAndStatusWithDetails(
             @Param("liftSystemId") Long liftSystemId,
             @Param("status") RunStatus status);
+
+    /**
+     * Find all runs with their relationships eagerly loaded, with pagination support.
+     *
+     * @param pageable pagination and sorting parameters
+     * @return page of runs
+     */
+    @Query(value = "SELECT r FROM SimulationRun r "
+            + "LEFT JOIN FETCH r.liftSystem "
+            + "LEFT JOIN FETCH r.version "
+            + "LEFT JOIN FETCH r.scenario",
+           countQuery = "SELECT count(r) FROM SimulationRun r")
+    Page<SimulationRun> findAllWithDetails(Pageable pageable);
+
+    /**
+     * Find all runs for a specific lift system with relationships eagerly loaded, with pagination.
+     *
+     * @param liftSystemId the lift system id
+     * @param pageable pagination and sorting parameters
+     * @return page of runs
+     */
+    @Query(value = "SELECT r FROM SimulationRun r "
+            + "LEFT JOIN FETCH r.liftSystem "
+            + "LEFT JOIN FETCH r.version "
+            + "LEFT JOIN FETCH r.scenario "
+            + "WHERE r.liftSystem.id = :liftSystemId",
+           countQuery = "SELECT count(r) FROM SimulationRun r WHERE r.liftSystem.id = :liftSystemId")
+    Page<SimulationRun> findByLiftSystemIdWithDetails(@Param("liftSystemId") Long liftSystemId, Pageable pageable);
+
+    /**
+     * Find all runs with a specific status with relationships eagerly loaded, with pagination.
+     *
+     * @param status the run status
+     * @param pageable pagination and sorting parameters
+     * @return page of runs
+     */
+    @Query(value = "SELECT r FROM SimulationRun r "
+            + "LEFT JOIN FETCH r.liftSystem "
+            + "LEFT JOIN FETCH r.version "
+            + "LEFT JOIN FETCH r.scenario "
+            + "WHERE r.status = :status",
+           countQuery = "SELECT count(r) FROM SimulationRun r WHERE r.status = :status")
+    Page<SimulationRun> findByStatusWithDetails(@Param("status") RunStatus status, Pageable pageable);
+
+    /**
+     * Find all runs for a specific lift system with a specific status, with pagination.
+     *
+     * @param liftSystemId the lift system id
+     * @param status the run status
+     * @param pageable pagination and sorting parameters
+     * @return page of runs
+     */
+    @Query(value = "SELECT r FROM SimulationRun r "
+            + "LEFT JOIN FETCH r.liftSystem "
+            + "LEFT JOIN FETCH r.version "
+            + "LEFT JOIN FETCH r.scenario "
+            + "WHERE r.liftSystem.id = :liftSystemId AND r.status = :status",
+           countQuery = "SELECT count(r) FROM SimulationRun r "
+            + "WHERE r.liftSystem.id = :liftSystemId AND r.status = :status")
+    Page<SimulationRun> findByLiftSystemIdAndStatusWithDetails(
+            @Param("liftSystemId") Long liftSystemId,
+            @Param("status") RunStatus status,
+            Pageable pageable);
 
     /**
      * Find all runs for a specific lift system.

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -23,6 +23,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 /**
  * Service for managing simulation runs.
@@ -167,6 +171,12 @@ public class SimulationRunService {
         return runDir.toAbsolutePath().toString();
     }
 
+    /** Maximum allowed page size to prevent excessively large result sets. */
+    public static final int MAX_PAGE_SIZE = 100;
+
+    /** Default page size when not specified by the caller. */
+    public static final int DEFAULT_PAGE_SIZE = 20;
+
     /**
      * Get all simulation runs with their related entities (lift system, version, scenario).
      *
@@ -194,6 +204,43 @@ public class SimulationRunService {
         } else {
             return runRepository.findAllWithDetails();
         }
+    }
+
+    /**
+     * Get a page of runs with optional filtering by lift system ID and status.
+     * Enforces a maximum page size of {@value #MAX_PAGE_SIZE}. Requests with a larger
+     * page size are silently capped. Defaults to sorting by {@code createdAt} descending
+     * when the caller does not supply an explicit sort.
+     *
+     * @param liftSystemId optional lift system ID filter
+     * @param status optional status filter
+     * @param pageable pagination and sorting parameters supplied by the caller
+     * @return page of matching runs with details
+     */
+    public Page<SimulationRun> getPagedRunsWithDetails(Long liftSystemId, RunStatus status, Pageable pageable) {
+        Pageable effective = capPageSize(pageable);
+        if (liftSystemId != null && status != null) {
+            return runRepository.findByLiftSystemIdAndStatusWithDetails(liftSystemId, status, effective);
+        } else if (liftSystemId != null) {
+            return runRepository.findByLiftSystemIdWithDetails(liftSystemId, effective);
+        } else if (status != null) {
+            return runRepository.findByStatusWithDetails(status, effective);
+        } else {
+            return runRepository.findAllWithDetails(effective);
+        }
+    }
+
+    /**
+     * Returns a {@link Pageable} that is identical to the input but with the page size
+     * capped at {@value #MAX_PAGE_SIZE}. Falls back to default sort (createdAt DESC)
+     * when the caller provides no sort criteria.
+     */
+    private Pageable capPageSize(Pageable pageable) {
+        Sort sort = pageable.getSort().isSorted()
+                ? pageable.getSort()
+                : Sort.by(Sort.Direction.DESC, "createdAt");
+        int size = Math.min(pageable.getPageSize(), MAX_PAGE_SIZE);
+        return PageRequest.of(pageable.getPageNumber(), size, sort);
     }
 
     /**

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -366,4 +366,60 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
                 .header(API_KEY_HEADER, "invalid-key"))
             .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    public void testListSimulationRuns_Pagination_PageSizeAndTotals() throws Exception {
+        // Create 50 runs
+        for (int i = 0; i < 50; i++) {
+            SimulationRun run = new SimulationRun(testSystem, testVersion);
+            runRepository.save(run);
+        }
+
+        // Page 0, size 20 => 20 items, 3 total pages, 50 total elements
+        mockMvc.perform(get("/api/v1/simulation-runs?page=0&size=20&sort=createdAt,desc")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content.length()").value(20))
+            .andExpect(jsonPath("$.totalElements").value(50))
+            .andExpect(jsonPath("$.totalPages").value(3))
+            .andExpect(jsonPath("$.number").value(0))
+            .andExpect(jsonPath("$.size").value(20));
+
+        // Page 2, size 20 => 10 items (50 - 2*20 = 10)
+        mockMvc.perform(get("/api/v1/simulation-runs?page=2&size=20&sort=createdAt,desc")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content.length()").value(10))
+            .andExpect(jsonPath("$.totalElements").value(50))
+            .andExpect(jsonPath("$.number").value(2));
+    }
+
+    @Test
+    public void testListSimulationRuns_Pagination_DefaultsToFirstPage() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            SimulationRun run = new SimulationRun(testSystem, testVersion);
+            runRepository.save(run);
+        }
+
+        // No pagination params => defaults to page 0, size 20
+        mockMvc.perform(get("/api/v1/simulation-runs")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content.length()").value(5))
+            .andExpect(jsonPath("$.totalElements").value(5))
+            .andExpect(jsonPath("$.number").value(0))
+            .andExpect(jsonPath("$.size").value(20));
+    }
+
+    @Test
+    public void testListSimulationRuns_Pagination_MaxSizeEnforced() throws Exception {
+        // Requesting size=200 should be capped at 100
+        mockMvc.perform(get("/api/v1/simulation-runs?page=0&size=200")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size").value(100));
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds pagination support to the simulation runs list endpoint (`GET /api/v1/simulation-runs`), allowing clients to retrieve large result sets in manageable chunks with configurable sorting.

## Key Changes

- **Repository layer**: Added four new paginated query methods to `SimulationRunRepository`:
  - `findAllWithDetails(Pageable)` - all runs with eager-loaded relationships
  - `findByLiftSystemIdWithDetails(Long, Pageable)` - filtered by lift system
  - `findByStatusWithDetails(RunStatus, Pageable)` - filtered by status
  - `findByLiftSystemIdAndStatusWithDetails(Long, RunStatus, Pageable)` - filtered by both

- **Service layer**: Introduced `getPagedRunsWithDetails()` method in `SimulationRunService` that:
  - Routes to the appropriate repository method based on provided filters
  - Enforces a maximum page size of 100 to prevent excessively large result sets
  - Applies a default sort by `createdAt` descending when no sort is specified
  - Caps requested page sizes silently to the maximum

- **Controller layer**: Updated `listSimulationRuns()` endpoint to:
  - Accept `page`, `size`, and `sort` query parameters via Spring Data's `@PageableDefault`
  - Return a `Page<SimulationRunListResponse>` instead of a `List`
  - Maintain backward compatibility with existing `systemId` and `status` filters

- **Frontend API client**: Updated `simulationRunsApi.js` to:
  - Always include pagination parameters (`page`, `size`, `sort`) in requests
  - Default to page 0, size 20, and sort by `createdAt` descending

- **Tests**: Added three new integration tests covering:
  - Pagination with multiple pages and correct totals
  - Default pagination behavior when no parameters provided
  - Maximum page size enforcement

## Implementation Details

- All paginated queries use `LEFT JOIN FETCH` to eagerly load related entities (liftSystem, version, scenario), preventing N+1 query problems
- Separate count queries are provided for accurate total element counts
- The `capPageSize()` utility method ensures consistent enforcement of pagination limits across all queries
- Version bumped to 0.48.0 in both backend (pom.xml) and frontend (package.json)

https://claude.ai/code/session_01HNKLdzVPB75DDVzYj7t7MP