### PR TITLE
Bump version to 0.49.9 and consolidate changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **Note on dates:** Entries are ordered newest-first by semantic version. The
+> dates reflect when each entry was authored rather than a strict release
+> sequence, so a few dates do not decrease monotonically alongside the version
+> numbers.
+
 ## [Unreleased]
+
+## [0.49.9] - 2026-06-08
+
+### Changed
+- **Changelog de-duplication and ordering cleanup**: Merged the near-identical consecutive patch entries `0.41.2`/`0.41.3` (duplicate SPA index.html 404 fix) and `0.17.1`/`0.17.2` (duplicate directional-scan furthest-stop behavior) into single range entries matching the existing range pattern, and documented that entry dates reflect authoring order rather than a strict release sequence so the version/date ordering inversions no longer read as errors.
+- **Patch version bump**: Updated repository package metadata, frontend package metadata, README version references, and extracted documentation JAR examples from 0.49.8 to 0.49.9.
 
 ## [0.49.8] - 2026-06-08
 
@@ -178,16 +189,11 @@ UI consistency release for configuration-version workflows, lift-system editing,
   - Changed to direct `JSON.parse()` calls where parsed object wasn't needed
   - All ESLint warnings and errors now resolved
 
-## [0.41.3] - 2026-01-17
+## [0.41.2–0.41.3] - 2026-01-17
 
 ### Fixed
 - Return a helpful 404 response when the SPA index.html asset is missing, avoiding noisy stack traces when the frontend is not built.
 - Ensure SPA forwarding uses explicit return types so Spring MVC applies the correct view/response handling.
-
-## [0.41.2] - 2026-01-17
-
-### Fixed
-- Return a helpful 404 response when the SPA index.html asset is missing, avoiding noisy stack traces when the frontend is not built.
 
 ## [0.41.1] - 2026-01-17
 
@@ -580,15 +586,10 @@ Directional/SCAN controller release integrating direction-aware scheduling into 
 ### Added
 - Demo output now includes a request lifecycle summary table showing created and completed/cancelled ticks for each request
 
-## [0.17.2] - 2026-01-12
+## [0.17.1–0.17.2] - 2026-01-12
 
 ### Changed
 - Directional scan controller keeps traveling to the furthest pending stop in the current direction before reversing, even when only opposite-direction hall calls remain
-
-## [0.17.1] - 2026-01-12
-
-### Changed
-- Directional scan controller now rides to the furthest pending stop in the current direction before reversing, even when only opposite-direction hall calls remain
 
 ## [0.17.0] - 2026-01-11
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Java-based simulation of lift (elevator) controllers with a focus on correctne
 
 ## Version
 
-Current version: **0.49.8**
+Current version: **0.49.9**
 
 This project follows [Semantic Versioning](https://semver.org/). See [CHANGELOG.md](CHANGELOG.md) for version history, including a condensed summary of the pre-release foundation milestones.
 
@@ -242,7 +242,7 @@ To package the React UI with the Spring Boot backend and serve everything from *
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.8.jar
+java -jar target/lift-simulator-0.49.9.jar
 ```
 
 This builds the React app and bundles it into the Spring Boot JAR so the frontend is served from `/` and all API calls remain under `/api/v1`.
@@ -292,7 +292,7 @@ Or build and run the JAR:
 
 ```bash
 mvn clean package
-java -jar target/lift-simulator-0.49.8.jar
+java -jar target/lift-simulator-0.49.9.jar
 ```
 
 The backend will start on `http://localhost:8080`.
@@ -320,7 +320,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - Logging level: `INFO` (root), `DEBUG` (com.liftsimulator package)
 - Actuator endpoints: health, info
 
-No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.8.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is activated by the checked-in base configuration. Development and production launches must set `SPRING_PROFILES_ACTIVE` explicitly, for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for local development or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.9.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (environment variable: `SECURITY_OPENAPI_PUBLIC_ACCESS`). The default is `true` to preserve current behavior; set it to `false` when documentation endpoints should require ADMIN-role authentication.
 
@@ -754,7 +754,7 @@ For backup and restore procedures, see [docs/DATABASE-BACKUP.md](docs/DATABASE-B
 
 ## Features
 
-The current version (v0.49.8) includes comprehensive lift simulation and configuration management capabilities:
+The current version (v0.49.9) includes comprehensive lift simulation and configuration management capabilities:
 
 ### Admin Backend & REST API
 
@@ -963,10 +963,10 @@ To build a deployable Spring Boot JAR that also serves the React admin UI from `
 mvn -Pfrontend clean package
 ```
 
-The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.8.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
+The frontend profile installs Node.js 20.19.0 for compatibility with Vite 7, runs `npm ci`, builds the Vite bundle, copies the generated files into `target/classes/static/`, and packages them under `BOOT-INF/classes/static/` in `target/lift-simulator-0.49.9.jar`. The CI backend and E2E packaging jobs use this profile so downloaded CI JAR artifacts include the frontend assets. You can verify the packaged UI with:
 
 ```bash
-jar tf target/lift-simulator-0.49.8.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.9.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running Tests
@@ -1047,7 +1047,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 Or run directly after building:
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.Main
 ```
 
 ### Configuring the Demo
@@ -1056,16 +1056,16 @@ The demo supports selecting the controller strategy via command-line arguments:
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.Main --help
 
 # Run with the default demo configuration (nearest-request routing)
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.Main
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.Main
 
 # Run with directional scan controller
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.Main --strategy=directional-scan
 
 # Run with nearest-request routing controller (explicit)
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.Main --strategy=nearest-request
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.Main --strategy=nearest-request
 ```
 
 **Available Options:**
@@ -1079,7 +1079,7 @@ The demo runs a pre-configured scenario with several lift requests and displays 
 Use a published configuration JSON file to run a lightweight simulation:
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 
 Optional flags:
@@ -1097,7 +1097,7 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
 Or run a custom scenario file:
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 ### Configuring Scenario Runner
@@ -1106,13 +1106,13 @@ The scenario runner relies on scenario file settings for controller strategy and
 
 ```bash
 # Show help
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.scenario.ScenarioRunnerMain --help
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.scenario.ScenarioRunnerMain
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.scenario.ScenarioRunnerMain
 
 # Run a custom scenario
-java -cp target/lift-simulator-0.49.8.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
+java -cp target/lift-simulator-0.49.9.jar com.liftsimulator.scenario.ScenarioRunnerMain custom.scenario
 ```
 
 **Available Options:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -1025,7 +1025,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -1039,12 +1039,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -1083,7 +1083,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -1096,7 +1096,7 @@ java -cp target/lift-simulator-0.49.8.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -1107,7 +1107,7 @@ java -cp target/lift-simulator-0.49.8.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -1383,7 +1383,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.8.jar \
+   java -cp target/lift-simulator-0.49.9.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -1428,7 +1428,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -1520,7 +1520,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.8.jar \
+java -cp target/lift-simulator-0.49.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.8.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.9.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.8",
+      "version": "0.49.9",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.8",
+  "version": "0.49.9",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.8</version>
+    <version>0.49.9</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
## Summary
This release updates the project version from 0.49.8 to 0.49.9 and performs changelog maintenance by consolidating duplicate consecutive patch entries into range entries.

## Key Changes
- **Version bump**: Updated version references across all configuration files:
  - `pom.xml`: 0.49.8 → 0.49.9
  - `frontend/package.json`: 0.49.8 → 0.49.9
  - `README.md`: All JAR artifact references and version mentions
  - `docs/API.md`: All CLI example commands
  - `docs/DEVELOPER-GUIDE.md`: JAR verification examples

- **Changelog consolidation**: 
  - Merged duplicate entries `0.41.2` and `0.41.3` (both addressing SPA index.html 404 handling) into a single range entry `0.41.2–0.41.3`
  - Merged duplicate entries `0.17.1` and `0.17.2` (both addressing directional-scan furthest-stop behavior) into a single range entry `0.17.1–0.17.2`
  - Added clarifying note documenting that changelog entry dates reflect authoring order rather than strict release sequence, explaining version/date ordering inversions

- **New changelog entry**: Added `[0.49.9] - 2026-06-08` documenting the changelog de-duplication and version bump changes

## Notable Details
The changelog consolidation eliminates redundant entries while preserving all documented fixes and changes. The new note clarifies the authoring-order dating convention to prevent misinterpretation of non-monotonic date sequences alongside version numbers.

https://claude.ai/code/session_013goYKE1b2bh1WWSTJaBgsj