### PR TITLE
Update API base URL to /api/v1 and fix whitespace

### DIFF
--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -7,7 +7,7 @@ import { handleApiError } from '../utils/errorHandlers';
 import './SimulationRunDetail.css';
 
 const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
-const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api').trim() || '/api';
+const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/api/v1';
 const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, '');
 
 const kpiLabels = {


### PR DESCRIPTION
## Summary
This PR updates the default API base URL from `/api` to `/api/v1` and fixes inconsistent whitespace formatting throughout the SimulationRunDetail component.

## Key Changes
- **API URL Update**: Changed the default `apiBaseUrl` from `/api` to `/api/v1` to align with the versioned API endpoint structure
- **Code Formatting**: Fixed whitespace inconsistencies throughout the file (primarily converting tabs to spaces for consistent indentation)

## Implementation Details
The main functional change is on line 11 where the API base URL default is updated:
```javascript
// Before
const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api').trim() || '/api';

// After
const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/api/v1';
```

This ensures that all API calls made through `artefactDownloadUrl()` and other API endpoints will use the `/api/v1` path when no explicit `VITE_API_BASE_URL` environment variable is provided.

The remaining changes are purely cosmetic whitespace fixes with no functional impact.

https://claude.ai/code/session_01XK2Zeja94ysHcEths4eage