### PR TITLE
Extract troubleshooting and backup docs from README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.4] - 2026-06-08
+
+### Changed
+- **Troubleshooting guide extraction**: Moved the Quick Troubleshooting section and Database Troubleshooting content from `README.md` into a new `docs/TROUBLESHOOTING.md`; the README Quick Troubleshooting section is now a short list of the four most common issues with a link to the full guide.
+- **Database backup extraction**: Moved the Database Backup and Restore section from `README.md` into a new `docs/DATABASE-BACKUP.md`; the README Database Setup section now links to the dedicated file.
+- **Patch version bump**: Updated version references from 0.49.3 to 0.49.4.
+
 ## [0.49.3] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.49.3**
+Current version: **0.49.4**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history, including a condensed summary of the pre-release foundation milestones.
 
@@ -158,43 +158,14 @@ Use these as starting points or reference examples.
 
 ### Quick Troubleshooting
 
-**Backend won't start:**
-- Verify PostgreSQL is running: `psql -h localhost -U lift_admin -d lift_simulator`
-- Check database credentials in `src/main/resources/application-dev.yml`
-- Check port 8080 isn't already in use: `lsof -i :8080` (macOS/Linux) or `netstat -ano | findstr :8080` (Windows)
+Most setup failures fall into one of these categories:
 
-**StackOverflowError in backend logs when loading HTML routes:**
-- Ensure the SPA forwarder does not match `/index.html` (the app now excludes it to prevent recursive forwards)
-- Restart the backend after pulling the latest changes
+- **Database not running** — start PostgreSQL and verify credentials in `application-dev.yml`
+- **Port conflict** — check that ports 8080 (backend) and 3000 (frontend) are free
+- **Node version** — ensure Node.js 20.19+ or 22.12+ is installed (`node --version`)
+- **Migration failure** — verify PostgreSQL 12+ and check Flyway files in `src/main/resources/db/migration/`
 
-**Backend returns 404 for index.html:**
-- Build the frontend assets with `mvn -Pfrontend clean package` or run the frontend dev server at http://localhost:3000
-- Verify `target/classes/static/index.html` exists after building the frontend bundle
-
-**Frontend won't start:**
-- Verify Node.js version: `node --version` (should be 20.19+ or 22.12+)
-- Delete `node_modules` and reinstall: `rm -rf node_modules && npm install`
-- Check port 3000 isn't already in use
-
-**Can't connect to backend from frontend:**
-- Verify backend is running at http://localhost:8080/api/v1/health
-- Check browser console for CORS errors
-- Vite dev proxy should handle this automatically
-
-**Database migrations fail:**
-- Drop and recreate database (see [Database Setup](#database-setup))
-- Verify PostgreSQL version is 12+
-- Check Flyway migration files in `src/main/resources/db/migration/`
-
-**Scenario validation fails with "Unable to read scenario payload":**
-- Confirm the scenario JSON is valid and not empty
-- Retry the request after verifying the payload format
-
-**Cannot delete a lift system due to scenario dependencies:**
-- Delete scenarios (or the versions that reference them) before deleting the lift system
-- Retry the delete once dependent scenarios are removed
-
-For detailed troubleshooting, see the relevant sections below.
+For the full troubleshooting guide covering all failure modes, see [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md).
 
 ---
 
@@ -897,203 +868,15 @@ mvn test
 
 #### Troubleshooting
 
-**Connection refused errors:**
-- Ensure PostgreSQL is running: `sudo service postgresql status`
-- Check the connection settings in `application-dev.yml`
-
-**Permission denied errors:**
-- Verify the database user has proper permissions: `GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;`
-- Ensure schema-level permissions: `GRANT ALL ON SCHEMA lift_simulator TO lift_admin;`
-
-**Migration errors:**
-- Check Flyway history: `SELECT * FROM flyway_schema_history;`
-- For development, you can reset the database: `DROP DATABASE lift_simulator; CREATE DATABASE lift_simulator;`
-- If `public.flyway_schema_history` exists from earlier runs, drop it and restart the app so Flyway recreates history in `lift_simulator`: `DROP TABLE public.flyway_schema_history;`
-- If a legacy `public.schema_metadata` table exists from older releases, it can be dropped; current migrations do not use it: `DROP TABLE public.schema_metadata;`
-- If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` once to clear stale build artifacts; the build now removes old migration resources automatically.
-- If Flyway reports "No migrations found", rebuild with `mvn clean package` to refresh the packaged `db/migration` resources.
+For connection, permission, and migration errors, see [docs/TROUBLESHOOTING.md — Database Troubleshooting](docs/TROUBLESHOOTING.md#database-troubleshooting).
 
 ### Database Backup and Restore
 
-The lift simulator's configuration database can be backed up and restored using PostgreSQL's native `pg_dump` and `pg_restore` utilities. Backups protect against data loss from hardware failure, operator error, or corruption.
-
-#### Manual Ad-Hoc Backup
-
-For immediate, on-demand backups, execute:
-
-**Linux/macOS:**
-```bash
-pg_dump -h localhost -U lift_admin -d lift_simulator -F p -f lift_simulator_backup_$(date +%Y%m%d_%H%M%S).sql
-```
-
-**Windows (Command Prompt):**
-```cmd
-pg_dump -h localhost -U lift_admin -d lift_simulator -F p -f lift_simulator_backup_%date:~-4,4%%date:~-10,2%%date:~-7,2%_%time:~0,2%%time:~3,2%%time:~6,2%.sql
-```
-
-**Windows (PowerShell):**
-```powershell
-pg_dump -h localhost -U lift_admin -d lift_simulator -F p -f "lift_simulator_backup_$(Get-Date -Format 'yyyyMMdd_HHmmss').sql"
-```
-
-This creates a plain SQL backup file with a timestamp in the filename (e.g., `lift_simulator_backup_20260113_140530.sql`).
-
-**When to use manual backups:**
-- Before major schema migrations or application upgrades
-- Before bulk data updates or deletions
-- Before testing risky operations
-- Before deploying to a new environment
-
-#### Automated Scheduled Backup
-
-Automated backups are managed via an external PowerShell script in the **My-Scripts** repository.
-
-**Schedule**: Every Tuesday at 8:00 a.m. (Windows Task Scheduler)
-
-**Script Location**: `My-Scripts/src/powershell/backup/Backup-LiftSimulatorDatabase.ps1`
-
-**Command** (example local path, may vary):
-```powershell
-pwsh -File "C:\Users\manoj\Documents\Scripts\src\powershell\backup\Backup-LiftSimulatorDatabase.ps1"
-```
-
-**Backup Storage**:
-- Backups: `D:\pgbackup\lift_simulator`
-- Logs: `D:\pgbackup\lift_simulator\logs`
-
-**Note**: Paths shown are local examples; your implementation may vary. Refer to the My-Scripts repository at `src/powershell/backup/README-LiftSimulator.md` for setup instructions, prerequisites, and configuration details.
-
-#### Restore Procedure
-
-**Standard Restore** (to existing database):
-
-1. Stop the Spring Boot application to prevent writes during restore
-
-2. Drop and recreate the database:
-
-   **Linux/macOS:**
-   ```bash
-   sudo -u postgres psql -c "DROP DATABASE lift_simulator;"
-   sudo -u postgres psql -c "CREATE DATABASE lift_simulator;"
-   sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;"
-   ```
-
-   **Windows:**
-   ```cmd
-   psql -U postgres -c "DROP DATABASE lift_simulator;"
-   psql -U postgres -c "CREATE DATABASE lift_simulator;"
-   psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;"
-   ```
-
-3. Restore from backup file:
-
-   **Linux/macOS:**
-   ```bash
-   psql -h localhost -U lift_admin -d lift_simulator -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
-   ```
-
-   **Windows:**
-   ```cmd
-   psql -h localhost -U lift_admin -d lift_simulator -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
-   ```
-
-4. Verify the restore:
-
-   **Linux/macOS:**
-   ```bash
-   psql -h localhost -U lift_admin -d lift_simulator -c "\dt"
-   psql -h localhost -U lift_admin -d lift_simulator -c "SELECT COUNT(*) FROM lift_system;"
-   ```
-
-   **Windows:**
-   ```cmd
-   psql -h localhost -U lift_admin -d lift_simulator -c "\dt"
-   psql -h localhost -U lift_admin -d lift_simulator -c "SELECT COUNT(*) FROM lift_system;"
-   ```
-
-5. Restart the application
-
-**Clean Restore** (to new machine or fresh install):
-
-1. Install PostgreSQL 12 or later
-2. Create the database and user as documented in the Database Setup section above
-3. Restore from backup (step 3 from Standard Restore)
-4. Verify the restore (step 4 from Standard Restore)
-5. Start the application
-
-#### Backup Verification
-
-To verify a backup file is valid:
-
-**Linux/macOS:**
-```bash
-# Check file size and format
-ls -lh lift_simulator_backup_*.sql
-
-# View first 20 lines (should show valid SQL)
-head -n 20 lift_simulator_backup_*.sql
-```
-
-**Windows (Command Prompt):**
-```cmd
-REM Check file size
-dir lift_simulator_backup_*.sql
-
-REM View first 20 lines (should show valid SQL)
-more /E +1 lift_simulator_backup_*.sql | findstr /N ".*" | findstr "^[1-9]: ^[12][0-9]:"
-```
-
-**Windows (PowerShell):**
-```powershell
-# Check file size
-Get-ChildItem lift_simulator_backup_*.sql | Format-Table Name, Length, LastWriteTime
-
-# View first 20 lines (should show valid SQL)
-Get-Content lift_simulator_backup_*.sql -Head 20
-```
-
-**Periodic restore testing** (recommended quarterly):
-
-**Linux/macOS:**
-```bash
-# Create test database
-createdb lift_simulator_test
-
-# Restore to test database
-psql -U lift_admin -d lift_simulator_test -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
-
-# Verify tables exist
-psql -U lift_admin -d lift_simulator_test -c "\dt"
-
-# Clean up
-dropdb lift_simulator_test
-```
-
-**Windows:**
-```cmd
-REM Create test database
-createdb lift_simulator_test
-
-REM Restore to test database
-psql -U lift_admin -d lift_simulator_test -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
-
-REM Verify tables exist
-psql -U lift_admin -d lift_simulator_test -c "\dt"
-
-REM Clean up
-dropdb lift_simulator_test
-```
-
-#### Important Notes
-
-- Backups can be taken while the database is online (no application downtime required)
-- Configuration data is **not** committed to version control; backups are the only recovery mechanism
-- For detailed backup/restore architecture and automation setup, see ADR-0012 and the My-Scripts repository documentation
-- Backup retention policy and log management are handled by the external backup script
+For backup and restore procedures, see [docs/DATABASE-BACKUP.md](docs/DATABASE-BACKUP.md).
 
 ## Features
 
-The current version (v0.49.3) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.49.4) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.3.jar
+java -jar target/lift-simulator-0.49.4.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api/v1`.
@@ -292,7 +292,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.49.3.jar
+java -jar target/lift-simulator-0.49.4.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -320,7 +320,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - Logging level: `INFO` (root), `DEBUG` (com.liftsimulator package)
 - Actuator endpoints: health, info
 
-No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.3.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.4.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (environment variable: `SECURITY_OPENAPI_PUBLIC_ACCESS`). The default is `true` to preserve current behavior; set it to `false` when documentation endpoints should require ADMIN-role authentication.
 
@@ -813,7 +813,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.3.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.4.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -1085,10 +1085,10 @@ To build a deployable Spring Boot JAR that also serves the React admin UI from `
 mvn -Pfrontend clean package
 ```
 
-The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.3.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
+The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.4.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
 
 ```bash
-jar tf target/lift-simulator-0.49.3.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.4.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running Tests
@@ -1169,7 +1169,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1178,16 +1178,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1201,7 +1201,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1219,7 +1219,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1228,13 +1228,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.49.3.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.49.4.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -1025,7 +1025,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -1039,12 +1039,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -1083,7 +1083,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -1096,7 +1096,7 @@ java -cp target/lift-simulator-0.49.3.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -1107,7 +1107,7 @@ java -cp target/lift-simulator-0.49.3.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -1383,7 +1383,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.3.jar \
+   java -cp target/lift-simulator-0.49.4.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -1428,7 +1428,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -1520,7 +1520,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.3.jar \
+java -cp target/lift-simulator-0.49.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/docs/DATABASE-BACKUP.md
+++ b/docs/DATABASE-BACKUP.md
@@ -1,0 +1,189 @@
+# Database Backup and Restore
+
+The lift simulator's configuration database can be backed up and restored using PostgreSQL's native `pg_dump` and `pg_restore` utilities. Backups protect against data loss from hardware failure, operator error, or corruption.
+
+For database setup instructions, see the [Database Setup](../README.md#database-setup) section of the README.
+
+---
+
+## Manual Ad-Hoc Backup
+
+For immediate, on-demand backups, execute:
+
+**Linux/macOS:**
+```bash
+pg_dump -h localhost -U lift_admin -d lift_simulator -F p -f lift_simulator_backup_$(date +%Y%m%d_%H%M%S).sql
+```
+
+**Windows (Command Prompt):**
+```cmd
+pg_dump -h localhost -U lift_admin -d lift_simulator -F p -f lift_simulator_backup_%date:~-4,4%%date:~-10,2%%date:~-7,2%_%time:~0,2%%time:~3,2%%time:~6,2%.sql
+```
+
+**Windows (PowerShell):**
+```powershell
+pg_dump -h localhost -U lift_admin -d lift_simulator -F p -f "lift_simulator_backup_$(Get-Date -Format 'yyyyMMdd_HHmmss').sql"
+```
+
+This creates a plain SQL backup file with a timestamp in the filename (e.g., `lift_simulator_backup_20260113_140530.sql`).
+
+**When to use manual backups:**
+- Before major schema migrations or application upgrades
+- Before bulk data updates or deletions
+- Before testing risky operations
+- Before deploying to a new environment
+
+---
+
+## Automated Scheduled Backup
+
+Automated backups are managed via an external PowerShell script in the **My-Scripts** repository.
+
+**Schedule**: Every Tuesday at 8:00 a.m. (Windows Task Scheduler)
+
+**Script Location**: `My-Scripts/src/powershell/backup/Backup-LiftSimulatorDatabase.ps1`
+
+**Command** (example local path, may vary):
+```powershell
+pwsh -File "C:\Users\manoj\Documents\Scripts\src\powershell\backup\Backup-LiftSimulatorDatabase.ps1"
+```
+
+**Backup Storage**:
+- Backups: `D:\pgbackup\lift_simulator`
+- Logs: `D:\pgbackup\lift_simulator\logs`
+
+**Note**: Paths shown are local examples; your implementation may vary. Refer to the My-Scripts repository at `src/powershell/backup/README-LiftSimulator.md` for setup instructions, prerequisites, and configuration details.
+
+---
+
+## Restore Procedure
+
+### Standard Restore (to existing database)
+
+1. Stop the Spring Boot application to prevent writes during restore
+
+2. Drop and recreate the database:
+
+   **Linux/macOS:**
+   ```bash
+   sudo -u postgres psql -c "DROP DATABASE lift_simulator;"
+   sudo -u postgres psql -c "CREATE DATABASE lift_simulator;"
+   sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;"
+   ```
+
+   **Windows:**
+   ```cmd
+   psql -U postgres -c "DROP DATABASE lift_simulator;"
+   psql -U postgres -c "CREATE DATABASE lift_simulator;"
+   psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;"
+   ```
+
+3. Restore from backup file:
+
+   **Linux/macOS:**
+   ```bash
+   psql -h localhost -U lift_admin -d lift_simulator -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
+   ```
+
+   **Windows:**
+   ```cmd
+   psql -h localhost -U lift_admin -d lift_simulator -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
+   ```
+
+4. Verify the restore:
+
+   **Linux/macOS:**
+   ```bash
+   psql -h localhost -U lift_admin -d lift_simulator -c "\dt"
+   psql -h localhost -U lift_admin -d lift_simulator -c "SELECT COUNT(*) FROM lift_system;"
+   ```
+
+   **Windows:**
+   ```cmd
+   psql -h localhost -U lift_admin -d lift_simulator -c "\dt"
+   psql -h localhost -U lift_admin -d lift_simulator -c "SELECT COUNT(*) FROM lift_system;"
+   ```
+
+5. Restart the application
+
+### Clean Restore (to new machine or fresh install)
+
+1. Install PostgreSQL 12 or later
+2. Create the database and user as documented in the [Database Setup](../README.md#database-setup) section
+3. Restore from backup (step 3 from Standard Restore above)
+4. Verify the restore (step 4 from Standard Restore above)
+5. Start the application
+
+---
+
+## Backup Verification
+
+To verify a backup file is valid:
+
+**Linux/macOS:**
+```bash
+# Check file size and format
+ls -lh lift_simulator_backup_*.sql
+
+# View first 20 lines (should show valid SQL)
+head -n 20 lift_simulator_backup_*.sql
+```
+
+**Windows (Command Prompt):**
+```cmd
+REM Check file size
+dir lift_simulator_backup_*.sql
+
+REM View first 20 lines (should show valid SQL)
+more /E +1 lift_simulator_backup_*.sql | findstr /N ".*" | findstr "^[1-9]: ^[12][0-9]:"
+```
+
+**Windows (PowerShell):**
+```powershell
+# Check file size
+Get-ChildItem lift_simulator_backup_*.sql | Format-Table Name, Length, LastWriteTime
+
+# View first 20 lines (should show valid SQL)
+Get-Content lift_simulator_backup_*.sql -Head 20
+```
+
+**Periodic restore testing** (recommended quarterly):
+
+**Linux/macOS:**
+```bash
+# Create test database
+createdb lift_simulator_test
+
+# Restore to test database
+psql -U lift_admin -d lift_simulator_test -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
+
+# Verify tables exist
+psql -U lift_admin -d lift_simulator_test -c "\dt"
+
+# Clean up
+dropdb lift_simulator_test
+```
+
+**Windows:**
+```cmd
+REM Create test database
+createdb lift_simulator_test
+
+REM Restore to test database
+psql -U lift_admin -d lift_simulator_test -f lift_simulator_backup_YYYYMMDD_HHMMSS.sql
+
+REM Verify tables exist
+psql -U lift_admin -d lift_simulator_test -c "\dt"
+
+REM Clean up
+dropdb lift_simulator_test
+```
+
+---
+
+## Important Notes
+
+- Backups can be taken while the database is online (no application downtime required)
+- Configuration data is **not** committed to version control; backups are the only recovery mechanism
+- For detailed backup/restore architecture and automation setup, see [ADR-0012](decisions/0012-database-backup-restore-strategy.md) and the My-Scripts repository documentation
+- Backup retention policy and log management are handled by the external backup script

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,76 @@
+# Troubleshooting Guide
+
+This guide covers common problems encountered when setting up, running, or operating the Lift Simulator.
+
+For API-level errors, see [docs/API.md](API.md).
+
+---
+
+## Quick Start Troubleshooting
+
+### Backend won't start
+
+- Verify PostgreSQL is running: `psql -h localhost -U lift_admin -d lift_simulator`
+- Check database credentials in `src/main/resources/application-dev.yml`
+- Check port 8080 isn't already in use: `lsof -i :8080` (macOS/Linux) or `netstat -ano | findstr :8080` (Windows)
+
+### StackOverflowError in backend logs when loading HTML routes
+
+- Ensure the SPA forwarder does not match `/index.html` (the app now excludes it to prevent recursive forwards)
+- Restart the backend after pulling the latest changes
+
+### Backend returns 404 for index.html
+
+- Build the frontend assets with `mvn -Pfrontend clean package` or run the frontend dev server at http://localhost:3000
+- Verify `target/classes/static/index.html` exists after building the frontend bundle
+
+### Frontend won't start
+
+- Verify Node.js version: `node --version` (should be 20.19+ or 22.12+)
+- Delete `node_modules` and reinstall: `rm -rf node_modules && npm install`
+- Check port 3000 isn't already in use
+
+### Can't connect to backend from frontend
+
+- Verify backend is running at http://localhost:8080/api/v1/health
+- Check browser console for CORS errors
+- Vite dev proxy should handle this automatically
+
+### Database migrations fail
+
+- Drop and recreate database (see [Database Setup](../README.md#database-setup))
+- Verify PostgreSQL version is 12+
+- Check Flyway migration files in `src/main/resources/db/migration/`
+
+### Scenario validation fails with "Unable to read scenario payload"
+
+- Confirm the scenario JSON is valid and not empty
+- Retry the request after verifying the payload format
+
+### Cannot delete a lift system due to scenario dependencies
+
+- Delete scenarios (or the versions that reference them) before deleting the lift system
+- Retry the delete once dependent scenarios are removed
+
+---
+
+## Database Troubleshooting
+
+### Connection refused errors
+
+- Ensure PostgreSQL is running: `sudo service postgresql status`
+- Check the connection settings in `application-dev.yml`
+
+### Permission denied errors
+
+- Verify the database user has proper permissions: `GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;`
+- Ensure schema-level permissions: `GRANT ALL ON SCHEMA lift_simulator TO lift_admin;`
+
+### Migration errors
+
+- Check Flyway history: `SELECT * FROM flyway_schema_history;`
+- For development, you can reset the database: `DROP DATABASE lift_simulator; CREATE DATABASE lift_simulator;`
+- If `public.flyway_schema_history` exists from earlier runs, drop it and restart the app so Flyway recreates history in `lift_simulator`: `DROP TABLE public.flyway_schema_history;`
+- If a legacy `public.schema_metadata` table exists from older releases, it can be dropped; current migrations do not use it: `DROP TABLE public.schema_metadata;`
+- If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` once to clear stale build artifacts; the build now removes old migration resources automatically.
+- If Flyway reports "No migrations found", rebuild with `mvn clean package` to refresh the packaged `db/migration` resources.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.3",
+  "version": "0.49.4",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.3</version>
+    <version>0.49.4</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
## Summary

This PR refactors documentation by extracting lengthy troubleshooting and database backup procedures from the main README into dedicated documentation files, improving maintainability and navigation while keeping the README focused on core setup instructions.

## Key Changes

- **Created `docs/TROUBLESHOOTING.md`**: Extracted comprehensive troubleshooting guide covering:
  - Quick start issues (backend/frontend startup, connectivity, migrations)
  - Database-specific troubleshooting (connection, permissions, Flyway errors)
  - Scenario validation and lift system deletion issues

- **Created `docs/DATABASE-BACKUP.md`**: Extracted complete backup and restore procedures including:
  - Manual ad-hoc backup commands (Linux/macOS/Windows variants)
  - Automated scheduled backup setup via PowerShell
  - Standard and clean restore procedures
  - Backup verification and periodic testing steps

- **Updated `README.md`**:
  - Condensed "Quick Troubleshooting" section to a brief 4-item list with link to full guide
  - Replaced detailed database troubleshooting with single-line reference to `docs/TROUBLESHOOTING.md`
  - Replaced extensive backup/restore section with single-line reference to `docs/DATABASE-BACKUP.md`

- **Version bump**: Updated version from 0.49.3 to 0.49.4 in:
  - `README.md`
  - `pom.xml`
  - `frontend/package.json`
  - `CHANGELOG.md`

## Implementation Details

- All extracted content is preserved verbatim with proper cross-references
- Documentation links use relative paths for consistency
- Quick Troubleshooting section in README now focuses on the four most common setup issues
- Full troubleshooting and backup guides remain accessible via clear documentation links

https://claude.ai/code/session_01Ru3xzxu3yso5D2v48379oA