### PR TITLE
Automate version synchronization across project artifacts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,8 +6,18 @@ if ! git diff --cached --name-only | grep -q '^pom\.xml$'; then
   exit 0
 fi
 
+# Resolve python binary (python3 on Linux/Mac, may be python on Windows)
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "[pre-commit] ERROR: python3/python not found — cannot sync version." >&2
+  exit 1
+fi
+
 # Extract project version from staged pom.xml (avoids reading parent <version>)
-VERSION=$(git show :pom.xml | python3 -c "
+VERSION=$(git show :pom.xml | $PYTHON -c "
 import sys, xml.etree.ElementTree as ET
 tree = ET.parse(sys.stdin)
 root = tree.getroot()
@@ -24,7 +34,7 @@ mvn generate-resources -q
 if command -v npm >/dev/null 2>&1; then
   npm --prefix frontend version "${VERSION}" --no-git-tag-version --allow-same-version --silent
 else
-  python3 - "${VERSION}" <<'PYEOF'
+  $PYTHON - "${VERSION}" <<'PYEOF'
 import json, sys
 path = 'frontend/package.json'
 with open(path) as f:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Only act when pom.xml is staged — version bump detection
+if ! git diff --cached --name-only | grep -q '^pom\.xml$'; then
+  exit 0
+fi
+
+# Extract project version from staged pom.xml (avoids reading parent <version>)
+VERSION=$(git show :pom.xml | python3 -c "
+import sys, xml.etree.ElementTree as ET
+tree = ET.parse(sys.stdin)
+root = tree.getroot()
+ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+print(root.find('m:version', ns).text)
+")
+
+echo "[pre-commit] Version bump detected: ${VERSION} — syncing version references..."
+
+# Sync README.md and docs/*.md (fast — no compilation)
+mvn generate-resources -q
+
+# Sync frontend/package.json (and package-lock.json if npm is available)
+if command -v npm >/dev/null 2>&1; then
+  npm --prefix frontend version "${VERSION}" --no-git-tag-version --allow-same-version --silent
+else
+  python3 - "${VERSION}" <<'PYEOF'
+import json, sys
+path = 'frontend/package.json'
+with open(path) as f:
+    data = json.load(f)
+data['version'] = sys.argv[1]
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+PYEOF
+fi
+
+# Re-stage all version-synced files
+git add README.md docs/
+git add frontend/package.json
+if [ -f frontend/package-lock.json ]; then
+  git add frontend/package-lock.json
+fi
+
+echo "[pre-commit] Version references synced and staged."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,41 @@ jobs:
       env:
         PGPASSWORD: liftpassword
 
+    - name: Verify version consistency
+      run: |
+        POM_VERSION=$(python3 -c "
+        import xml.etree.ElementTree as ET
+        tree = ET.parse('pom.xml')
+        root = tree.getroot()
+        ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+        print(root.find('m:version', ns).text)
+        ")
+        echo "POM version: $POM_VERSION"
+        FAILED=0
+
+        if ! grep -qF "Current version: **${POM_VERSION}**" README.md; then
+          echo "ERROR: README.md version does not match pom.xml ($POM_VERSION)"
+          FAILED=1
+        fi
+
+        for f in docs/*.md; do
+          if grep -qE 'lift-simulator-[0-9]+\.[0-9]+\.[0-9]+\.jar' "$f"; then
+            if ! grep -qF "lift-simulator-${POM_VERSION}.jar" "$f"; then
+              echo "ERROR: $f contains a stale JAR version (expected $POM_VERSION)"
+              FAILED=1
+            fi
+          fi
+        done
+
+        PKG_VERSION=$(python3 -c "import json; print(json.load(open('frontend/package.json'))['version'])")
+        if [ "$PKG_VERSION" != "$POM_VERSION" ]; then
+          echo "ERROR: frontend/package.json version ($PKG_VERSION) != pom.xml ($POM_VERSION)"
+          FAILED=1
+        fi
+
+        [ $FAILED -eq 0 ] && echo "All version references are consistent."
+        exit $FAILED
+
     - name: Build project
       run: mvn -q clean compile
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -443,3 +443,17 @@ Run the tests:
 ```bash
 mvn test -Dtest=LiftSystemRepositoryTest,LiftSystemVersionRepositoryTest
 ```
+
+## Git Hooks
+
+A pre-commit hook lives in `.githooks/pre-commit`. It fires automatically whenever `pom.xml` is staged and keeps version references in `README.md`, `docs/*.md`, and `frontend/package.json` in sync — so you never need to update them by hand.
+
+Activate it once after cloning:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+**What the hook does:** when it detects a version change in the staged `pom.xml`, it runs `mvn generate-resources` to update `README.md` and `docs/*.md`, updates `frontend/package.json` (via `npm version` if available, otherwise Python), and re-stages all affected files before the commit is recorded.
+
+**CI safety net:** the CI pipeline includes a version-consistency check that fails the build if any of these files are out of sync with `pom.xml`, catching the rare case where the hook was bypassed with `--no-verify`.

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,41 @@
                             <goal>run</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>sync-readme-version</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <replaceregexp
+                                    file="${project.basedir}/README.md"
+                                    match="Current version: \*\*[0-9]+\.[0-9]+\.[0-9]+\*\*"
+                                    replace="Current version: **${project.version}**"
+                                    byline="true"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>sync-docs-jar-version</id>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <target>
+                                <replaceregexp
+                                    match="lift-simulator-[0-9]+\.[0-9]+\.[0-9]+\.jar"
+                                    replace="lift-simulator-${project.version}.jar"
+                                    byline="true">
+                                    <fileset dir="${project.basedir}/docs">
+                                        <include name="*.md"/>
+                                    </fileset>
+                                </replaceregexp>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -292,6 +327,15 @@
                                 <configuration>
                                     <nodeVersion>v20.19.0</nodeVersion>
                                     <npmVersion>10.2.4</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>sync-package-version</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>version ${project.version} --no-git-tag-version --allow-same-version</arguments>
                                 </configuration>
                             </execution>
                             <execution>

--- a/src/main/java/com/liftsimulator/admin/config/OpenApiConfig.java
+++ b/src/main/java/com/liftsimulator/admin/config/OpenApiConfig.java
@@ -24,6 +24,9 @@ public class OpenApiConfig {
     @Value("${spring.application.name:lift-config-service}")
     private String applicationName;
 
+    @Value("${version:unknown}")
+    private String projectVersion;
+
     /**
      * Configures the OpenAPI specification with API metadata and security schemes.
      *
@@ -37,7 +40,7 @@ public class OpenApiConfig {
                         .description("REST API for managing lift systems, scenarios, and simulation runs. "
                                 + "The Lift Simulator provides endpoints for creating and managing lift "
                                 + "configurations, running simulations, and retrieving results.")
-                        .version("0.46.0")
+                        .version(projectVersion)
                         .contact(new Contact()
                                 .name("Lift Simulator Team")
                                 .url("https://github.com/manoj-bhaskaran/lift-simulator"))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,8 @@
 spring:
   application:
     name: lift-config-service
+  config:
+    import: "optional:classpath:version.properties"
   jpa:
     open-in-view: false
   flyway:


### PR DESCRIPTION
## Summary
This PR implements automated version synchronization across multiple project artifacts (README, documentation, npm package, and OpenAPI spec) to ensure consistency and reduce manual version management overhead.

## Key Changes
- **Maven Build Automation**: Added two new Maven Antrun executions in the `generate-resources` phase:
  - `sync-readme-version`: Automatically updates the version string in README.md to match the project version
  - `sync-docs-jar-version`: Updates all JAR filename references in documentation files to reflect the current project version

- **NPM Package Version Sync**: Added a new Maven Frontend Plugin execution that runs `npm version` during the build to keep the npm package version in sync with the Maven project version

- **OpenAPI Specification**: Modified `OpenApiConfig.java` to dynamically inject the project version into the OpenAPI spec instead of using a hardcoded version string ("0.46.0")

- **Version Property Management**: Updated `application.yml` to import version properties from a `version.properties` file, enabling centralized version management

## Implementation Details
- Version synchronization occurs during the `generate-resources` phase, ensuring it happens early in the build lifecycle
- The npm version sync uses `--no-git-tag-version --allow-same-version` flags to prevent git operations and allow re-running builds with the same version
- All version references now use `${project.version}` placeholder, creating a single source of truth for versioning
- The OpenAPI version is injected via Spring's `@Value` annotation with a fallback to "unknown" if not provided

https://claude.ai/code/session_01GJWrPrBS3JuYux73uUYMjD