### PR TITLE
docs(changelog): fix changelog structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.49.7] - 2026-06-08
+
+### Fixed
+- **Changelog structure cleanup**: Relocated the empty `Unreleased` placeholder to the top of the changelog, migrated already-shipped entries into `0.49.6`, removed the phantom maintenance-version reference and outdated current-version claims, and normalized section headings to Keep a Changelog categories.
+
+### Changed
+- **Patch version bump**: Updated repository package metadata, frontend package metadata, README examples, and extracted documentation references from 0.49.6 to 0.49.7.
+
 ## [0.49.6] - 2026-06-08
+
+### Added
+- **Configurable OpenAPI/Swagger access**: Added `security.openapi.public-access` / `SECURITY_OPENAPI_PUBLIC_ACCESS` so Swagger UI and OpenAPI JSON can either remain public (default, preserving existing behavior) or require ADMIN-role HTTP Basic authentication.
+- **CI coverage artifacts**: The backend CI job now uploads the JaCoCo HTML report from `target/site/jacoco/` on every run.
+- **Testcontainers-backed integration tests**: Integration and repository tests now provision a throwaway `postgres:15-alpine` instance on demand via Testcontainers, so `mvn test` runs without a pre-existing PostgreSQL database (a running Docker daemon is the only prerequisite). A single container is shared across the suite via a globally-registered Spring `ContextCustomizerFactory`, covering both `@SpringBootTest` and `@DataJpaTest` slices.
+- **Flyway migrations exercised by tests**: The test profile now runs the real `db/migration` scripts at startup and Hibernate runs in `validate` mode (instead of `ddl-auto: update`), so migration bugs and entity/schema drift are caught by the test suite.
+- **Migration verification test**: Added `FlywayMigrationIntegrationTest`, which asserts the Flyway schema history is populated, all migrations succeeded, and migrated tables exist.
+- **Unit tests for RunMetrics**: Added `RunMetricsTest` covering KPI computation (completed/cancelled counts, average and max wait ticks, utilisation), per-floor passenger flows and lift visits, per-lift config output, and idempotency of `recordTerminalRequests`.
 
 ### Changed
 - **Developer guide extraction**: Moved simulation engine internals, request modeling, lift state machine, and JPA entity/repository reference material from `README.md` into the new `docs/DEVELOPER-GUIDE.md`; the README now links to the dedicated developer reference.
+- **YAML configuration cleanup**: Replaced the checked-in base `application.properties` and local override properties template with YAML equivalents, removed the hardcoded development profile activation, and documented explicit `SPRING_PROFILES_ACTIVE` requirements for development and production launches.
+- **README configuration documentation**: Documented the single-lift-system-per-simulation-run architecture assumption, profile setup, YAML configuration files, current 0.49.6 package version, and configurable Swagger/OpenAPI access.
+- **Simulation run performance optimization**: Replaced O(n²) log tail buffering with an `ArrayDeque` ring buffer, cached shared `RunMetrics` KPI values across result serializers, and avoided allocating passenger-flow tick maps for empty scenarios. Added large-file tail coverage for 12K and 100K line logs.
+- **Backend dependency refresh**: Updated backend package metadata to 0.49.6, upgraded Spring Boot from 3.2.1 to 3.4.13, added the Spring Boot-managed Flyway PostgreSQL database module required by the newer Flyway baseline, and verified the PostgreSQL JDBC driver remains on the latest 42.7.11 release.
+- **CI Playwright E2E coverage**: Moved frontend Playwright execution into a dedicated `e2e-playwright` GitHub Actions job that provisions PostgreSQL, packages and starts the Spring Boot backend, waits for `/api/v1/health`, and runs the browser suite against the live API. The job publishes the Playwright HTML report and failure artifacts, including backend logs, so feature-test failures are visible in CI.
+- **Playwright-only E2E auth configuration**: Added optional Playwright environment variables for admin Basic auth and runtime API-key headers so local and CI E2E runs can exercise authenticated backend endpoints without exposing credentials in browser bundles.
+- **Backend-backed E2E stabilization**: Updated Playwright tests and helpers to use the inline Create Version validation flow, unique retry-safe system data, scoped assertions, backend response waits, route-aware system creation waits, current alert modal selectors, the current health-check UI payload, and Vite dev-proxy auth header injection so the new CI E2E job exercises the live backend reliably.
+- **Decoupled simulation run execution wiring**: Removed the lazy circular dependency between `SimulationRunService` and `SimulationRunExecutionService`; the execution service now updates run lifecycle state and progress through `SimulationRunRepository` directly.
+- **Extract RunMetrics to `metrics` sub-package**: Decomposed `SimulationRunExecutionService` by moving `RunMetrics`, `FloorMetrics`, and `RequestLifecycle` inner classes into a new `com.liftsimulator.admin.service.metrics` package. The execution service is reduced from ~711 lines to ~450 lines and the metrics classes are now independently testable. No public API or behaviour changes.
 - **Patch version bump**: Updated package metadata, frontend package metadata, README references, and extracted API documentation references from 0.49.5 to 0.49.6.
+
+### Fixed
+- **Hibernate 6.6 cascade delete tests**: Cleared managed child entities before repository cascade-delete assertions so tests rely on the PostgreSQL `ON DELETE CASCADE` constraints without Hibernate transient-reference flush errors.
+- **CI deployable JAR packaging**: GitHub Actions backend and E2E packaging steps now activate the Maven `frontend` profile, log profile activation, install a Vite-compatible Node.js 20.19.0 runtime, verify the produced Spring Boot JAR contains React assets under `BOOT-INF/classes/static/`, and confirm the packaged app serves the React root page during E2E startup.
+- **NPE prevention in scenario execution**: Added null check for `scenario.durationTicks()` in `SimulationRunExecutionService.runSimulation()`. The method now fails cleanly with a clear error message if the scenario has a null duration, preventing NullPointerException during unboxing to primitive int.
+- **Removed dead code**: Eliminated duplicate `SimulationRunService.getAllRuns()` method which was superseded by the more efficient `getAllRunsWithDetails()` that eagerly loads related entities (lift system, version, scenario).
+- **Unified artefact path configuration**: Removed the duplicate `simulation.runs.artefacts-root` config key from `SimulationRunExecutionService`. All artefact storage now uses the single `simulation.artefacts.base-path` property (default: `./simulation-runs`) that was already present in `application.properties`.
+- **Directory orphaning eliminated**: `SimulationRunExecutionService.executeRun()` no longer creates a second run directory and overwrites the persisted path. The execution service now reads `artefactBasePath` from the run entity (set once by `SimulationRunService`) and writes all artefacts to that directory.
+- **Artefact storage documentation and tests**: Added `simulation.artefacts.base-path` to `application-dev.yml.template`, updated README documentation for the single artefact storage configuration key, and added `SimulationRunDirectoryIntegrationTest` coverage verifying that exactly one artefact directory is created per run and that it matches the persisted `artefactBasePath`.
 
 ## [0.49.5] - 2026-06-08
 
@@ -50,69 +86,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Paginated simulation run list endpoint**: `GET /api/v1/simulation-runs` now accepts `?page=0&size=20&sort=createdAt,desc` query parameters and returns a Spring Data `Page` envelope with `content`, `totalElements`, and `totalPages`. Default page size is 20; the API enforces a maximum of 100 per request. Filter parameters (`systemId`, `status`) continue to work alongside pagination. The frontend API client (`simulationRunsApi.js`) is updated to pass page, size, and sort on every call.
-
-## [Unreleased]
-
-### Added
-- **Configurable OpenAPI/Swagger access**: Added `security.openapi.public-access` / `SECURITY_OPENAPI_PUBLIC_ACCESS` so Swagger UI and OpenAPI JSON can either remain public (default, preserving existing behavior) or require ADMIN-role HTTP Basic authentication.
-- **CI coverage artifacts**: The backend CI job now uploads the JaCoCo HTML report from `target/site/jacoco/` on every run.
-
-### Changed
-- **YAML configuration cleanup**: Replaced the checked-in base `application.properties` and local override properties template with YAML equivalents, removed the hardcoded development profile activation, and documented explicit `SPRING_PROFILES_ACTIVE` requirements for development and production launches.
-- **README configuration documentation**: Documented the single-lift-system-per-simulation-run architecture assumption, profile setup, YAML configuration files, current 0.48.0 package version, and configurable Swagger/OpenAPI access.
-- **Simulation run performance optimization**: Replaced O(n²) log tail buffering with an `ArrayDeque` ring buffer, cached shared `RunMetrics` KPI values across result serializers, and avoided allocating passenger-flow tick maps for empty scenarios. Added large-file tail coverage for 12K and 100K line logs.
-- **Backend dependency refresh**: Bumped the backend maintenance version to 0.47.1, upgraded Spring Boot from 3.2.1 to 3.4.13, added the Spring Boot-managed Flyway PostgreSQL database module required by the newer Flyway baseline, and verified the PostgreSQL JDBC driver remains on the latest 42.7.11 release.
-- **CI Playwright E2E coverage**: Moved frontend Playwright execution into a dedicated `e2e-playwright` GitHub Actions job that provisions PostgreSQL, packages and starts the Spring Boot backend, waits for `/api/v1/health`, and runs the browser suite against the live API. The job publishes the Playwright HTML report and failure artifacts, including backend logs, so feature-test failures are visible in CI.
-- **Playwright-only E2E auth configuration**: Added optional Playwright environment variables for admin Basic auth and runtime API-key headers so local and CI E2E runs can exercise authenticated backend endpoints without exposing credentials in browser bundles.
-- **Backend-backed E2E stabilization**: Updated Playwright tests and helpers to use the inline Create Version validation flow, unique retry-safe system data, scoped assertions, backend response waits, route-aware system creation waits, current alert modal selectors, the current health-check UI payload, and Vite dev-proxy auth header injection so the new CI E2E job exercises the live backend reliably.
-
-### Refactored
-- **Decoupled simulation run execution wiring**: Removed the lazy circular dependency between `SimulationRunService` and `SimulationRunExecutionService`; the execution service now updates run lifecycle state and progress through `SimulationRunRepository` directly.
-- **Extract RunMetrics to `metrics` sub-package**: Decomposed `SimulationRunExecutionService`
-  by moving `RunMetrics`, `FloorMetrics`, and `RequestLifecycle` inner classes into a new
-  `com.liftsimulator.admin.service.metrics` package. The execution service is reduced from
-  ~711 lines to ~450 lines and the metrics classes are now independently testable. No public
-  API or behaviour changes.
-
-### Added
-- **Testcontainers-backed integration tests**: Integration and repository tests now provision a
-  throwaway `postgres:15-alpine` instance on demand via Testcontainers, so `mvn test` runs without
-  a pre-existing PostgreSQL database (a running Docker daemon is the only prerequisite). A single
-  container is shared across the suite via a globally-registered Spring `ContextCustomizerFactory`,
-  covering both `@SpringBootTest` and `@DataJpaTest` slices.
-- **Flyway migrations exercised by tests**: The test profile now runs the real `db/migration`
-  scripts at startup and Hibernate runs in `validate` mode (instead of `ddl-auto: update`), so
-  migration bugs and entity/schema drift are caught by the test suite.
-- **Migration verification test**: Added `FlywayMigrationIntegrationTest`, which asserts the Flyway
-  schema history is populated, all migrations succeeded, and migrated tables exist.
-- **Unit tests for RunMetrics**: Added `RunMetricsTest` covering KPI computation (completed/
-  cancelled counts, average and max wait ticks, utilisation), per-floor passenger flows and
-  lift visits, per-lift config output, and idempotency of `recordTerminalRequests`.
-
-### Fixed
-- **Hibernate 6.6 cascade delete tests**: Cleared managed child entities before repository cascade-delete assertions so tests rely on the PostgreSQL `ON DELETE CASCADE` constraints without Hibernate transient-reference flush errors.
-- **CI deployable JAR packaging**: GitHub Actions backend and E2E packaging steps now activate the Maven `frontend` profile, log profile activation, install a Vite-compatible Node.js 20.19.0 runtime, verify the produced Spring Boot JAR contains React assets under `BOOT-INF/classes/static/`, and confirm the packaged app serves the React root page during E2E startup.
-- **NPE prevention in scenario execution**: Added null check for `scenario.durationTicks()` in
-  `SimulationRunExecutionService.runSimulation()`. The method now fails cleanly with a clear
-  error message if the scenario has a null duration, preventing NullPointerException during
-  unboxing to primitive int.
-- **Removed dead code**: Eliminated duplicate `SimulationRunService.getAllRuns()` method which
-  was superseded by the more efficient `getAllRunsWithDetails()` that eagerly loads related
-  entities (lift system, version, scenario).
-- **Unified artefact path configuration**: Removed the duplicate `simulation.runs.artefacts-root`
-  config key from `SimulationRunExecutionService`. All artefact storage now uses the single
-  `simulation.artefacts.base-path` property (default: `./simulation-runs`) that was already
-  present in `application.properties`.
-- **Directory orphaning eliminated**: `SimulationRunExecutionService.executeRun()` no longer
-  creates a second run directory and overwrites the persisted path. The execution service now
-  reads `artefactBasePath` from the run entity (set once by `SimulationRunService`) and writes
-  all artefacts to that directory.
-- Added `simulation.artefacts.base-path` to `application-dev.yml.template` so developers have
-  an explicit reference for the configuration key.
-- Updated README to document `simulation.artefacts.base-path` as the single configuration key
-  for artefact storage.
-- Added integration tests (`SimulationRunDirectoryIntegrationTest`) verifying that exactly one
-  artefact directory is created per run and that it matches the persisted `artefactBasePath`.
 
 ## [0.47.0] - 2026-06-06
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.49.6**
+Current version: **0.49.7**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history, including a condensed summary of the pre-release foundation milestones.
 
@@ -242,7 +242,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.6.jar
+java -jar target/lift-simulator-0.49.7.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api/v1`.
@@ -292,7 +292,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.49.6.jar
+java -jar target/lift-simulator-0.49.7.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -320,7 +320,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - Logging level: `INFO` (root), `DEBUG` (com.liftsimulator package)
 - Actuator endpoints: health, info
 
-No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.6.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.7.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (environment variable: `SECURITY_OPENAPI_PUBLIC_ACCESS`). The default is `true` to preserve current behavior; set it to `false` when documentation endpoints should require ADMIN-role authentication.
 
@@ -754,7 +754,7 @@ For backup and restore procedures, see [docs/DATABASE-BACKUP.md](docs/DATABASE-B
 
 ## Features
 
-The current version (v0.49.6) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.49.7) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -963,10 +963,10 @@ To build a deployable Spring Boot JAR that also serves the React admin UI from `
 mvn -Pfrontend clean package
 ```
 
-The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.6.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
+The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.7.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
 
 ```bash
-jar tf target/lift-simulator-0.49.6.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.7.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running Tests
@@ -1047,7 +1047,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1056,16 +1056,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1079,7 +1079,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1097,7 +1097,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1106,13 +1106,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.49.6.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.49.7.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -1025,7 +1025,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -1039,12 +1039,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -1083,7 +1083,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -1096,7 +1096,7 @@ java -cp target/lift-simulator-0.49.6.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -1107,7 +1107,7 @@ java -cp target/lift-simulator-0.49.6.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -1383,7 +1383,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.6.jar \
+   java -cp target/lift-simulator-0.49.7.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -1428,7 +1428,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -1520,7 +1520,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.6.jar \
+java -cp target/lift-simulator-0.49.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.6.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.7.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.6",
+  "version": "0.49.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.6",
+      "version": "0.49.7",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.6",
+  "version": "0.49.7",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.6</version>
+    <version>0.49.7</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Repair malformed CHANGELOG layout and stale claims so the file follows Keep a Changelog structure and the topmost `Unreleased` section is intentionally empty. 
- Reconcile documented package/version references so README, extracted docs, and frontend metadata consistently refer to the correct next patch version.

### Description
- Moved the previously populated `Unreleased` content into the appropriate released entry and added a new patch entry `0.49.7` documenting the changelog structure fix while keeping `## [Unreleased]` empty. 
- Normalised section headings (Removed stray `Refactored` heading usage) and folded already-shipped items into `0.49.6` using valid Keep a Changelog categories (`Added`, `Changed`, `Fixed`, etc.).
- Bumped repository and frontend package versions from `0.49.6` → `0.49.7` and updated all JAR examples and extracted docs references accordingly in `README.md`, `docs/API.md`, and `docs/DEVELOPER-GUIDE.md`.
- Updated files: `CHANGELOG.md`, `README.md`, `docs/API.md`, `docs/DEVELOPER-GUIDE.md`, `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json`.

### Testing
- Ran a custom `python3` changelog structure validation script which asserted valid Keep a Changelog headings, no duplicate headings per release block, and that top `Unreleased` is empty; the script passed. 
- Ran `npm --prefix frontend install --package-lock-only --ignore-scripts` to refresh lockfile metadata and it completed successfully. 
- Ran `git diff --check` and basic repository sanity checks which passed. 
- Attempted `mvn -q -DskipTests validate` but it failed to resolve the Spring Boot parent POM due to external Maven Central access returning HTTP 403 in this environment, so full Maven validation was blocked by network/registry access (not a repository change failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26542ee6c48325aa8a8d35f46f4d4f)