### PR TITLE
Changelog proportionality cleanup (round 2) and version bump to 0.49.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.15] - 2026-06-08
+
+### Changed
+- **Changelog proportionality cleanup (round 2)**: Condensed the remaining over-detailed mid-history patch entries (0.41.4, 0.36.3, 0.33.5) from nested bullet lists into concise summaries of the user-facing fixes, dropping no-value churn bullets (import/JavaDoc-only changes), to match the proportionality treatment already applied across the rest of the changelog.
+
 ## [0.49.14] - 2026-06-08
 
 ### Changed
@@ -189,23 +194,9 @@ UI consistency release for configuration-version workflows, lift-system editing,
 ## [0.41.4] - 2026-01-18
 
 ### Fixed
-- **Draft Version Validation**: Fixed validation failure when editing DRAFT versions
-  - ConfigEditor now correctly sends validation requests as `{ config: "..." }` instead of parsed JSON object
-  - Resolves "Unknown property 'floors' is not allowed" error when validating DRAFT configurations
-  - Both handleValidate and handleSaveDraft validation calls updated to use correct request format
-  - Validation now works consistently with create and update operations
-- **Create Version Modal**: Version number is now displayed prominently at the top of the Create Version form
-  - Shows next version number (calculated as max existing version + 1, or 1 for first version)
-  - Added styled version number display with blue accent border
-  - Version number automatically updates based on existing versions
-- **Validation feedback**: Show descriptive validation feedback in the Create Version modal when configuration JSON fails backend validation.
-- **React Hooks and Linting**: Fixed React hooks exhaustive-deps warnings and ESLint errors
-  - Fixed missing dependency warnings in `useEffect` hooks in ConfigEditor.jsx and LiftSystemDetail.jsx
-  - Wrapped `loadData` and `loadSystemData` functions in `useCallback` to properly memoize them
-  - Added `useCallback` to dependency arrays to satisfy exhaustive-deps rules
-  - Removed unused `configObject` variables in ConfigEditor.jsx that violated no-unused-vars rule
-  - Changed to direct `JSON.parse()` calls where parsed object wasn't needed
-  - All ESLint warnings and errors now resolved
+- **Draft version validation**: ConfigEditor now sends validation requests as `{ config: "..." }` (raw string) rather than a parsed object, resolving the spurious "Unknown property 'floors' is not allowed" error when validating DRAFT versions; create and update flows now validate consistently.
+- **Create Version modal**: Display the next version number (max existing + 1) prominently at the top of the form, and surface descriptive backend validation feedback inline when the configuration JSON fails validation.
+- **React hooks/linting**: Memoized `loadData`/`loadSystemData` with `useCallback` and removed unused `configObject` variables, clearing all exhaustive-deps and no-unused-vars warnings.
 
 ## [0.41.2–0.41.3] - 2026-01-17
 
@@ -291,18 +282,11 @@ UI consistency release for configuration-version workflows, lift-system editing,
 
 ## [0.36.3] - 2026-01-16
 
-### Added
-- ConfigEditor now auto-validates configuration on save attempt to prevent saving invalid configurations
-- Validation errors are displayed immediately when attempting to save invalid configuration
-- Invalid configurations are now blocked from being saved until errors are fixed
-
 ### Changed
-- ConfigEditor save workflow improved: auto-runs validation before save if not already validated
-- LiftSystems error handling improved: removed unnecessary error throw that could cause unexpected behavior
+- **Auto-validate on save**: ConfigEditor now runs validation automatically before saving, blocking invalid configurations from being saved until errors are fixed and displaying validation errors immediately.
 
 ### Fixed
-- ConfigEditor no longer allows saving invalid configurations without validation
-- LiftSystems error handling no longer throws after displaying error in AlertModal, preventing duplicate error handling
+- LiftSystems no longer re-throws after showing an error in AlertModal, preventing duplicate error handling.
 
 ## [0.36.2] - 2026-01-16
 
@@ -372,19 +356,10 @@ UI consistency release for configuration-version workflows, lift-system editing,
 ## [0.33.5] - 2026-01-15
 
 ### Fixed
-- **Validation Error Handling**: Hardened GlobalExceptionHandler to safely handle both field-level and object-level validation constraints
-  - Fixed ClassCastException when processing object-level constraint violations (e.g., @AssertTrue on class methods)
-  - Updated handleValidationErrors method to check error type before casting
-  - Field-level errors (FieldError) now use field name as key
-  - Object-level errors (ObjectError) now use object name as key
-  - Both error types are properly surfaced in ValidationErrorResponse
+- **Validation error handling**: Hardened `GlobalExceptionHandler` to handle both field-level (`FieldError`) and object-level (`ObjectError`, e.g. `@AssertTrue` on class methods) constraints by checking error type before casting — fixing a `ClassCastException` on object-level violations — and surfaced both, keyed by field/object name, in `ValidationErrorResponse`.
 
 ### Added
-- **Comprehensive Validation Tests**: Added a 10-case `GlobalExceptionHandlerValidationTest` suite covering field-level, object-level, and mixed validation constraint handling.
-
-### Changed
-- GlobalExceptionHandler now imports ObjectError alongside FieldError
-- Enhanced JavaDoc comments in GlobalExceptionHandler for validation error handling
+- **Validation tests**: Added a 10-case `GlobalExceptionHandlerValidationTest` covering field-level, object-level, and mixed constraint handling.
 
 ## [0.33.4] - 2026-01-13
 
@@ -452,7 +427,6 @@ UI consistency release for configuration-version workflows, lift-system editing,
 ### Changed
 - README now documents lift-system CRUD and version-management capabilities.
 - Lift Systems page actions now navigate to the detail view.
-
 
 ## Earlier history
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.13**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.15**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -104,12 +104,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.13.jar
+java -jar target/lift-simulator-0.49.15.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.13.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.15.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -121,21 +121,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.13.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.13.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.13.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.13.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -200,7 +200,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.13.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.15.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.13.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.15.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.13.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.13.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.13.jar \
+   java -cp target/lift-simulator-0.49.15.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.13.jar \
+java -cp target/lift-simulator-0.49.15.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.13",
+  "version": "0.49.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.13",
+      "version": "0.49.15",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.13",
+  "version": "0.49.15",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.14</version>
+    <version>0.49.15</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
## Summary
This PR condenses over-detailed mid-history changelog entries (versions 0.41.4, 0.36.3, and 0.33.5) into concise, user-facing summaries while removing low-value churn bullets (import/JavaDoc-only changes). The version is bumped to 0.49.15 across all configuration files and documentation.

## Key Changes

- **Changelog condensing**: Simplified three verbose patch entries by:
  - **0.41.4**: Collapsed nested bullet lists covering draft validation, create version modal, and React hooks into three focused summary bullets highlighting user-facing fixes
  - **0.36.3**: Merged "Added" and "Changed" sections into a single "Changed" entry on auto-validation, and simplified the "Fixed" section
  - **0.33.5**: Condensed validation error handling details into a single technical summary, and removed JavaDoc/import-only changes from the "Changed" section
  
- **Version updates**: Bumped version from 0.49.13/0.49.14 to 0.49.15 in:
  - `pom.xml` (Maven project version)
  - `frontend/package.json` (Node.js package version)
  - `README.md` (current version reference and all JAR command examples)
  - `docs/Workflows-and-Troubleshooting.md` (all CLI command examples)
  - `docs/DEVELOPER-GUIDE.md` (JAR verification example)

## Notable Details

The changelog cleanup maintains proportionality with the rest of the changelog by removing implementation-level noise (e.g., "imports ObjectError alongside FieldError", "Enhanced JavaDoc comments") while preserving the essential user-facing and technical fixes. All documentation examples now consistently reference the new version number.

https://claude.ai/code/session_014vZTXA7QeokdgBruXL6LCP