### PR TITLE
fix: prevent orphaned running simulation runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.23] - 2026-06-13
+
+### Fixed
+- **Simulation run failure recovery**: Hardened async run failure handling so lifecycle transition races fall back to a direct guarded database update for RUNNING runs instead of leaving them stuck indefinitely at 0.0% progress. Runs now also persist an initial 0-tick progress update immediately after starting execution, and README/JAR metadata was synchronized for the 0.49.23 patch release.
+
 ## [0.49.22] - 2026-06-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.22**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.23**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -111,12 +111,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.22.jar
+java -jar target/lift-simulator-0.49.23.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.22.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.23.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -128,21 +128,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.22.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -207,7 +207,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.22.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.23.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.22.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.23.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.22.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.22.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.22.jar \
+   java -cp target/lift-simulator-0.49.23.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.22.jar \
+java -cp target/lift-simulator-0.49.23.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.22",
+  "version": "0.49.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.22",
+      "version": "0.49.23",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.22",
+  "version": "0.49.23",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.22</version>
+    <version>0.49.23</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -220,4 +221,24 @@ public interface SimulationRunRepository extends JpaRepository<SimulationRun, Lo
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE SimulationRun r SET r.currentTick = :currentTick WHERE r.id = :id")
     int updateCurrentTick(@Param("id") Long id, @Param("currentTick") Long currentTick);
+
+    /**
+     * Mark a currently running simulation run as failed without loading the entity.
+     * This best-effort update is used by asynchronous failure handling to avoid
+     * leaving runs orphaned in RUNNING if an entity state-machine transition races
+     * with another lifecycle update.
+     *
+     * @param id the run id
+     * @param errorMessage the failure message
+     * @param endedAt completion timestamp
+     * @return number of rows updated
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE SimulationRun r SET r.status = 'FAILED', r.errorMessage = :errorMessage, "
+            + "r.endedAt = :endedAt WHERE r.id = :id AND r.status = 'RUNNING'")
+    int markRunningRunFailed(
+            @Param("id") Long id,
+            @Param("errorMessage") String errorMessage,
+            @Param("endedAt") OffsetDateTime endedAt);
 }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -192,6 +192,7 @@ public class SimulationRunExecutionService {
                 startRun(request.runId());
             }
             started = true;
+            updateProgress(request.runId(), 0L);
             log(logWriter, "Simulation started for run " + request.runId());
 
             RunMetrics metrics = runSimulation(request.runId(), config, scenario, logWriter, cancelToken);
@@ -394,8 +395,34 @@ public class SimulationRunExecutionService {
                 startRun(runId);
             }
             failRun(runId, message);
+        } catch (IllegalStateException ex) {
+            markRunningRunFailedSafely(runId, message, ex);
         } catch (Exception ex) {
             logger.error("Failed to mark run {} as failed", runId, ex);
+        }
+    }
+
+    private void markRunningRunFailedSafely(Long runId, String message, IllegalStateException transitionFailure) {
+        int updated = runRepository.markRunningRunFailed(runId, message, OffsetDateTime.now());
+        if (updated > 0) {
+            logger.warn(
+                    "Recovered run {} by marking RUNNING run as FAILED after lifecycle transition failure",
+                    runId,
+                    transitionFailure
+            );
+            return;
+        }
+
+        try {
+            SimulationRun run = getRunById(runId);
+            logger.warn(
+                    "Run {} was not marked FAILED because its current status is {}; preserving existing lifecycle state",
+                    runId,
+                    run.getStatus(),
+                    transitionFailure
+            );
+        } catch (Exception lookupFailure) {
+            logger.error("Failed to inspect run {} after failure transition error", runId, lookupFailure);
         }
     }
 

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -7,9 +7,11 @@ import com.liftsimulator.admin.dto.CreateSimulationRunRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import com.liftsimulator.admin.entity.Scenario;
 import com.liftsimulator.admin.entity.SimulationRun;
 import com.liftsimulator.admin.repository.LiftSystemRepository;
 import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.repository.ScenarioRepository;
 import com.liftsimulator.admin.repository.SimulationRunRepository;
 import com.liftsimulator.admin.service.SimulationRunService;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,6 +71,9 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
     private SimulationRunRepository runRepository;
 
     @Autowired
+    private ScenarioRepository scenarioRepository;
+
+    @Autowired
     private SimulationRunService runService;
 
     private LiftSystem testSystem;
@@ -77,6 +82,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
     @BeforeEach
     public void setUp() {
         runRepository.deleteAll();
+        scenarioRepository.deleteAll();
         versionRepository.deleteAll();
         liftSystemRepository.deleteAll();
 
@@ -94,10 +100,17 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
 
     @Test
     public void testRunLifecycle_StartPollResults() throws Exception {
+        Scenario scenario = scenarioRepository.save(new Scenario(
+                "Lifecycle scenario",
+                "{\"durationTicks\": 20, \"seed\": 4242, \"passengerFlows\": "
+                        + "[{\"startTick\": 0, \"originFloor\": 0, \"destinationFloor\": 3, \"passengers\": 1}]}",
+                testVersion
+        ));
+
         CreateSimulationRunRequest request = new CreateSimulationRunRequest(
                 testSystem.getId(),
                 testVersion.getId(),
-                null,
+                scenario.getId(),
                 4242L
         );
 

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -193,6 +193,24 @@ public class SimulationRunExecutionServiceTest {
         assertInternalStateCleared(3L);
     }
 
+
+    @Test
+    public void failRunWithMessageUsesDirectFailedUpdateWhenLifecycleTransitionRaces() throws Exception {
+        SimulationRun run = new SimulationRun();
+        run.setId(9L);
+        run.setStatus(SimulationRun.RunStatus.RUNNING);
+        when(runRepository.findById(9L)).thenReturn(Optional.of(run));
+        when(runRepository.save(any(SimulationRun.class))).thenThrow(new IllegalStateException("stale state"));
+        when(runRepository.markRunningRunFailed(anyLong(), any(String.class), any())).thenReturn(1);
+
+        Method failRunWithMessage = SimulationRunExecutionService.class.getDeclaredMethod(
+                "failRunWithMessage", Long.class, String.class, boolean.class);
+        failRunWithMessage.setAccessible(true);
+        failRunWithMessage.invoke(executionService, 9L, "boom", true);
+
+        verify(runRepository).markRunningRunFailed(anyLong(), any(String.class), any());
+    }
+
     private AtomicReference<SimulationRun> prepareRepository(SimulationRun run) {
         AtomicReference<SimulationRun> storedRun = new AtomicReference<>(run);
         when(runRepository.findById(run.getId())).thenAnswer(invocation -> Optional.of(storedRun.get()));


### PR DESCRIPTION
### Motivation
- Simulation runs could become stuck in `RUNNING` at 0.0% when an async failure or lifecycle transition raced with entity state changes, leaving runs orphaned indefinitely.
- The execution path also lacked a persisted initial progress value when execution actually started, making UI progress ambiguous for very short or early-failing runs.
- Provide a robust fallback that marks a `RUNNING` run as `FAILED` using a guarded DB update when entity lifecycle transitions cannot be applied due to stale state.

### Description
- Add a new repository method `markRunningRunFailed(Long id, String errorMessage, OffsetDateTime endedAt)` to perform a targeted UPDATE that flips `RUNNING`→`FAILED` only when the row is still `RUNNING`.
- Harden `SimulationRunExecutionService.failRunWithMessage(...)` to catch `IllegalStateException` transition failures and call `markRunningRunFailedSafely(...)`, which uses the new repository update and preserves terminal states when appropriate.
- Persist an initial `0L` progress update via `updateProgress(runId, 0L)` immediately after the run is started so runs have a recorded starting tick before entering the tick loop.
- Add a regression test `failRunWithMessageUsesDirectFailedUpdateWhenLifecycleTransitionRaces()` to assert the fallback DB update is used when `save(...)` throws a lifecycle/stale-state `IllegalStateException`.
- Bump project and frontend metadata to `0.49.23`, update `CHANGELOG.md`, `README.md` and related docs to document the fix and synchronize JAR/README references.

### Testing
- Ran `git diff --check` to validate whitespace/line-end issues and the working tree; this passed with no blocking problems.
- Attempted `mvn -q -Dtest=SimulationRunExecutionServiceTest test` but it failed due to external dependency resolution (`org.springframework.boot` parent POM returned HTTP 403 from Maven Central). 
- Attempted offline `mvn -o -q -Dtest=SimulationRunExecutionServiceTest test` but that also failed because the required parent POM is not present in the local Maven cache.
- The new unit test was added and validated locally in the code, but automated execution was blocked by the environment/dependency resolution issues described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d178e616c8325b224b94052164a1d)