### PR TITLE
fix: add version config JSON schema guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.21] - 2026-06-12
+
+### Fixed
+- **Version configuration JSON guidance**: Replaced truncated configuration editor placeholders with complete valid JSON examples, added required-field/schema help and a schema documentation link beside the create/edit version fields, and refreshed API examples to avoid invalid ellipsis placeholders. Updated README and package metadata for the 0.49.21 patch release.
+
 ## [0.49.20] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.49.21] - 2026-06-12
 
 ### Fixed
-- **Version configuration JSON guidance**: Replaced truncated configuration editor placeholders with complete valid JSON examples, added required-field/schema help and a schema documentation link beside the create/edit version fields, and refreshed API examples to avoid invalid ellipsis placeholders. Updated README and package metadata for the 0.49.21 patch release.
+- **Version configuration JSON guidance**: Replaced truncated configuration editor placeholders with complete valid JSON examples, added required-field/schema help and a schema documentation link beside the create/edit version fields, and refreshed API examples to avoid invalid ellipsis placeholders. Updated README, developer/workflow guides, and package metadata for the 0.49.21 patch release.
 
 ## [0.49.20] - 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.20**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.21**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -79,7 +79,7 @@ The project ships a Spring Boot backend (`Lift Config Service`) and a React sing
 The **frontend admin UI** provides:
 - **Dashboard** — overview of lift systems with quick statistics
 - **Lift Systems Management** — full CRUD with list and detail views
-- **Version Management** — create, publish, and archive versioned configurations with pagination, sorting, and filtering
+- **Version Management** — create, publish, and archive versioned configurations with pagination, sorting, filtering, complete JSON examples, and schema guidance in the configuration editor
 - **Scenario Builder** — template-based or custom passenger-flow scenarios with server-side validation and an advanced JSON editor
 - **Simulator Runs** — launch published versions with scenarios, poll status, and review KPI results with artefact downloads and CLI reproduction hints
 - **Configuration Editor & Validator** — edit and validate configuration JSON before publishing
@@ -104,12 +104,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.20.jar
+java -jar target/lift-simulator-0.49.21.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.20.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.21.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -121,21 +121,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.20.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.20.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.20.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.20.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -200,7 +200,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.20.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.21.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -177,7 +177,7 @@ The backend includes a comprehensive validation framework for lift system config
   - Request body:
     ```json
     {
-      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2, \"travelTicksPerFloor\": 1, ...}"
+      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2, \"travelTicksPerFloor\": 1, \"doorTransitionTicks\": 2, \"doorDwellTicks\": 3, \"doorReopenWindowTicks\": 2, \"homeFloor\": 0, \"idleTimeoutTicks\": 5, \"controllerStrategy\": \"NEAREST_REQUEST_ROUTING\", \"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}"
     }
     ```
   - Response (200 OK) - Valid configuration:
@@ -418,7 +418,7 @@ Path inputFile = runService.generateBatchInputFile(runId);
 | `passengerFlows[].passengers` | Integer | Required, ≥ 1 | Number of passengers in the flow |
 | `seed` | Integer | Optional, ≥ 0 | Random seed for deterministic runs |
 
-**Configuration Structure:**
+##### Configuration Structure
 
 All lift system configurations must conform to the following structure:
 
@@ -1017,7 +1017,7 @@ curl -H "X-API-Key: replace-with-secure-key" \\
       "systemKey": "building-a-lifts",
       "displayName": "Building A Lift System",
       "versionNumber": 3,
-      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2, ...}",
+      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2, \"travelTicksPerFloor\": 1, \"doorTransitionTicks\": 2, \"doorDwellTicks\": 3, \"doorReopenWindowTicks\": 2, \"homeFloor\": 0, \"idleTimeoutTicks\": 5, \"controllerStrategy\": \"NEAREST_REQUEST_ROUTING\", \"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}",
       "publishedAt": "2026-01-11T14:30:00Z"
     }
     ```

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.20.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.21.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.20.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.20.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.20.jar \
+   java -cp target/lift-simulator-0.49.21.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.20.jar \
+java -cp target/lift-simulator-0.49.21.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/e2e/configuration-versions.spec.ts
+++ b/frontend/e2e/configuration-versions.spec.ts
@@ -59,6 +59,13 @@ test.describe('Configuration Version Management', () => {
     await expect(page.locator('.create-version-form')).toBeVisible();
     await expect(page.locator('.create-version-form h4')).toHaveText(/Version 1/i);
 
+    const configField = page.locator('#config');
+    await expect(configField).toHaveAttribute('placeholder', /"doorTransitionTicks"/);
+    await expect(configField).not.toHaveAttribute('placeholder', /\.\.\./);
+    await expect(page.locator('#config-help')).toContainText('Required integer fields');
+    await expect(page.locator('#config-required-fields')).toContainText('controllerStrategy');
+    await expect(page.locator('.create-version-form a:has-text("View schema docs")')).toBeVisible();
+
     // Step 2: Paste valid configuration JSON
     const validConfig = VALID_CONFIGS.basicOffice;
     await page.locator('#config').fill(JSON.stringify(validConfig, null, 2));

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.20",
+  "version": "0.49.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.20",
+      "version": "0.49.21",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.20",
+  "version": "0.49.21",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/pages/ConfigEditor.css
+++ b/frontend/src/pages/ConfigEditor.css
@@ -92,10 +92,52 @@
   color: #2c3e50;
 }
 
+.schema-docs-link {
+  color: #3498db;
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-top: 0.35rem;
+  text-decoration: none;
+}
+
+.schema-docs-link:hover {
+  text-decoration: underline;
+}
+
 .last-saved {
   font-size: 0.85rem;
   color: #27ae60;
   font-weight: 500;
+}
+
+.config-help-text,
+.config-required-fields {
+  margin: 0 0 0.75rem 0;
+  color: #5d6d7e;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.config-example-help {
+  margin-bottom: 0.75rem;
+  color: #34495e;
+  font-size: 0.9rem;
+}
+
+.config-example-help summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.config-example-help pre {
+  margin: 0.75rem 0 0 0;
+  padding: 0.75rem;
+  overflow-x: auto;
+  background: #eef3f7;
+  border: 1px solid #d6e0ea;
+  border-radius: 4px;
+  color: #2c3e50;
 }
 
 .config-textarea {

--- a/frontend/src/pages/ConfigEditor.jsx
+++ b/frontend/src/pages/ConfigEditor.jsx
@@ -5,6 +5,7 @@ import { liftSystemsApi } from '../api/liftSystemsApi';
 import ConfirmModal from '../components/ConfirmModal';
 import { handleApiError } from '../utils/errorHandlers';
 import { getStatusBadgeClass } from '../utils/statusUtils';
+import { CONFIG_EXAMPLE_JSON, CONFIG_REQUIRED_FIELDS, CONFIG_SCHEMA_DOCS_URL, CONFIG_SCHEMA_HELP_TEXT } from '../utils/configSchemaHelp';
 import './ConfigEditor.css';
 
 /**
@@ -254,7 +255,12 @@ function ConfigEditor() {
       <div className="editor-layout">
         <div className="editor-section">
           <div className="section-header">
-            <h3>Configuration JSON</h3>
+            <div>
+              <h3>Configuration JSON</h3>
+              <a className="schema-docs-link" href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
+                View schema docs
+              </a>
+            </div>
             {lastSaved && (
               <span className="last-saved">
                 Last saved: {lastSaved.toLocaleTimeString()}
@@ -262,13 +268,22 @@ function ConfigEditor() {
             )}
           </div>
 
+          <p id="config-editor-help" className="config-help-text">{CONFIG_SCHEMA_HELP_TEXT}</p>
+          <details className="config-example-help">
+            <summary>Show complete valid example</summary>
+            <pre>{CONFIG_EXAMPLE_JSON}</pre>
+          </details>
           <textarea
             className="config-textarea"
             value={config}
             onChange={handleConfigChange}
             spellCheck="false"
-            placeholder='{"minFloor": 0, "maxFloor": 9, "lifts": 2, ...}'
+            placeholder={CONFIG_EXAMPLE_JSON}
+            aria-describedby="config-editor-help config-editor-required-fields"
           />
+          <p id="config-editor-required-fields" className="config-required-fields">
+            Required fields: {CONFIG_REQUIRED_FIELDS.map((field) => `\`${field}\``).join(', ')}.
+          </p>
 
           <div className="editor-actions">
             <button

--- a/frontend/src/pages/LiftSystemDetail.css
+++ b/frontend/src/pages/LiftSystemDetail.css
@@ -284,6 +284,59 @@
   margin-bottom: 1rem;
 }
 
+
+.config-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.config-label-row label {
+  margin-bottom: 0;
+}
+
+.config-label-row a {
+  color: #3498db;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.config-label-row a:hover {
+  text-decoration: underline;
+}
+
+.config-help-text,
+.config-required-fields {
+  margin: 0 0 0.75rem 0;
+  color: #5d6d7e;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.config-example-help {
+  margin-bottom: 0.75rem;
+  color: #34495e;
+  font-size: 0.9rem;
+}
+
+.config-example-help summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.config-example-help pre {
+  margin: 0.75rem 0 0 0;
+  padding: 0.75rem;
+  overflow-x: auto;
+  background: #eef3f7;
+  border: 1px solid #d6e0ea;
+  border-radius: 4px;
+  color: #2c3e50;
+}
+
 .form-actions {
   display: flex;
   gap: 0.5rem;

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -8,6 +8,7 @@ import AlertModal from '../components/AlertModal';
 import EditSystemModal from '../components/EditSystemModal';
 import { handleApiError } from '../utils/errorHandlers';
 import { getStatusBadgeClass } from '../utils/statusUtils';
+import { CONFIG_EXAMPLE_JSON, CONFIG_REQUIRED_FIELDS, CONFIG_SCHEMA_DOCS_URL, CONFIG_SCHEMA_HELP_TEXT } from '../utils/configSchemaHelp';
 import './LiftSystemDetail.css';
 
 /**
@@ -387,15 +388,29 @@ function LiftSystemDetail() {
             <div className="version-number-display">
               <h4>Version {versions.length > 0 ? Math.max(...versions.map(v => v.versionNumber)) + 1 : 1}</h4>
             </div>
-            <label htmlFor="config">Configuration JSON</label>
+            <div className="config-label-row">
+              <label htmlFor="config">Configuration JSON</label>
+              <a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
+                View schema docs
+              </a>
+            </div>
+            <p id="config-help" className="config-help-text">{CONFIG_SCHEMA_HELP_TEXT}</p>
+            <details className="config-example-help">
+              <summary>Show complete valid example</summary>
+              <pre>{CONFIG_EXAMPLE_JSON}</pre>
+            </details>
             <textarea
               id="config"
               value={newVersionConfig}
               onChange={handleNewVersionConfigChange}
-              placeholder='{"minFloor": 0, "maxFloor": 9, "lifts": 2, "travelTicksPerFloor": 10, ...}'
-              rows="10"
+              placeholder={CONFIG_EXAMPLE_JSON}
+              rows="14"
               required
+              aria-describedby="config-help config-required-fields"
             />
+            <p id="config-required-fields" className="config-required-fields">
+              Required fields: {CONFIG_REQUIRED_FIELDS.map((field) => `\`${field}\``).join(', ')}.
+            </p>
             <div className="form-actions">
               <button
                 type="button"

--- a/frontend/src/utils/configSchemaHelp.js
+++ b/frontend/src/utils/configSchemaHelp.js
@@ -1,0 +1,34 @@
+export const CONFIG_EXAMPLE = {
+  minFloor: 0,
+  maxFloor: 9,
+  lifts: 2,
+  travelTicksPerFloor: 1,
+  doorTransitionTicks: 2,
+  doorDwellTicks: 3,
+  doorReopenWindowTicks: 2,
+  homeFloor: 0,
+  idleTimeoutTicks: 5,
+  controllerStrategy: 'NEAREST_REQUEST_ROUTING',
+  idleParkingMode: 'PARK_TO_HOME_FLOOR'
+};
+
+export const CONFIG_EXAMPLE_JSON = JSON.stringify(CONFIG_EXAMPLE, null, 2);
+
+export const CONFIG_REQUIRED_FIELDS = [
+  'minFloor',
+  'maxFloor',
+  'lifts',
+  'travelTicksPerFloor',
+  'doorTransitionTicks',
+  'doorDwellTicks',
+  'doorReopenWindowTicks',
+  'homeFloor',
+  'idleTimeoutTicks',
+  'controllerStrategy',
+  'idleParkingMode'
+];
+
+export const CONFIG_SCHEMA_HELP_TEXT =
+  'Required integer fields: minFloor, maxFloor, lifts, travelTicksPerFloor, doorTransitionTicks, doorDwellTicks, doorReopenWindowTicks, homeFloor, idleTimeoutTicks. controllerStrategy must be NEAREST_REQUEST_ROUTING or DIRECTIONAL_SCAN; idleParkingMode must be STAY_AT_CURRENT_FLOOR or PARK_TO_HOME_FLOOR.';
+
+export const CONFIG_SCHEMA_DOCS_URL = 'https://github.com/manoj-bhaskaran/lift-simulator/blob/main/docs/API.md#configuration-structure';

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.20</version>
+    <version>0.49.21</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- The configuration JSON editor used an abbreviated placeholder with `...` and provided no inline schema guidance, which made creating valid lift-system configs error-prone.  
- The change provides clear, discoverable schema help and a full valid example so users can author config JSON correctly before validation/publish.  

### Description
- Add reusable schema helpers in `frontend/src/utils/configSchemaHelp.js` exposing a complete valid example (`CONFIG_EXAMPLE_JSON`), required-field list, inline help text and a docs URL.  
- Replace truncated placeholder text in the Create Version form and the Config Editor with the full example, add a schema docs link, visible required-field line, and an expandable example block in `frontend/src/pages/LiftSystemDetail.jsx` and `frontend/src/pages/ConfigEditor.jsx`.  
- Add styling for help text, example block and schema link in `frontend/src/pages/LiftSystemDetail.css` and `frontend/src/pages/ConfigEditor.css`.  
- Update E2E test assertions in `frontend/e2e/configuration-versions.spec.ts` to assert the placeholder contains concrete schema fields and guidance, refresh `docs/API.md` configuration examples, update `README.md` and `CHANGELOG.md`, and bump frontend/backend package metadata/version to `0.49.21` (`frontend/package.json`, `frontend/package-lock.json`, `pom.xml`).  

### Testing
- Ran frontend lint with `npm run lint` which completed with warnings but no errors.  
- Ran frontend unit tests with `npm run test:unit` (Vitest) which passed (6 test files / 54 tests).  
- Built the frontend with `npm run build` which succeeded and produced a production bundle.  
- Verified local sanity checks: `git diff --check` (no whitespace errors).  
- Attempted backend `mvn test -Dskip.npm=true` but the Maven parent POM failed to resolve due to network (HTTP 403) in this environment, so full backend integration run could not complete.  
- Attempted `npx playwright install` to capture a UI screenshot, but Playwright browser downloads were blocked by network (HTTP 403), so browser-driven screenshot was not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bcb6231248325ad3ceb4287c832e8)