### PR TITLE
docs: extract developer guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.49.6] - 2026-06-08
+
+### Changed
+- **Developer guide extraction**: Moved simulation engine internals, request modeling, lift state machine, and JPA entity/repository reference material from `README.md` into the new `docs/DEVELOPER-GUIDE.md`; the README now links to the dedicated developer reference.
+- **Patch version bump**: Updated package metadata, frontend package metadata, README references, and extracted API documentation references from 0.49.5 to 0.49.6.
+
 ## [0.49.5] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.49.5**
+Current version: **0.49.6**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history, including a condensed summary of the pre-release foundation milestones.
 
@@ -242,7 +242,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.5.jar
+java -jar target/lift-simulator-0.49.6.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api/v1`.
@@ -292,7 +292,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.49.5.jar
+java -jar target/lift-simulator-0.49.6.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -320,7 +320,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - Logging level: `INFO` (root), `DEBUG` (com.liftsimulator package)
 - Actuator endpoints: health, info
 
-No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.5.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.6.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (environment variable: `SECURITY_OPENAPI_PUBLIC_ACCESS`). The default is `true` to preserve current behavior; set it to `false` when documentation endpoints should require ADMIN-role authentication.
 
@@ -741,130 +741,8 @@ The `simulation_run` table tracks run status (CREATED, RUNNING, SUCCEEDED, FAILE
 
 ### JPA Entities and Repositories
 
-The backend includes JPA entities and Spring Data repositories for database access:
+For developer-facing details about JPA entities, Spring Data repositories, verification runner usage, and repository integration tests, see [docs/DEVELOPER-GUIDE.md#jpa-entities-and-repositories](docs/DEVELOPER-GUIDE.md#jpa-entities-and-repositories).
 
-#### Entities
-
-- **LiftSystem** (`com.liftsimulator.admin.entity.LiftSystem`)
-  - Maps to `lift_system` table
-  - Root configuration records for lift systems
-  - Manages one-to-many relationship with versions
-  - Automatic timestamp management via `@PrePersist` and `@PreUpdate`
-
-- **LiftSystemVersion** (`com.liftsimulator.admin.entity.LiftSystemVersion`)
-  - Maps to `lift_system_version` table
-  - Versioned lift configuration payloads
-  - **JSONB field mapping**: Uses `@JdbcTypeCode(SqlTypes.JSON)` for PostgreSQL JSONB support
-  - Version status enum: DRAFT, PUBLISHED, ARCHIVED
-  - Helper methods: `publish()`, `archive()`
-
-- **Scenario** (`com.liftsimulator.admin.entity.Scenario`)
-  - Maps to `scenario` table
-  - Reusable test scenarios for lift system testing
-  - **JSONB field mapping**: Stores scenario configuration as JSON
-  - Automatic timestamp management via `@PrePersist` and `@PreUpdate`
-
-- **SimulationRun** (`com.liftsimulator.admin.entity.SimulationRun`)
-  - Maps to `simulation_run` table
-  - Individual simulation run executions with lifecycle tracking
-  - Run status enum: CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED
-  - Relationships: Many-to-one with LiftSystem, LiftSystemVersion, and Scenario
-  - Status transition methods: `start()`, `succeed()`, `fail()`, `cancel()`
-  - Progress tracking via repository-backed current tick updates
-
-#### Repositories
-
-- **LiftSystemRepository** (`com.liftsimulator.admin.repository.LiftSystemRepository`)
-  - Find by system key: `findBySystemKey(String systemKey)`
-  - Check existence: `existsBySystemKey(String systemKey)`
-  - Standard CRUD operations via `JpaRepository`
-
-- **LiftSystemVersionRepository** (`com.liftsimulator.admin.repository.LiftSystemVersionRepository`)
-  - Find versions by lift system: `findByLiftSystemIdOrderByVersionNumberDesc(Long liftSystemId)`
-  - Find specific version: `findByLiftSystemIdAndVersionNumber(Long liftSystemId, Integer versionNumber)`
-  - Find published versions: `findByLiftSystemIdAndIsPublishedTrue(Long liftSystemId)`
-  - Find by status: `findByStatus(VersionStatus status)`
-  - Get max version number: `findMaxVersionNumberByLiftSystemId(Long liftSystemId)`
-
-- **ScenarioRepository** (`com.liftsimulator.admin.repository.ScenarioRepository`)
-  - Find by name: `findByName(String name)`
-  - Find by name pattern: `findByNameContainingIgnoreCase(String name)`
-  - Check existence: `existsByName(String name)`
-  - Standard CRUD operations via `JpaRepository`
-
-- **SimulationRunRepository** (`com.liftsimulator.admin.repository.SimulationRunRepository`)
-  - Persists simulation run lifecycle changes for both API orchestration and asynchronous execution, avoiding service-to-service circular dependencies
-  - Update run progress directly: `updateCurrentTick(Long id, Long currentTick)`
-  - Find runs by lift system: `findByLiftSystemIdOrderByCreatedAtDesc(Long liftSystemId)`
-  - Find runs by version: `findByVersionIdOrderByCreatedAtDesc(Long versionId)`
-  - Find runs by scenario: `findByScenarioIdOrderByCreatedAtDesc(Long scenarioId)`
-  - Find runs by status: `findByStatusOrderByCreatedAtDesc(RunStatus status)`
-  - Find active runs: `findActiveRunsByLiftSystemId(Long liftSystemId)`
-  - Count operations: `countByLiftSystemId(Long liftSystemId)`, `countByStatus(RunStatus status)`
-
-#### Verifying JPA Operations
-
-To verify the JPA entities and repositories are working correctly, run the Spring Boot application with the JPA verification runner:
-
-```bash
-mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
-```
-
-Or with the JAR:
-
-```bash
-java -jar target/lift-simulator-0.49.5.jar --spring.jpa.verify=true
-```
-
-The verification runner will:
-1. Create and retrieve `LiftSystem` entities
-2. Create and retrieve `LiftSystemVersion` entities with JSONB configs
-3. Test complex JSON configurations
-4. Verify entity relationships and cascading
-5. Test all custom query methods
-
-Look for log output like:
-```
-=== Starting JPA Entity and Repository Verification ===
---- Verifying LiftSystem CRUD Operations ---
-✓ Created LiftSystem: id=1, key=demo-system
-✓ Found LiftSystem by ID: demo-system
---- Verifying JSONB Field Mapping ---
-✓ Saved complex JSONB config: id=2
-✓ Retrieved JSONB config matches original
-=== JPA Verification Completed Successfully ===
-```
-
-The verification runner is located at `com.liftsimulator.admin.runner.JpaVerificationRunner` and is only enabled when `spring.jpa.verify=true` is set.
-
-#### Integration Tests
-
-Integration tests for the repositories are available:
-- `LiftSystemRepositoryTest`: Tests CRUD operations, queries, and updates
-- `LiftSystemVersionRepositoryTest`: Tests version operations, JSONB mapping, and relationships
-- `FlywayMigrationIntegrationTest`: Verifies that Flyway migrations are executed at startup
-
-**Test Database Configuration:**
-- Integration tests run against a **real PostgreSQL** instance provisioned on demand by
-  [Testcontainers](https://java.testcontainers.org/) — **no pre-existing database is required**.
-- The only prerequisite is a running **Docker** daemon (Testcontainers starts and tears down a
-  `postgres:15-alpine` container automatically). A single container is shared across the suite to
-  keep startup fast.
-- **Flyway migrations run during test startup**, so migration bugs are caught by the test suite.
-- Hibernate runs in **`validate`** mode (not `ddl-auto: update`), so the entity mappings are
-  checked against the migrated schema and any drift fails the build.
-- In CI, where the workflow provides a PostgreSQL service container via `SPRING_DATASOURCE_URL`,
-  Testcontainers stands aside and that database is used instead.
-
-Run the tests:
-```bash
-mvn test -Dtest=LiftSystemRepositoryTest,LiftSystemVersionRepositoryTest
-```
-
-Or run all tests:
-```bash
-mvn test
-```
 
 #### Troubleshooting
 
@@ -876,7 +754,7 @@ For backup and restore procedures, see [docs/DATABASE-BACKUP.md](docs/DATABASE-B
 
 ## Features
 
-The current version (v0.49.5) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.49.6) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -1085,10 +963,10 @@ To build a deployable Spring Boot JAR that also serves the React admin UI from `
 mvn -Pfrontend clean package
 ```
 
-The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.5.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
+The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.6.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
 
 ```bash
-jar tf target/lift-simulator-0.49.5.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.6.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running Tests
@@ -1169,7 +1047,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1178,16 +1056,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1201,7 +1079,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1219,7 +1097,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1228,13 +1106,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.49.5.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**
@@ -1285,352 +1163,9 @@ Scenario metadata keys:
 
 Note: If a `return_to_service` event is scheduled while the lift is still completing the out-of-service shutdown sequence, the return is deferred until the lift reaches the `OUT_OF_SERVICE` state.
 
-## Configuring Tick Timing
+## Simulation Engine and Developer Reference
 
-You can model travel and door timing by using the `SimulationEngine` builder:
-
-```java
-SimulationEngine engine = SimulationEngine.builder(controller, 0, 10)
-    .travelTicksPerFloor(3)
-    .doorTransitionTicks(2)
-    .doorDwellTicks(3)
-    .doorReopenWindowTicks(2)
-    .build();
-```
-
-- **travelTicksPerFloor**: How many ticks it takes to move one floor
-- **doorTransitionTicks**: Ticks required for doors to fully open or close
-- **doorDwellTicks**: How long doors remain open before automatically closing
-- **doorReopenWindowTicks**: Time window (in ticks) during door closing when doors can be reopened for new requests at the current floor
-  - Must be non-negative and cannot exceed `doorTransitionTicks`
-  - Default: `min(2, doorTransitionTicks)` for backward compatibility
-  - Setting to 0 disables door reopening (doors cannot be interrupted once closing starts)
-  - Realistic behavior: if a request arrives for the current floor while doors are closing and within this window, doors will reopen
-  - If the window has passed, the request is queued normally and will be served in the next cycle
-
-## Configuring Idle Parking
-
-You can configure the home floor, idle timeout, and parking behavior for the naive controller:
-
-```java
-NaiveLiftController controller = new NaiveLiftController(
-    0,                                        // homeFloor
-    5,                                        // idleTimeoutTicks
-    IdleParkingMode.PARK_TO_HOME_FLOOR       // idleParkingMode
-);
-```
-
-- **homeFloor**: The floor to park on when idle (used only with `PARK_TO_HOME_FLOOR` mode)
-- **idleTimeoutTicks**: How many idle ticks before the parking behavior activates (0 means activate immediately)
-- **idleParkingMode**: The parking behavior when idle timeout is reached (optional, defaults to `PARK_TO_HOME_FLOOR`)
-  - `IdleParkingMode.STAY_AT_CURRENT_FLOOR`: Lift stays at current floor indefinitely when idle
-  - `IdleParkingMode.PARK_TO_HOME_FLOOR`: Lift moves to home floor after idle timeout (existing behavior)
-
-**Backward compatibility**: The two-parameter constructor defaults to `PARK_TO_HOME_FLOOR` mode:
-
-```java
-// This uses PARK_TO_HOME_FLOOR mode by default
-NaiveLiftController controller = new NaiveLiftController(0, 5);
-```
-
-**Scenario file configuration:**
-
-```
-home_floor: 0
-idle_timeout_ticks: 5
-idle_parking_mode: STAY_AT_CURRENT_FLOOR
-```
-
-The `idle_parking_mode` parameter is optional and defaults to `PARK_TO_HOME_FLOOR` if not specified.
-
-## Selecting Controller Strategy
-
-You can configure which controller algorithm the lift uses via the `ControllerStrategy` enum:
-
-```java
-// Create controller using factory with desired strategy
-LiftController controller = ControllerFactory.createController(
-    ControllerStrategy.NEAREST_REQUEST_ROUTING,
-    0,                                        // homeFloor
-    5,                                        // idleTimeoutTicks
-    IdleParkingMode.PARK_TO_HOME_FLOOR       // idleParkingMode
-);
-```
-
-**Available strategies:**
-- `ControllerStrategy.NEAREST_REQUEST_ROUTING`: Services the nearest request first (default, uses `NaiveLiftController`)
-- `ControllerStrategy.DIRECTIONAL_SCAN`: Directional scan/elevator algorithm (uses `DirectionalScanLiftController`)
-
-**Factory methods:**
-
-```java
-// With default parameters (home floor 0, idle timeout 5 ticks, park to home floor)
-LiftController controller = ControllerFactory.createController(
-    ControllerStrategy.NEAREST_REQUEST_ROUTING
-);
-
-// With custom parameters
-LiftController controller = ControllerFactory.createController(
-    ControllerStrategy.NEAREST_REQUEST_ROUTING,
-    homeFloor,
-    idleTimeoutTicks,
-    idleParkingMode
-);
-```
-
-**Scenario file configuration:**
-
-```
-controller_strategy: NEAREST_REQUEST_ROUTING
-```
-
-The `controller_strategy` parameter is optional and defaults to `NEAREST_REQUEST_ROUTING` if not specified.
-
-**Notes:**
-- The controller strategy must be selected at system initialization (not runtime switchable)
-- Invalid strategy names in scenario files will throw an `IllegalArgumentException`
-
-## Controller Strategies
-
-### Nearest Request Routing (NaiveLiftController)
-
-The nearest request routing strategy services the closest requested floor first, regardless of direction. This is a simple but inefficient algorithm that can result in excessive back-and-forth movement.
-
-**Behavior:**
-- Selects the nearest floor with a pending request
-- Services requests immediately upon arrival
-- No batching or direction preference
-- Best suited for low-traffic scenarios
-
-**Use case:** Simple lifts with minimal traffic where efficiency isn't critical.
-
-### Directional Scan (DirectionalScanLiftController)
-
-The directional scan strategy implements a SCAN-style algorithm that continues in the current direction until all requests in that direction are serviced, then reverses.
-
-**Behavior:**
-- **Direction commitment:** Once moving in a direction, continues until no more requests exist ahead
-- **Hall call filtering:** Only services hall calls that match the current travel direction
-  - Example: While going UP, only services hall calls with direction=UP
-  - Exception: Car calls are always eligible (passengers already onboard)
-- **Reversal logic:** Reverses at the furthest pending stop in the current direction
-- **Efficient batching:** Reduces back-and-forth movement by servicing multiple requests in one sweep
-- **Direction selection:** When idle, selects initial direction based on nearest request
-
-**Example scenario:**
-```
-Lift at floor 0, requests:
-- Hall call: floor 2, UP
-- Car call: floor 5
-- Hall call: floor 3, DOWN
-
-Execution:
-1. Select UP direction (floor 2 is nearest)
-2. Service floor 2 (hall call UP) ✓
-3. Continue to floor 5 (car call) ✓
-4. No more requests going UP, reverse to DOWN
-5. Service floor 3 (hall call DOWN) ✓
-```
-
-**Advantages:**
-- Reduces average wait time in moderate to high traffic
-- Minimizes unnecessary direction changes
-- More predictable behavior for passengers
-- Better energy efficiency
-
-**Use case:** Most real-world elevator scenarios, especially multi-floor buildings with moderate traffic.
-
-**Key invariants maintained:**
-- No duplicate servicing of requests
-- No lost requests during movement
-- Compatible with door open/close timing semantics
-- Requests can be added during movement and will be scheduled according to rules
-
-## Taking Lifts Out of Service
-
-You can take a lift out of service for maintenance or emergency situations:
-
-```java
-// Take lift out of service
-controller.takeOutOfService();  // Cancels all pending requests
-engine.setOutOfService();       // Transitions to OUT_OF_SERVICE state
-
-// ... lift is now offline and cannot move or accept requests ...
-
-// Return to service
-controller.returnToService();   // Prepares controller for normal operation
-engine.returnToService();       // Transitions to IDLE state
-```
-
-**Behavior when taking out of service (graceful shutdown):**
-- All pending requests (QUEUED, ASSIGNED, SERVING) are immediately cancelled
-- If the lift is moving, it completes movement to the next floor in its current direction
-- Doors open to allow passengers to exit safely
-- Doors close after dwell time
-- Lift transitions to OUT_OF_SERVICE state
-- While OUT_OF_SERVICE: cannot move, open doors, or accept new requests (new assignments are ignored)
-
-**Behavior when returning to service:**
-- Lift transitions to IDLE state at its current floor
-- Can immediately accept and service new requests
-- Operates normally as if freshly initialized
-
-**Use cases:**
-- Emergency stop situations
-- Scheduled maintenance windows
-- Simulating equipment failures
-- Testing failover scenarios in multi-lift systems
-
-## Running Tests
-
-Execute all tests:
-
-```bash
-mvn test
-```
-
-Run code style checks:
-
-```bash
-mvn checkstyle:check
-```
-
-Run static analysis:
-
-```bash
-mvn spotbugs:check
-```
-
-Run tests with coverage:
-
-```bash
-mvn test jacoco:report jacoco:check
-```
-
-The JaCoCo check enforces a minimum 80% line coverage threshold for the project.
-
-## Request Types: Hall Calls vs. Car Calls
-
-The simulator distinguishes between two types of lift requests, modeling real-world elevator behavior:
-
-### Hall Call (Request from outside the lift)
-
-Made when someone presses an up/down button **outside** the lift:
-
-```java
-controller.addHallCall(new HallCall(3, Direction.UP));
-```
-
-**Known information:**
-- **Origin floor**: Where the person is waiting (floor 3)
-- **Direction**: Where they want to go (UP or DOWN)
-- **Unknown**: Exact destination floor (person hasn't boarded yet)
-
-**Physical analog:** The up/down buttons on each floor
-
-**Completion:** Request completes when lift arrives at the origin floor and opens doors (person can now board)
-
-### Car Call (Request from inside the lift)
-
-Made when someone presses a floor button **inside** the lift:
-
-```java
-controller.addCarCall(new CarCall(7));
-```
-
-**Known information:**
-- **Destination floor**: Where the person wants to go (floor 7)
-- **Unknown/Irrelevant**: Origin floor, direction (inferred from current position)
-
-**Physical analog:** The numbered floor buttons inside the lift car
-
-**Completion:** Request completes when lift arrives at the destination floor and opens doors (person can now exit)
-
-### Why the Distinction Matters
-
-#### 1. Current Naive Algorithm
-The current `NaiveLiftController` treats both types similarly (goes to nearest floor), but the infrastructure supports future smart algorithms.
-
-#### 2. Future Direction-Aware Scheduling
-Smart algorithms can optimize based on hall call direction:
-
-**Example scenario:**
-- Lift at floor 0
-- Hall call: floor 3 going DOWN
-- Hall call: floor 5 going UP
-- Car call: floor 7
-
-**Naive:** 0 → 3 → 5 → 7 (inefficient backtracking)
-
-**Smart:** 0 → 5 (pick up UP) → 7 (drop off) → 3 (now going down, pick up DOWN)
-
-#### 3. Real-World Modeling
-Elevator panels have different buttons:
-- **Hall panels:** Only up/down buttons (direction matters)
-- **Car panels:** Only floor buttons (destination matters)
-
-#### 4. Multiple Requests at Same Floor
-If two people at floor 4 press different buttons:
-- Person A presses UP
-- Person B presses DOWN
-
-These should be **separate requests** because they'll board at different times (when lift is going their direction).
-
-### Unified Request Model
-
-The `LiftRequest` class unifies both types while preserving the distinction:
-
-```java
-// Hall call
-LiftRequest hallRequest = LiftRequest.hallCall(5, Direction.UP);
-// Has: type=HALL_CALL, originFloor=5, direction=UP, destinationFloor=null
-
-// Car call
-LiftRequest carRequest = LiftRequest.carCall(10);
-// Has: type=CAR_CALL, originFloor=null, destinationFloor=10, direction=null
-```
-
-This architecture enables future algorithms like SCAN, LOOK, and destination dispatch while maintaining backward compatibility.
-
-## Lift State Machine
-
-The lift uses a **single source of truth** pattern where `LiftStatus` is the only stored state - all other properties (direction, door state) are derived from it.
-
-### States
-
-| State | Description | Direction | Doors |
-|-------|-------------|-----------|-------|
-| **IDLE** | Stationary, ready to accept requests | IDLE | CLOSED |
-| **MOVING_UP** | Traveling upward between floors | UP | CLOSED (locked) |
-| **MOVING_DOWN** | Traveling downward between floors | DOWN | CLOSED (locked) |
-| **DOORS_OPENING** | Doors in process of opening (transitional) | IDLE | CLOSED |
-| **DOORS_OPEN** | Doors fully open, passengers can enter/exit | IDLE | OPEN |
-| **DOORS_CLOSING** | Doors in process of closing (transitional) | IDLE | CLOSED |
-| **OUT_OF_SERVICE** | Offline for maintenance or emergency | IDLE | CLOSED |
-
-### State Transition Table
-
-| From ↓ / To → | IDLE | MOVING_UP | MOVING_DOWN | DOORS_OPENING | DOORS_OPEN | DOORS_CLOSING | OUT_OF_SERVICE |
-|---------------|------|-----------|-------------|---------------|------------|---------------|----------------|
-| **IDLE** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| **MOVING_UP** | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| **MOVING_DOWN** | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **DOORS_OPENING** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| **DOORS_OPEN** | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| **DOORS_CLOSING** | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ |
-| **OUT_OF_SERVICE** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-
-### Safety Constraints
-
-The state machine enforces critical safety rules:
-- **Cannot move with doors open**: DOORS_OPEN/DOORS_OPENING/DOORS_CLOSING cannot transition to MOVING_UP/MOVING_DOWN
-- **Cannot reverse direction**: Must stop (IDLE) before changing direction
-- **Cannot open doors while moving**: MOVING_UP/MOVING_DOWN must first transition to IDLE (stop), then to DOORS_OPENING
-- **Doors must complete transitions**: DOORS_OPENING cannot transition directly to IDLE; must go through DOORS_OPEN → DOORS_CLOSING → IDLE
-- **Symmetric door transitions**: Both opening and closing are modeled as separate states
-- **All transitions validated**: Invalid transitions are prevented and logged
-
-Valid transitions are managed by the `StateTransitionValidator` class, which ensures the lift operates safely and predictably.
+For simulation engine internals, programmatic configuration, controller strategy behavior, out-of-service handling, request modeling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
 
 ## Project Structure
 
@@ -1738,7 +1273,8 @@ The project enforces a minimum of **80% line coverage** through JaCoCo. The buil
 
 ## Architecture Decisions
 
-See [docs/decisions](docs/decisions) for Architecture Decision Records (ADRs):
+See [docs/decisions](docs/decisions) for Architecture Decision Records (ADRs). For developer-facing simulation engine and persistence internals associated with these decisions, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
+
 - [ADR-0001: Tick-Based Simulation](docs/decisions/0001-tick-based-simulation.md)
 - [ADR-0002: Single Source of Truth for Lift State](docs/decisions/0002-single-source-of-truth-state.md)
 - [ADR-0003: Request Lifecycle Management](docs/decisions/0003-request-lifecycle-management.md)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1025,7 +1025,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -1039,12 +1039,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -1083,7 +1083,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -1096,7 +1096,7 @@ java -cp target/lift-simulator-0.49.5.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -1107,7 +1107,7 @@ java -cp target/lift-simulator-0.49.5.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -1383,7 +1383,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.5.jar \
+   java -cp target/lift-simulator-0.49.6.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -1428,7 +1428,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -1520,7 +1520,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.5.jar \
+java -cp target/lift-simulator-0.49.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -1,0 +1,445 @@
+# Developer Guide
+
+This guide contains developer-facing details for contributors who extend the lift simulator internals. It preserves the simulation engine, request model, state machine, and persistence reference material that used to live in the README.
+
+## Simulation Engine — Tick Timing
+
+You can model travel and door timing by using the `SimulationEngine` builder:
+
+```java
+SimulationEngine engine = SimulationEngine.builder(controller, 0, 10)
+    .travelTicksPerFloor(3)
+    .doorTransitionTicks(2)
+    .doorDwellTicks(3)
+    .doorReopenWindowTicks(2)
+    .build();
+```
+
+- **travelTicksPerFloor**: How many ticks it takes to move one floor
+- **doorTransitionTicks**: Ticks required for doors to fully open or close
+- **doorDwellTicks**: How long doors remain open before automatically closing
+- **doorReopenWindowTicks**: Time window (in ticks) during door closing when doors can be reopened for new requests at the current floor
+  - Must be non-negative and cannot exceed `doorTransitionTicks`
+  - Default: `min(2, doorTransitionTicks)` for backward compatibility
+  - Setting to 0 disables door reopening (doors cannot be interrupted once closing starts)
+  - Realistic behavior: if a request arrives for the current floor while doors are closing and within this window, doors will reopen
+  - If the window has passed, the request is queued normally and will be served in the next cycle
+
+## Simulation Engine — Idle Parking
+
+You can configure the home floor, idle timeout, and parking behavior for the naive controller:
+
+```java
+NaiveLiftController controller = new NaiveLiftController(
+    0,                                        // homeFloor
+    5,                                        // idleTimeoutTicks
+    IdleParkingMode.PARK_TO_HOME_FLOOR       // idleParkingMode
+);
+```
+
+- **homeFloor**: The floor to park on when idle (used only with `PARK_TO_HOME_FLOOR` mode)
+- **idleTimeoutTicks**: How many idle ticks before the parking behavior activates (0 means activate immediately)
+- **idleParkingMode**: The parking behavior when idle timeout is reached (optional, defaults to `PARK_TO_HOME_FLOOR`)
+  - `IdleParkingMode.STAY_AT_CURRENT_FLOOR`: Lift stays at current floor indefinitely when idle
+  - `IdleParkingMode.PARK_TO_HOME_FLOOR`: Lift moves to home floor after idle timeout (existing behavior)
+
+**Backward compatibility**: The two-parameter constructor defaults to `PARK_TO_HOME_FLOOR` mode:
+
+```java
+// This uses PARK_TO_HOME_FLOOR mode by default
+NaiveLiftController controller = new NaiveLiftController(0, 5);
+```
+
+**Scenario file configuration:**
+
+```
+home_floor: 0
+idle_timeout_ticks: 5
+idle_parking_mode: STAY_AT_CURRENT_FLOOR
+```
+
+The `idle_parking_mode` parameter is optional and defaults to `PARK_TO_HOME_FLOOR` if not specified.
+
+## Simulation Engine — Controller Strategy Selection
+
+You can configure which controller algorithm the lift uses via the `ControllerStrategy` enum:
+
+```java
+// Create controller using factory with desired strategy
+LiftController controller = ControllerFactory.createController(
+    ControllerStrategy.NEAREST_REQUEST_ROUTING,
+    0,                                        // homeFloor
+    5,                                        // idleTimeoutTicks
+    IdleParkingMode.PARK_TO_HOME_FLOOR       // idleParkingMode
+);
+```
+
+**Available strategies:**
+- `ControllerStrategy.NEAREST_REQUEST_ROUTING`: Services the nearest request first (default, uses `NaiveLiftController`)
+- `ControllerStrategy.DIRECTIONAL_SCAN`: Directional scan/elevator algorithm (uses `DirectionalScanLiftController`)
+
+**Factory methods:**
+
+```java
+// With default parameters (home floor 0, idle timeout 5 ticks, park to home floor)
+LiftController controller = ControllerFactory.createController(
+    ControllerStrategy.NEAREST_REQUEST_ROUTING
+);
+
+// With custom parameters
+LiftController controller = ControllerFactory.createController(
+    ControllerStrategy.NEAREST_REQUEST_ROUTING,
+    homeFloor,
+    idleTimeoutTicks,
+    idleParkingMode
+);
+```
+
+**Scenario file configuration:**
+
+```
+controller_strategy: NEAREST_REQUEST_ROUTING
+```
+
+The `controller_strategy` parameter is optional and defaults to `NEAREST_REQUEST_ROUTING` if not specified.
+
+**Notes:**
+- The controller strategy must be selected at system initialization (not runtime switchable)
+- Invalid strategy names in scenario files will throw an `IllegalArgumentException`
+
+## Simulation Engine — Controller Strategies
+
+### Nearest Request Routing (NaiveLiftController)
+
+The nearest request routing strategy services the closest requested floor first, regardless of direction. This is a simple but inefficient algorithm that can result in excessive back-and-forth movement.
+
+**Behavior:**
+- Selects the nearest floor with a pending request
+- Services requests immediately upon arrival
+- No batching or direction preference
+- Best suited for low-traffic scenarios
+
+**Use case:** Simple lifts with minimal traffic where efficiency isn't critical.
+
+### Directional Scan (DirectionalScanLiftController)
+
+The directional scan strategy implements a SCAN-style algorithm that continues in the current direction until all requests in that direction are serviced, then reverses.
+
+**Behavior:**
+- **Direction commitment:** Once moving in a direction, continues until no more requests exist ahead
+- **Hall call filtering:** Only services hall calls that match the current travel direction
+  - Example: While going UP, only services hall calls with direction=UP
+  - Exception: Car calls are always eligible (passengers already onboard)
+- **Reversal logic:** Reverses at the furthest pending stop in the current direction
+- **Efficient batching:** Reduces back-and-forth movement by servicing multiple requests in one sweep
+- **Direction selection:** When idle, selects initial direction based on nearest request
+
+**Example scenario:**
+```
+Lift at floor 0, requests:
+- Hall call: floor 2, UP
+- Car call: floor 5
+- Hall call: floor 3, DOWN
+
+Execution:
+1. Select UP direction (floor 2 is nearest)
+2. Service floor 2 (hall call UP) ✓
+3. Continue to floor 5 (car call) ✓
+4. No more requests going UP, reverse to DOWN
+5. Service floor 3 (hall call DOWN) ✓
+```
+
+**Advantages:**
+- Reduces average wait time in moderate to high traffic
+- Minimizes unnecessary direction changes
+- More predictable behavior for passengers
+- Better energy efficiency
+
+**Use case:** Most real-world elevator scenarios, especially multi-floor buildings with moderate traffic.
+
+**Key invariants maintained:**
+- No duplicate servicing of requests
+- No lost requests during movement
+- Compatible with door open/close timing semantics
+- Requests can be added during movement and will be scheduled according to rules
+
+## Taking Lifts Out of Service
+
+You can take a lift out of service for maintenance or emergency situations:
+
+```java
+// Take lift out of service
+controller.takeOutOfService();  // Cancels all pending requests
+engine.setOutOfService();       // Transitions to OUT_OF_SERVICE state
+
+// ... lift is now offline and cannot move or accept requests ...
+
+// Return to service
+controller.returnToService();   // Prepares controller for normal operation
+engine.returnToService();       // Transitions to IDLE state
+```
+
+**Behavior when taking out of service (graceful shutdown):**
+- All pending requests (QUEUED, ASSIGNED, SERVING) are immediately cancelled
+- If the lift is moving, it completes movement to the next floor in its current direction
+- Doors open to allow passengers to exit safely
+- Doors close after dwell time
+- Lift transitions to OUT_OF_SERVICE state
+- While OUT_OF_SERVICE: cannot move, open doors, or accept new requests (new assignments are ignored)
+
+**Behavior when returning to service:**
+- Lift transitions to IDLE state at its current floor
+- Can immediately accept and service new requests
+- Operates normally as if freshly initialized
+
+**Use cases:**
+- Emergency stop situations
+- Scheduled maintenance windows
+- Simulating equipment failures
+- Testing failover scenarios in multi-lift systems
+
+## Request Types: Hall Calls vs. Car Calls
+
+The simulator distinguishes between two types of lift requests, modeling real-world elevator behavior:
+
+### Hall Call (Request from outside the lift)
+
+Made when someone presses an up/down button **outside** the lift:
+
+```java
+controller.addHallCall(new HallCall(3, Direction.UP));
+```
+
+**Known information:**
+- **Origin floor**: Where the person is waiting (floor 3)
+- **Direction**: Where they want to go (UP or DOWN)
+- **Unknown**: Exact destination floor (person hasn't boarded yet)
+
+**Physical analog:** The up/down buttons on each floor
+
+**Completion:** Request completes when lift arrives at the origin floor and opens doors (person can now board)
+
+### Car Call (Request from inside the lift)
+
+Made when someone presses a floor button **inside** the lift:
+
+```java
+controller.addCarCall(new CarCall(7));
+```
+
+**Known information:**
+- **Destination floor**: Where the person wants to go (floor 7)
+- **Unknown/Irrelevant**: Origin floor, direction (inferred from current position)
+
+**Physical analog:** The numbered floor buttons inside the lift car
+
+**Completion:** Request completes when lift arrives at the destination floor and opens doors (person can now exit)
+
+### Why the Distinction Matters
+
+#### 1. Current Naive Algorithm
+The current `NaiveLiftController` treats both types similarly (goes to nearest floor), but the infrastructure supports future smart algorithms.
+
+#### 2. Future Direction-Aware Scheduling
+Smart algorithms can optimize based on hall call direction:
+
+**Example scenario:**
+- Lift at floor 0
+- Hall call: floor 3 going DOWN
+- Hall call: floor 5 going UP
+- Car call: floor 7
+
+**Naive:** 0 → 3 → 5 → 7 (inefficient backtracking)
+
+**Smart:** 0 → 5 (pick up UP) → 7 (drop off) → 3 (now going down, pick up DOWN)
+
+#### 3. Real-World Modeling
+Elevator panels have different buttons:
+- **Hall panels:** Only up/down buttons (direction matters)
+- **Car panels:** Only floor buttons (destination matters)
+
+#### 4. Multiple Requests at Same Floor
+If two people at floor 4 press different buttons:
+- Person A presses UP
+- Person B presses DOWN
+
+These should be **separate requests** because they'll board at different times (when lift is going their direction).
+
+### Unified Request Model
+
+The `LiftRequest` class unifies both types while preserving the distinction:
+
+```java
+// Hall call
+LiftRequest hallRequest = LiftRequest.hallCall(5, Direction.UP);
+// Has: type=HALL_CALL, originFloor=5, direction=UP, destinationFloor=null
+
+// Car call
+LiftRequest carRequest = LiftRequest.carCall(10);
+// Has: type=CAR_CALL, originFloor=null, destinationFloor=10, direction=null
+```
+
+This architecture enables future algorithms like SCAN, LOOK, and destination dispatch while maintaining backward compatibility.
+
+## Lift State Machine
+
+The lift uses a **single source of truth** pattern where `LiftStatus` is the only stored state - all other properties (direction, door state) are derived from it.
+
+### States
+
+| State | Description | Direction | Doors |
+|-------|-------------|-----------|-------|
+| **IDLE** | Stationary, ready to accept requests | IDLE | CLOSED |
+| **MOVING_UP** | Traveling upward between floors | UP | CLOSED (locked) |
+| **MOVING_DOWN** | Traveling downward between floors | DOWN | CLOSED (locked) |
+| **DOORS_OPENING** | Doors in process of opening (transitional) | IDLE | CLOSED |
+| **DOORS_OPEN** | Doors fully open, passengers can enter/exit | IDLE | OPEN |
+| **DOORS_CLOSING** | Doors in process of closing (transitional) | IDLE | CLOSED |
+| **OUT_OF_SERVICE** | Offline for maintenance or emergency | IDLE | CLOSED |
+
+### State Transition Table
+
+| From ↓ / To → | IDLE | MOVING_UP | MOVING_DOWN | DOORS_OPENING | DOORS_OPEN | DOORS_CLOSING | OUT_OF_SERVICE |
+|---------------|------|-----------|-------------|---------------|------------|---------------|----------------|
+| **IDLE** | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| **MOVING_UP** | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **MOVING_DOWN** | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| **DOORS_OPENING** | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **DOORS_OPEN** | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **DOORS_CLOSING** | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ |
+| **OUT_OF_SERVICE** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+
+### Safety Constraints
+
+The state machine enforces critical safety rules:
+- **Cannot move with doors open**: DOORS_OPEN/DOORS_OPENING/DOORS_CLOSING cannot transition to MOVING_UP/MOVING_DOWN
+- **Cannot reverse direction**: Must stop (IDLE) before changing direction
+- **Cannot open doors while moving**: MOVING_UP/MOVING_DOWN must first transition to IDLE (stop), then to DOORS_OPENING
+- **Doors must complete transitions**: DOORS_OPENING cannot transition directly to IDLE; must go through DOORS_OPEN → DOORS_CLOSING → IDLE
+- **Symmetric door transitions**: Both opening and closing are modeled as separate states
+- **All transitions validated**: Invalid transitions are prevented and logged
+
+Valid transitions are managed by the `StateTransitionValidator` class, which ensures the lift operates safely and predictably.
+
+
+## JPA Entities and Repositories
+
+The backend includes JPA entities and Spring Data repositories for database access:
+
+#### Entities
+
+- **LiftSystem** (`com.liftsimulator.admin.entity.LiftSystem`)
+  - Maps to `lift_system` table
+  - Root configuration records for lift systems
+  - Manages one-to-many relationship with versions
+  - Automatic timestamp management via `@PrePersist` and `@PreUpdate`
+
+- **LiftSystemVersion** (`com.liftsimulator.admin.entity.LiftSystemVersion`)
+  - Maps to `lift_system_version` table
+  - Versioned lift configuration payloads
+  - **JSONB field mapping**: Uses `@JdbcTypeCode(SqlTypes.JSON)` for PostgreSQL JSONB support
+  - Version status enum: DRAFT, PUBLISHED, ARCHIVED
+  - Helper methods: `publish()`, `archive()`
+
+- **Scenario** (`com.liftsimulator.admin.entity.Scenario`)
+  - Maps to `scenario` table
+  - Reusable test scenarios for lift system testing
+  - **JSONB field mapping**: Stores scenario configuration as JSON
+  - Automatic timestamp management via `@PrePersist` and `@PreUpdate`
+
+- **SimulationRun** (`com.liftsimulator.admin.entity.SimulationRun`)
+  - Maps to `simulation_run` table
+  - Individual simulation run executions with lifecycle tracking
+  - Run status enum: CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED
+  - Relationships: Many-to-one with LiftSystem, LiftSystemVersion, and Scenario
+  - Status transition methods: `start()`, `succeed()`, `fail()`, `cancel()`
+  - Progress tracking via repository-backed current tick updates
+
+#### Repositories
+
+- **LiftSystemRepository** (`com.liftsimulator.admin.repository.LiftSystemRepository`)
+  - Find by system key: `findBySystemKey(String systemKey)`
+  - Check existence: `existsBySystemKey(String systemKey)`
+  - Standard CRUD operations via `JpaRepository`
+
+- **LiftSystemVersionRepository** (`com.liftsimulator.admin.repository.LiftSystemVersionRepository`)
+  - Find versions by lift system: `findByLiftSystemIdOrderByVersionNumberDesc(Long liftSystemId)`
+  - Find specific version: `findByLiftSystemIdAndVersionNumber(Long liftSystemId, Integer versionNumber)`
+  - Find published versions: `findByLiftSystemIdAndIsPublishedTrue(Long liftSystemId)`
+  - Find by status: `findByStatus(VersionStatus status)`
+  - Get max version number: `findMaxVersionNumberByLiftSystemId(Long liftSystemId)`
+
+- **ScenarioRepository** (`com.liftsimulator.admin.repository.ScenarioRepository`)
+  - Find by name: `findByName(String name)`
+  - Find by name pattern: `findByNameContainingIgnoreCase(String name)`
+  - Check existence: `existsByName(String name)`
+  - Standard CRUD operations via `JpaRepository`
+
+- **SimulationRunRepository** (`com.liftsimulator.admin.repository.SimulationRunRepository`)
+  - Persists simulation run lifecycle changes for both API orchestration and asynchronous execution, avoiding service-to-service circular dependencies
+  - Update run progress directly: `updateCurrentTick(Long id, Long currentTick)`
+  - Find runs by lift system: `findByLiftSystemIdOrderByCreatedAtDesc(Long liftSystemId)`
+  - Find runs by version: `findByVersionIdOrderByCreatedAtDesc(Long versionId)`
+  - Find runs by scenario: `findByScenarioIdOrderByCreatedAtDesc(Long scenarioId)`
+  - Find runs by status: `findByStatusOrderByCreatedAtDesc(RunStatus status)`
+  - Find active runs: `findActiveRunsByLiftSystemId(Long liftSystemId)`
+  - Count operations: `countByLiftSystemId(Long liftSystemId)`, `countByStatus(RunStatus status)`
+
+#### Verifying JPA Operations
+
+To verify the JPA entities and repositories are working correctly, run the Spring Boot application with the JPA verification runner:
+
+```bash
+mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
+```
+
+Or with the JAR:
+
+```bash
+java -jar target/lift-simulator-0.49.6.jar --spring.jpa.verify=true
+```
+
+The verification runner will:
+1. Create and retrieve `LiftSystem` entities
+2. Create and retrieve `LiftSystemVersion` entities with JSONB configs
+3. Test complex JSON configurations
+4. Verify entity relationships and cascading
+5. Test all custom query methods
+
+Look for log output like:
+```
+=== Starting JPA Entity and Repository Verification ===
+--- Verifying LiftSystem CRUD Operations ---
+✓ Created LiftSystem: id=1, key=demo-system
+✓ Found LiftSystem by ID: demo-system
+--- Verifying JSONB Field Mapping ---
+✓ Saved complex JSONB config: id=2
+✓ Retrieved JSONB config matches original
+=== JPA Verification Completed Successfully ===
+```
+
+The verification runner is located at `com.liftsimulator.admin.runner.JpaVerificationRunner` and is only enabled when `spring.jpa.verify=true` is set.
+
+#### Integration Tests
+
+Integration tests for the repositories are available:
+- `LiftSystemRepositoryTest`: Tests CRUD operations, queries, and updates
+- `LiftSystemVersionRepositoryTest`: Tests version operations, JSONB mapping, and relationships
+- `FlywayMigrationIntegrationTest`: Verifies that Flyway migrations are executed at startup
+
+**Test Database Configuration:**
+- Integration tests run against a **real PostgreSQL** instance provisioned on demand by
+  [Testcontainers](https://java.testcontainers.org/) — **no pre-existing database is required**.
+- The only prerequisite is a running **Docker** daemon (Testcontainers starts and tears down a
+  `postgres:15-alpine` container automatically). A single container is shared across the suite to
+  keep startup fast.
+- **Flyway migrations run during test startup**, so migration bugs are caught by the test suite.
+- Hibernate runs in **`validate`** mode (not `ddl-auto: update`), so the entity mappings are
+  checked against the migrated schema and any drift fails the build.
+- In CI, where the workflow provides a PostgreSQL service container via `SPRING_DATASOURCE_URL`,
+  Testcontainers stands aside and that database is used instead.
+
+Run the tests:
+```bash
+mvn test -Dtest=LiftSystemRepositoryTest,LiftSystemVersionRepositoryTest
+```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.5",
+  "version": "0.49.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.5",
+      "version": "0.49.6",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.5",
+  "version": "0.49.6",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.5</version>
+    <version>0.49.6</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Reduce README size and create a focused developer-facing reference for the simulation engine, request model, state machine, and JPA persistence details by moving those internals into `docs/DEVELOPER-GUIDE.md`.
- Keep user/operator-facing README concise while preserving CLI examples and link developer readers to the extracted guide, and bump the patch version to reflect documentation/package metadata changes (`0.49.5` → `0.49.6`).

### Description
- Add `docs/DEVELOPER-GUIDE.md` containing simulation engine internals (tick timing, idle parking, controller strategies, out-of-service behavior, request model, lift state machine) and the JPA entities/repositories reference. 
- Replace the moved deep-dive sections in `README.md` with cross-references to the new developer guide and update CLI/JAR examples to the new patch version. 
- Update version references and metadata in `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json` to `0.49.6`, and update example usages in `docs/API.md` and other docs. 
- Add a `CHANGELOG.md` entry for `0.49.6` describing the documentation extraction and version bump.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/link issues, which passed. 
- Ran a local Markdown link validation script (`python3`) to verify internal Markdown links resolve, which passed. 
- Attempted a Maven package build with `mvn -q -DskipTests package`, which failed to complete in this environment due to a network/registry issue resolving the Spring Boot parent POM (HTTP 403 from Maven Central); build is otherwise expected to succeed in a normal CI environment with network access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264ab399988325a56865642e0de8bf)