### PR TITLE
fix(simulation): defer run execution until after commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.24] - 2026-06-13
+
+### Fixed
+- **Simulation run async submission race**: Deferred simulation execution submission until after the create-and-start transaction commits, ensuring the async worker can see the persisted run before configuring artefacts or advancing ticks. Updated service coverage and synchronized README/JAR metadata for the 0.49.24 patch release.
+
 ## [0.49.23] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.23**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.24**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -111,12 +111,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.23.jar
+java -jar target/lift-simulator-0.49.24.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.23.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.24.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -128,21 +128,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.23.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -207,7 +207,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.23.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.24.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.23.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.24.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.23.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.23.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.23.jar \
+   java -cp target/lift-simulator-0.49.24.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.23.jar \
+java -cp target/lift-simulator-0.49.24.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.23",
+  "version": "0.49.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.23",
+      "version": "0.49.24",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.23",
+  "version": "0.49.24",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.23</version>
+    <version>0.49.24</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -15,6 +15,8 @@ import jakarta.persistence.PersistenceContext;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -149,10 +151,25 @@ public class SimulationRunService {
         run.start();
         run = runRepository.save(run);
 
-        // Submit the run for execution
-        // The execution service will handle the actual simulation
-        executionService.submitRunForExecution(run.getId());
+        // Submit the run for execution only after the surrounding transaction commits.
+        // Otherwise, the async executor can start immediately and attempt to read the
+        // run before the newly-created row is visible outside this transaction.
+        submitRunForExecutionAfterCommit(run.getId());
         return run;
+    }
+
+    private void submitRunForExecutionAfterCommit(Long runId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            executionService.submitRunForExecution(runId);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                executionService.submitRunForExecution(runId);
+            }
+        });
     }
 
     /**

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -227,6 +229,36 @@ public class SimulationRunServiceTest {
         assertNotNull(result.getArtefactBasePath());
         assertTrue(Files.isDirectory(Path.of(result.getArtefactBasePath())));
         verify(executionService).submitRunForExecution(42L);
+    }
+
+    @Test
+    public void testCreateAndStartRun_SubmitsExecutionAfterTransactionCommit() throws Exception {
+        when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
+            SimulationRun savedRun = invocation.getArgument(0);
+            if (savedRun.getId() == null) {
+                savedRun.setId(42L);
+            }
+            return savedRun;
+        });
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            SimulationRun result = runService.createAndStartRun(1L, 1L, null, 12345L);
+
+            assertEquals(42L, result.getId());
+            verify(executionService, never()).submitRunForExecution(42L);
+
+            List<TransactionSynchronization> synchronizations =
+                    TransactionSynchronizationManager.getSynchronizations();
+            assertEquals(1, synchronizations.size());
+
+            synchronizations.get(0).afterCommit();
+            verify(executionService).submitRunForExecution(42L);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- A race occurred where the async execution worker could start reading a newly-created simulation run before the creating transaction committed, leaving progress stuck at 0.0% or otherwise observing partial state.
- The change defers async submission until the create-and-start transaction commits so the executor always sees the persisted run and configured artefacts.

### Description
- Added `submitRunForExecutionAfterCommit(Long)` to `SimulationRunService` which uses `TransactionSynchronizationManager` to register an `afterCommit` callback that calls `executionService.submitRunForExecution(runId)`.
- The submission logic preserves immediate submission when no transaction synchronization is active by falling back to direct `executionService.submitRunForExecution(runId)`.
- Added a unit test `testCreateAndStartRun_SubmitsExecutionAfterTransactionCommit` in `SimulationRunServiceTest` to verify registration and `afterCommit` behaviour.
- Bumped project version to `0.49.24` and synchronized references in `pom.xml`, `README.md`, `CHANGELOG.md`, `docs/*`, and `frontend` package files; added a `0.49.24` changelog entry describing the fix.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted to run the focused unit tests with `mvn -Dtest=SimulationRunServiceTest test`, but execution was blocked by dependency resolution (Maven Central returned HTTP 403 for the Spring Boot parent POM), so the test suite could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6901668083258752a386539e677f)