### PR TITLE
fix(auth): frontend Axios client sends Basic auth and API key headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.22] - 2026-06-12
+
+### Fixed
+- **Frontend API authentication headers**: The Axios client now reads Vite-provided admin Basic auth and runtime API-key credentials at construction time and sends `Authorization` and `X-API-Key` defaults with API requests. Updated setup documentation for `frontend/.env.local` and synchronized package metadata for the 0.49.22 patch release.
+
 ## [0.49.21] - 2026-06-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.21**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.22**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -40,24 +40,31 @@ The simulation is text-based and designed for clarity over visual appeal.
    GRANT ALL ON SCHEMA lift_simulator TO lift_admin;
    \q
    ```
-2. **Configure application settings** — copy the template and set your database password:
+2. **Configure application settings** — copy the template and set your database password and API credentials:
    ```bash
    cp src/main/resources/application-dev.yml.template src/main/resources/application-dev.yml
    ```
-   Edit `application-dev.yml` and replace `CHANGE_ME` under `spring.datasource.password`. This file is excluded from version control.
-3. **Start the backend** with the `dev` profile so it loads `application-dev.yml` (the first run downloads dependencies and applies Flyway migrations):
+   Edit `application-dev.yml` and replace `CHANGE_ME` under `spring.datasource.password`, `security.admin.password`, and `api.auth.key`. This file is excluded from version control.
+3. **Configure frontend API credentials** — create `frontend/.env.local` with values matching `application-dev.yml` so the browser client can send both backend auth schemes:
+   ```bash
+   VITE_ADMIN_USERNAME=admin
+   VITE_ADMIN_PASSWORD=local-admin-password
+   VITE_API_KEY=local-api-key
+   ```
+   `frontend/.env.local` is ignored by Git via the frontend `*.local` rule. Vite exposes `VITE_*` values to the browser bundle, so use only environment-appropriate credentials and never commit this file.
+4. **Start the backend** with the `dev` profile so it loads `application-dev.yml` (the first run downloads dependencies and applies Flyway migrations):
    ```bash
    SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run
    ```
    The backend listens on **http://localhost:8080**.
-4. **Start the frontend** in a new terminal:
+5. **Start the frontend** in a new terminal:
    ```bash
    cd frontend
    npm install   # first time only
    npm run dev
    ```
    The frontend is served at **http://localhost:3000**.
-5. **Open** http://localhost:3000 — you should see the Lift Simulator dashboard.
+6. **Open** http://localhost:3000 — you should see the Lift Simulator dashboard.
 
 **Daily usage** (after first-time setup)
 
@@ -104,12 +111,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.21.jar
+java -jar target/lift-simulator-0.49.22.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.21.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.22.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -121,21 +128,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.21.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -200,7 +207,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.21.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.22.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 
@@ -209,7 +216,9 @@ OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECUR
 The backend requires authentication for API access through two mechanisms:
 
 - **Admin APIs** (`/api/v1/**` except `/api/v1/health`) use **HTTP Basic** authentication. Set credentials under `security.admin` in `application-dev.yml`, or via the `ADMIN_USERNAME` / `ADMIN_PASSWORD` environment variables.
-- **Runtime APIs** (`/api/v1/runtime/**`) use an **API key** in the `X-API-Key` header. Set `api.auth.key` (or the `API_KEY` environment variable); generate a key with `openssl rand -hex 32`.
+- **Runtime and simulation APIs** (`/api/v1/runtime/**`, `/api/v1/simulation-runs/**`) use an **API key** in the `X-API-Key` header. Set `api.auth.key` (or the `API_KEY` environment variable); generate a key with `openssl rand -hex 32`.
+
+The React admin UI sends both schemes from Vite environment variables when present. For local development, create `frontend/.env.local` with `VITE_ADMIN_USERNAME`, `VITE_ADMIN_PASSWORD`, and `VITE_API_KEY` values that match the backend credentials. The backend ignores the unused header for each endpoint, so one Axios client can safely send both headers on API requests.
 
 Public endpoints requiring no authentication are `/api/v1/health`, `/actuator/health`, `/actuator/info`, and static/frontend routes. Unauthenticated requests return HTTP 401; authenticated requests lacking permission return HTTP 403.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.21.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.22.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -443,6 +443,18 @@ Run the tests:
 ```bash
 mvn test -Dtest=LiftSystemRepositoryTest,LiftSystemVersionRepositoryTest
 ```
+
+## Frontend API Authentication
+
+The React admin UI uses `frontend/src/api/client.js` for backend calls. During local development, create `frontend/.env.local` with credentials that match `src/main/resources/application-dev.yml` or the backend environment variables:
+
+```bash
+VITE_ADMIN_USERNAME=admin
+VITE_ADMIN_PASSWORD=local-admin-password
+VITE_API_KEY=local-api-key
+```
+
+When both admin values are present, the Axios client sends an HTTP Basic `Authorization` header. When `VITE_API_KEY` is present, it sends the runtime `X-API-Key` header. The backend ignores the header that is irrelevant to a given endpoint, so the shared client can send both defaults. `frontend/.env.local` is covered by the frontend `*.local` ignore rule; never commit real credentials, and remember that Vite exposes `VITE_*` variables to browser bundles.
 
 ## Git Hooks
 

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.21.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.21.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.21.jar \
+   java -cp target/lift-simulator-0.49.22.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.21.jar \
+java -cp target/lift-simulator-0.49.22.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,7 +70,19 @@ Shared interfaces include `LiftSystem`, `Version`, and `ValidationResult`.
 npm install
 ```
 
-### 2. Start Development Server
+### 2. Configure API Credentials
+
+Create `frontend/.env.local` with credentials that match the backend values in `application-dev.yml` or the backend environment. The file is ignored by Git through the frontend `*.local` rule.
+
+```bash
+VITE_ADMIN_USERNAME=admin
+VITE_ADMIN_PASSWORD=local-admin-password
+VITE_API_KEY=local-api-key
+```
+
+The Axios client sends `Authorization: Basic ...` when both admin values are set and sends `X-API-Key` when `VITE_API_KEY` is set. Vite exposes `VITE_*` values in the browser bundle, so use environment-scoped credentials and never commit this file.
+
+### 3. Start Development Server
 
 ```bash
 npm run dev
@@ -78,7 +90,7 @@ npm run dev
 
 The application will start on **http://localhost:3000**
 
-### 3. Start Backend Service
+### 4. Start Backend Service
 
 Make sure the Spring Boot backend is running on port 8080. The authenticated admin and simulation APIs require credentials even during E2E runs, so export backend credentials before starting Spring Boot. The matching browser-test credentials are injected by Playwright at test time, not by the application bundle:
 
@@ -433,15 +445,21 @@ The API client can be configured at build time via Vite environment variables:
 | --- | --- | --- |
 | `VITE_API_BASE_URL` | Base URL for API requests (e.g., `https://api.example.com/api/v1`) | `/api/v1` |
 | `VITE_API_TIMEOUT_MS` | Axios request timeout in milliseconds | `10000` |
+| `VITE_ADMIN_USERNAME` | Optional admin username used with `VITE_ADMIN_PASSWORD` to build an HTTP Basic `Authorization` header | unset |
+| `VITE_ADMIN_PASSWORD` | Optional admin password used with `VITE_ADMIN_USERNAME` to build an HTTP Basic `Authorization` header | unset |
+| `VITE_API_KEY` | Optional runtime/simulation API key sent as `X-API-Key` | unset |
 
 Example `.env` file:
 
 ```bash
 VITE_API_BASE_URL=http://localhost:8080/api/v1
 VITE_API_TIMEOUT_MS=15000
+VITE_ADMIN_USERNAME=admin
+VITE_ADMIN_PASSWORD=local-admin-password
+VITE_API_KEY=local-api-key
 ```
 
-If `VITE_API_BASE_URL` is left unset, the app will continue to use `/api/v1`, which works with the Vite proxy in local development.
+If `VITE_API_BASE_URL` is left unset, the app will continue to use `/api/v1`, which works with the Vite proxy in local development. The backend ignores whichever auth header does not apply to a specific endpoint, so sending both the Basic auth and API-key headers from the shared Axios client is safe.
 
 ### Playwright E2E Environment Variables
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.21",
+  "version": "0.49.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.21",
+      "version": "0.49.22",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.21",
+  "version": "0.49.22",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/api/__tests__/client.test.js
+++ b/frontend/src/api/__tests__/client.test.js
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const axiosMock = vi.hoisted(() => ({
+  create: vi.fn(),
+  client: {
+    interceptors: {
+      response: {
+        use: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    create: axiosMock.create,
+  },
+}));
+
+const importClient = async () => {
+  await import('../client');
+  return axiosMock.create.mock.calls.at(-1)?.[0];
+};
+
+describe('api client', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    axiosMock.create.mockReset();
+    axiosMock.client.interceptors.response.use.mockReset();
+    axiosMock.create.mockReturnValue(axiosMock.client);
+  });
+
+  it('creates axios client with JSON defaults when auth env vars are absent', async () => {
+    const config = await importClient();
+
+    expect(config).toEqual({
+      baseURL: '/api/v1',
+      timeout: 10000,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(config.headers).not.toHaveProperty('Authorization');
+    expect(config.headers).not.toHaveProperty('X-API-Key');
+  });
+
+  it('adds Basic auth and API key headers from Vite env vars', async () => {
+    vi.stubEnv('VITE_ADMIN_USERNAME', 'admin');
+    vi.stubEnv('VITE_ADMIN_PASSWORD', 'local-admin-password');
+    vi.stubEnv('VITE_API_KEY', 'local-api-key');
+
+    const config = await importClient();
+
+    expect(config.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${btoa('admin:local-admin-password')}`,
+      'X-API-Key': 'local-api-key',
+    });
+  });
+
+  it('omits Basic auth unless both username and password are present', async () => {
+    vi.stubEnv('VITE_ADMIN_USERNAME', 'admin');
+    vi.stubEnv('VITE_API_KEY', 'local-api-key');
+
+    const config = await importClient();
+
+    expect(config.headers).not.toHaveProperty('Authorization');
+    expect(config.headers).toHaveProperty('X-API-Key', 'local-api-key');
+  });
+});

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -4,13 +4,25 @@ const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/
 const timeoutFromEnv = Number(import.meta.env.VITE_API_TIMEOUT_MS);
 const requestTimeoutMs =
   Number.isFinite(timeoutFromEnv) && timeoutFromEnv > 0 ? timeoutFromEnv : 10000;
+const adminUsername = (import.meta.env.VITE_ADMIN_USERNAME || '').trim();
+const adminPassword = import.meta.env.VITE_ADMIN_PASSWORD || '';
+const apiKey = (import.meta.env.VITE_API_KEY || '').trim();
+const defaultHeaders = {
+  'Content-Type': 'application/json',
+};
+
+if (adminUsername && adminPassword) {
+  defaultHeaders.Authorization = `Basic ${btoa(`${adminUsername}:${adminPassword}`)}`;
+}
+
+if (apiKey) {
+  defaultHeaders['X-API-Key'] = apiKey;
+}
 
 const apiClient = axios.create({
   baseURL: apiBaseUrl,
   timeout: requestTimeoutMs,
-  headers: {
-    'Content-Type': 'application/json',
-  },
+  headers: defaultHeaders,
 });
 
 apiClient.interceptors.response.use(

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.21</version>
+    <version>0.49.22</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation

- Fix the frontend bug where the shared Axios client did not include HTTP Basic or API-key headers for authenticated admin/runtime endpoints so local dev, E2E and CI flows can exercise secured backend APIs.
- Ensure documentation and package metadata reflect the change and keep versioning in sync for a small patch release.

### Description

- Read Vite-provided environment variables `VITE_ADMIN_USERNAME`, `VITE_ADMIN_PASSWORD`, and `VITE_API_KEY` in `frontend/src/api/client.js` and add default `Authorization: Basic ...` and `X-API-Key` headers when present. 
- Add unit tests `frontend/src/api/__tests__/client.test.js` (Vitest) that validate default JSON-only behavior, Basic+API-key header injection, and partial-credential behavior. 
- Document local frontend credential setup and the fact that the UI may send both auth schemes in `README.md`, `frontend/README.md`, `docs/DEVELOPER-GUIDE.md`, and `docs/Workflows-and-Troubleshooting.md`, and update examples to the new patch version. 
- Bump the project patch version to `0.49.22` (pom, frontend/package.json, package-lock) and add a `CHANGELOG.md` entry describing the fix.

### Testing

- Ran unit tests: `npm run test:unit -- client.test.js` (Vitest) which passed (3 tests), and then full frontend unit suite `npm run test:unit` which passed (7 files, 57 tests). 
- Ran frontend lint and production build: `npm run lint && npm run build`; lint completed with warnings only and build succeeded. 
- Attempted Maven validation `mvn -q -DskipTests validate` to verify backend sync, but it failed in this environment due to network access resolving Spring Boot parent POM (Maven Central returned HTTP 403); this is an environment/network issue and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c3528a7a88325bac306a0362b992c)