### PR TITLE
fix(openapi): upgrade springdoc to 2.7.0 for Spring Boot 3.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.16] - 2026-06-12
+
+### Fixed
+- **Swagger/OpenAPI compatibility**: Upgraded `springdoc-openapi-starter-webmvc-ui` to `2.7.0` so Spring Boot 3.4.13 can generate `/api/v1/api-docs` without the removed `ControllerAdviceBean(Object)` constructor error, restoring Swagger UI at `/api/v1/swagger-ui.html` with the configured `basicAuth` and `apiKey` security schemes.
+
 ## [0.49.15] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.15**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.16**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -104,12 +104,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.15.jar
+java -jar target/lift-simulator-0.49.16.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.15.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.16.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -121,21 +121,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.16.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.16.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.16.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.15.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.16.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -200,7 +200,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.15.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.16.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 
@@ -267,7 +267,7 @@ Alternatively, set `LOGGING_FILE_PATH` as an environment variable.
 
 This project ships an `.editorconfig` for consistent formatting across editors and IDEs (IntelliJ IDEA has built-in support; VS Code, Eclipse, and Vim/Neovim use plugins). It enforces UTF-8 encoding, LF line endings, 4-space indentation for Java and XML, trailing-whitespace removal, and final-newline insertion.
 
-**Backend dependency baseline:** Spring Boot 3.4.13, PostgreSQL JDBC driver 42.7.11, and the Flyway PostgreSQL module (managed by Spring Boot dependency management).
+**Backend dependency baseline:** Spring Boot 3.4.13, Springdoc OpenAPI 2.7.0, PostgreSQL JDBC driver 42.7.11, and the Flyway PostgreSQL module (managed by Spring Boot dependency management).
 
 **Commenting style:** use `//` for single-line comments and `/* */` for multi-line explanations, write non-obvious logic as complete sentences, and end comment sentences with periods.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.15.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.16.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.15.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.15.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.15.jar \
+   java -cp target/lift-simulator-0.49.16.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.15.jar \
+java -cp target/lift-simulator-0.49.16.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.15",
+  "version": "0.49.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.15",
+      "version": "0.49.16",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.15",
+  "version": "0.49.16",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.15</version>
+    <version>0.49.16</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
+            <version>2.7.0</version>
         </dependency>
 
         <!-- Spring Boot Test Starter -->

--- a/src/test/java/com/liftsimulator/admin/config/OpenApiPrivateSecurityConfigTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/OpenApiPrivateSecurityConfigTest.java
@@ -7,11 +7,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -44,11 +44,16 @@ class OpenApiPrivateSecurityConfigTest extends LocalIntegrationTest {
     }
 
     @Test
-    void openApiDocs_PrivateAccess_AdminRole_DoesNotReturnAuthzFailure() throws Exception {
+    void openApiDocs_PrivateAccess_AdminRole_ReturnsOpenApiJsonWithSecuritySchemes() throws Exception {
         mockMvc.perform(get("/api/v1/api-docs")
                 .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD)))
-            .andExpect(result -> assertThat(result.getResponse().getStatus())
-                .isNotIn(401, 403));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.openapi").exists())
+            .andExpect(jsonPath("$.components.securitySchemes.basicAuth.type").value("http"))
+            .andExpect(jsonPath("$.components.securitySchemes.basicAuth.scheme").value("basic"))
+            .andExpect(jsonPath("$.components.securitySchemes.apiKey.type").value("apiKey"))
+            .andExpect(jsonPath("$.components.securitySchemes.apiKey.in").value("header"))
+            .andExpect(jsonPath("$.components.securitySchemes.apiKey.name").value("X-API-Key"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Springdoc `2.3.0` was incompatible with Spring Boot `3.4.13`, causing Swagger UI/OpenAPI generation to fail; the change restores working `/api/v1/api-docs` and `/api/v1/swagger-ui.html` endpoints.
- Keep project metadata consistent after the dependency fix by bumping the project/package version to `0.49.16` and updating docs/examples that reference the artifact name.

### Description
- Upgraded `springdoc-openapi-starter-webmvc-ui` from `2.3.0` to `2.7.0` in `pom.xml` to address the Spring Boot `3.4.13` incompatibility. 
- Bumped Maven project version to `0.49.16` and updated `frontend/package.json` and `frontend/package-lock.json` to `0.49.16` for repository-wide version alignment. 
- Added a `0.49.16` entry to `CHANGELOG.md` describing the Swagger/OpenAPI compatibility fix. 
- Updated `README.md`, `docs/DEVELOPER-GUIDE.md`, and `docs/Workflows-and-Troubleshooting.md` examples and CLI/JAR references to use the new `0.49.16` artifact name. 
- Strengthened the OpenAPI integration test `OpenApiPrivateSecurityConfigTest` to assert that authenticated GET `/api/v1/api-docs` returns HTTP `200` OpenAPI JSON and includes the configured `basicAuth` and `apiKey` security schemes.
- Commit message used: `fix(openapi): update springdoc for boot 3.4`.

### Testing
- Ran `git diff --check` to verify no whitespace/git issues; result: PASS. 
- Verified `pom.xml` parses as well-formed XML via a Python XML parse; result: PASS. 
- Read frontend package version with `npm --prefix frontend pkg get version`; result: PASS (shows `0.49.16`). 
- Attempted `mvn -Dtest=OpenApiPrivateSecurityConfigTest test` to run the modified test, but the Maven build was blocked by environment network restrictions (HTTP 403 from Maven Central while resolving the Spring Boot parent POM); result: WARN/blocked (network).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b80447b408325930d405e4b31fe78)