### PR TITLE
perf(simulation): optimize log tailing and KPI metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Simulation run performance optimization**: Replaced O(n²) log tail buffering with an `ArrayDeque` ring buffer, cached shared `RunMetrics` KPI values across result serializers, and avoided allocating passenger-flow tick maps for empty scenarios. Added large-file tail coverage for 12K and 100K line logs.
 - **Backend dependency refresh**: Bumped the backend maintenance version to 0.47.1, upgraded Spring Boot from 3.2.1 to 3.4.13, added the Spring Boot-managed Flyway PostgreSQL database module required by the newer Flyway baseline, and verified the PostgreSQL JDBC driver remains on the latest 42.7.11 release.
 - **CI Playwright E2E coverage**: Moved frontend Playwright execution into a dedicated `e2e-playwright` GitHub Actions job that provisions PostgreSQL, packages and starts the Spring Boot backend, waits for `/api/v1/health`, and runs the browser suite against the live API. The job publishes the Playwright HTML report and failure artifacts, including backend logs, so feature-test failures are visible in CI.
 - **Playwright-only E2E auth configuration**: Added optional Playwright environment variables for admin Basic auth and runtime API-key headers so local and CI E2E runs can exercise authenticated backend endpoints without exposing credentials in browser bundles.

--- a/README.md
+++ b/README.md
@@ -1210,6 +1210,7 @@ Retrieves simulation logs with optional tail functionality.
 - `tail` (optional): Number of lines to retrieve from end of log
   - Default: All lines
   - Maximum: 10,000 lines
+  - Large tails are buffered with fixed-size deque storage, so reading the last lines of large logs uses bounded memory and linear time.
 
 **Response (200 OK):**
 ```json

--- a/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
@@ -14,8 +14,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -259,15 +261,19 @@ public class ArtefactService {
      * @throws IOException if file reading fails
      */
     private String readLastNLines(Path path, int n) throws IOException {
-        List<String> lines = new ArrayList<>();
+        if (n == 0) {
+            return "";
+        }
+
+        Deque<String> lines = new ArrayDeque<>(n);
 
         try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
             String line;
             while ((line = reader.readLine()) != null) {
-                lines.add(line);
-                if (lines.size() > n) {
-                    lines.remove(0); // Remove oldest line to maintain size
+                if (lines.size() == n) {
+                    lines.removeFirst();
                 }
+                lines.addLast(line);
             }
         }
 

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -299,11 +300,11 @@ public class SimulationRunExecutionService {
     }
 
     private Map<Integer, List<PassengerFlowDTO>> groupFlowsByTick(ScenarioDefinitionDTO scenario) {
-        Map<Integer, List<PassengerFlowDTO>> flowsByTick = new HashMap<>();
-        if (scenario.passengerFlows() == null) {
-            return flowsByTick;
+        if (scenario.passengerFlows() == null || scenario.passengerFlows().isEmpty()) {
+            return Collections.emptyMap();
         }
 
+        Map<Integer, List<PassengerFlowDTO>> flowsByTick = new HashMap<>(scenario.passengerFlows().size());
         for (PassengerFlowDTO flow : scenario.passengerFlows()) {
             int tick = flow.startTick() != null ? flow.startTick() : 0;
             flowsByTick.computeIfAbsent(tick, key -> new ArrayList<>()).add(flow);

--- a/src/main/java/com/liftsimulator/admin/service/metrics/RunMetrics.java
+++ b/src/main/java/com/liftsimulator/admin/service/metrics/RunMetrics.java
@@ -23,6 +23,7 @@ public final class RunMetrics {
     private final int maxFloor;
     private long totalTicks;
     private Integer lastRecordedFloor;
+    private CachedKpis cachedKpis;
 
     public RunMetrics(int minFloor, int maxFloor) {
         this.minFloor = minFloor;
@@ -30,6 +31,7 @@ public final class RunMetrics {
     }
 
     public void recordPassengerFlow(PassengerFlowDTO flow, int passengers) {
+        invalidateCachedKpis();
         if (flow.originFloor() != null) {
             floorMetrics.computeIfAbsent(flow.originFloor(), FloorMetrics::new)
                 .addOrigins(passengers);
@@ -41,6 +43,7 @@ public final class RunMetrics {
     }
 
     public void recordLiftState(LiftState state) {
+        invalidateCachedKpis();
         statusCounts.merge(state.getStatus(), 1L, Long::sum);
         if (lastRecordedFloor == null || lastRecordedFloor != state.getFloor()) {
             floorMetrics.computeIfAbsent(state.getFloor(), FloorMetrics::new)
@@ -51,7 +54,10 @@ public final class RunMetrics {
     }
 
     public void recordRequestCreation(LiftRequest request, long tick) {
-        lifecycles.computeIfAbsent(request.getId(), id -> new RequestLifecycle(request, tick));
+        if (!lifecycles.containsKey(request.getId())) {
+            lifecycles.put(request.getId(), new RequestLifecycle(request, tick));
+            invalidateCachedKpis();
+        }
     }
 
     public void recordActiveRequests(Set<LiftRequest> requests, long tick) {
@@ -61,11 +67,16 @@ public final class RunMetrics {
     }
 
     public void recordTerminalRequests(long tick) {
+        boolean changed = false;
         for (RequestLifecycle lifecycle : lifecycles.values()) {
             if (lifecycle.terminalTick() != null || !lifecycle.request().isTerminal()) {
                 continue;
             }
             lifecycle.markTerminal(tick, lifecycle.request().getState());
+            changed = true;
+        }
+        if (changed) {
+            invalidateCachedKpis();
         }
     }
 
@@ -74,42 +85,17 @@ public final class RunMetrics {
     }
 
     public ObjectNode toKpisNode(ObjectMapper objectMapper) {
+        CachedKpis kpiValues = getCachedKpis();
         ObjectNode kpis = objectMapper.createObjectNode();
-        long completed = lifecycles.values().stream()
-            .filter(lifecycle -> lifecycle.terminalState() == RequestState.COMPLETED)
-            .count();
-        long cancelled = lifecycles.values().stream()
-            .filter(lifecycle -> lifecycle.terminalState() == RequestState.CANCELLED)
-            .count();
-        long maxWait = lifecycles.values().stream()
-            .filter(lifecycle -> lifecycle.terminalState() == RequestState.COMPLETED)
-            .mapToLong(RequestLifecycle::waitTicks)
-            .max()
-            .orElse(0L);
-        double avgWait = lifecycles.values().stream()
-            .filter(lifecycle -> lifecycle.terminalState() == RequestState.COMPLETED)
-            .mapToLong(RequestLifecycle::waitTicks)
-            .average()
-            .orElse(0.0);
-
-        long idleTicks = statusCounts.getOrDefault(LiftStatus.IDLE, 0L)
-            + statusCounts.getOrDefault(LiftStatus.OUT_OF_SERVICE, 0L);
-        long movingTicks = statusCounts.getOrDefault(LiftStatus.MOVING_UP, 0L)
-            + statusCounts.getOrDefault(LiftStatus.MOVING_DOWN, 0L);
-        long doorTicks = statusCounts.getOrDefault(LiftStatus.DOORS_OPENING, 0L)
-            + statusCounts.getOrDefault(LiftStatus.DOORS_OPEN, 0L)
-            + statusCounts.getOrDefault(LiftStatus.DOORS_CLOSING, 0L);
-        double utilisation = totalTicks == 0 ? 0.0 : (double) (movingTicks + doorTicks) / (double) totalTicks;
-
-        kpis.put("requestsTotal", lifecycles.size());
-        kpis.put("passengersServed", completed);
-        kpis.put("passengersCancelled", cancelled);
-        kpis.put("avgWaitTicks", avgWait);
-        kpis.put("maxWaitTicks", maxWait);
-        kpis.put("idleTicks", idleTicks);
-        kpis.put("movingTicks", movingTicks);
-        kpis.put("doorTicks", doorTicks);
-        kpis.put("utilisation", utilisation);
+        kpis.put("requestsTotal", kpiValues.requestsTotal());
+        kpis.put("passengersServed", kpiValues.passengersServed());
+        kpis.put("passengersCancelled", kpiValues.passengersCancelled());
+        kpis.put("avgWaitTicks", kpiValues.avgWaitTicks());
+        kpis.put("maxWaitTicks", kpiValues.maxWaitTicks());
+        kpis.put("idleTicks", kpiValues.idleTicks());
+        kpis.put("movingTicks", kpiValues.movingTicks());
+        kpis.put("doorTicks", kpiValues.doorTicks());
+        kpis.put("utilisation", kpiValues.utilisation());
         return kpis;
     }
 
@@ -133,6 +119,42 @@ public final class RunMetrics {
         }
         lift.set("statusCounts", statusNode);
 
+        CachedKpis kpiValues = getCachedKpis();
+        lift.put("totalTicks", totalTicks);
+        lift.put("idleTicks", kpiValues.idleTicks());
+        lift.put("movingTicks", kpiValues.movingTicks());
+        lift.put("doorTicks", kpiValues.doorTicks());
+        lift.put("utilisation", kpiValues.utilisation());
+
+        lifts.add(lift);
+        return lifts;
+    }
+
+    private CachedKpis getCachedKpis() {
+        if (cachedKpis == null) {
+            cachedKpis = computeKpis();
+        }
+        return cachedKpis;
+    }
+
+    private CachedKpis computeKpis() {
+        long completed = 0L;
+        long cancelled = 0L;
+        long maxWait = 0L;
+        long totalWait = 0L;
+
+        for (RequestLifecycle lifecycle : lifecycles.values()) {
+            if (lifecycle.terminalState() == RequestState.COMPLETED) {
+                completed++;
+                long waitTicks = lifecycle.waitTicks();
+                totalWait += waitTicks;
+                maxWait = Math.max(maxWait, waitTicks);
+            } else if (lifecycle.terminalState() == RequestState.CANCELLED) {
+                cancelled++;
+            }
+        }
+
+        double avgWait = completed == 0L ? 0.0 : (double) totalWait / (double) completed;
         long idleTicks = statusCounts.getOrDefault(LiftStatus.IDLE, 0L)
             + statusCounts.getOrDefault(LiftStatus.OUT_OF_SERVICE, 0L);
         long movingTicks = statusCounts.getOrDefault(LiftStatus.MOVING_UP, 0L)
@@ -142,14 +164,34 @@ public final class RunMetrics {
             + statusCounts.getOrDefault(LiftStatus.DOORS_CLOSING, 0L);
         double utilisation = totalTicks == 0 ? 0.0 : (double) (movingTicks + doorTicks) / (double) totalTicks;
 
-        lift.put("totalTicks", totalTicks);
-        lift.put("idleTicks", idleTicks);
-        lift.put("movingTicks", movingTicks);
-        lift.put("doorTicks", doorTicks);
-        lift.put("utilisation", utilisation);
+        return new CachedKpis(
+            lifecycles.size(),
+            completed,
+            cancelled,
+            avgWait,
+            maxWait,
+            idleTicks,
+            movingTicks,
+            doorTicks,
+            utilisation
+        );
+    }
 
-        lifts.add(lift);
-        return lifts;
+    private void invalidateCachedKpis() {
+        cachedKpis = null;
+    }
+
+    private record CachedKpis(
+        int requestsTotal,
+        long passengersServed,
+        long passengersCancelled,
+        double avgWaitTicks,
+        long maxWaitTicks,
+        long idleTicks,
+        long movingTicks,
+        long doorTicks,
+        double utilisation
+    ) {
     }
 
     public ArrayNode toPerFloorNode(ObjectMapper objectMapper) {

--- a/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
@@ -1,0 +1,70 @@
+package com.liftsimulator.admin.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.admin.entity.SimulationRun;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+class ArtefactServiceTest {
+
+    private final ArtefactService artefactService = new ArtefactService(new ObjectMapper());
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void readLogsReturnsLastLinesFromLargeFile() throws IOException {
+        writeRunLog(12_000);
+        SimulationRun run = runForTempDir();
+
+        String logs = artefactService.readLogs(run, 5);
+
+        assertEquals("line-11996\nline-11997\nline-11998\nline-11999\nline-12000", logs);
+    }
+
+    @Test
+    void readLogsHandlesZeroTailWithoutReadingLines() throws IOException {
+        writeRunLog(10);
+        SimulationRun run = runForTempDir();
+
+        assertEquals("", artefactService.readLogs(run, 0));
+    }
+
+    @Test
+    void readLogsTailsHundredThousandLineFileWithinMicrobenchmarkBudget() throws IOException {
+        writeRunLog(100_000);
+        SimulationRun run = runForTempDir();
+
+        String logs = assertTimeout(Duration.ofSeconds(2), () -> artefactService.readLogs(run, 10_000));
+
+        String[] tailedLines = logs.split("\\n");
+        assertEquals(10_000, tailedLines.length);
+        assertEquals("line-90001", tailedLines[0]);
+        assertEquals("line-100000", tailedLines[tailedLines.length - 1]);
+    }
+
+    private void writeRunLog(int lines) throws IOException {
+        List<String> content = new ArrayList<>(lines);
+        for (int line = 1; line <= lines; line++) {
+            content.add("line-" + line);
+        }
+        Files.write(tempDir.resolve("simulation.log"), content);
+    }
+
+    private SimulationRun runForTempDir() {
+        SimulationRun run = new SimulationRun();
+        run.setId(1L);
+        run.setArtefactBasePath(tempDir.toString());
+        return run;
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/service/RunMetricsTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/RunMetricsTest.java
@@ -98,6 +98,20 @@ class RunMetricsTest {
     }
 
     @Test
+    void cachedKpisAreInvalidatedWhenMetricsChange() {
+        metrics.recordLiftState(new LiftState(1, LiftStatus.IDLE));
+        ObjectNode initialKpis = metrics.toKpisNode(objectMapper);
+        assertEquals(1L, initialKpis.get("idleTicks").asLong());
+
+        metrics.recordLiftState(new LiftState(1, LiftStatus.MOVING_UP));
+        ObjectNode updatedKpis = metrics.toKpisNode(objectMapper);
+
+        assertEquals(1L, updatedKpis.get("idleTicks").asLong());
+        assertEquals(1L, updatedKpis.get("movingTicks").asLong());
+        assertEquals(0.5, updatedKpis.get("utilisation").asDouble(), 1e-9);
+    }
+
+    @Test
     void recordActiveRequestsDoesNotDuplicateKnownRequests() {
         LiftRequest req = LiftRequest.hallCall(1, Direction.UP);
         metrics.recordRequestCreation(req, 0L);


### PR DESCRIPTION
### Motivation
- Improve memory and CPU usage when tailing large run logs by removing an O(n²) buffering pattern. 
- Avoid repeated KPI recomputation when serializing run results to reduce redundant work during result generation. 
- Reduce unnecessary allocations when a scenario has no passenger flows to lower GC pressure for empty scenarios.

### Description
- Replaced `ArtefactService.readLastNLines()` list-shift buffering with a fixed-size `ArrayDeque` ring buffer and added a fast-path for `n == 0` to bound memory and make tailing linear-time. 
- Introduced cached KPI values in `RunMetrics` (`CachedKpis`) and added `invalidateCachedKpis()` calls in mutating methods so KPI computations are reused across `toKpisNode()` and `toPerLiftNode()`. 
- Optimized `SimulationRunExecutionService.groupFlowsByTick()` to return `Collections.emptyMap()` for empty flows and to pre-size the `HashMap` when flows exist to avoid unnecessary allocations. 
- Added tests: new `ArtefactServiceTest` covering large-file tailing (12K and 100K lines) and zero-tail behavior, and extended `RunMetricsTest` to assert cached KPI invalidation semantics. 
- Updated `CHANGELOG.md` and `README.md` to document the performance improvements and the bounded-memory tailing behavior.

### Testing
- `git diff --check` was run and produced no issues. 
- `mvn -Dtest=ArtefactServiceTest,RunMetricsTest test` was attempted but the run was blocked by the environment resolving Maven parent POM from Maven Central (response: `403 Forbidden`), so the new/updated tests could not be executed in this environment. 
- Unit tests were added (`src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java`) and an assertion was added to `RunMetricsTest` to verify cache invalidation; these tests are expected to pass when run in a normal build environment with repository access to Maven Central.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a253e10ee408325bd2b3835e85d247c)