### PR TITLE
fix(artefacts): send auth headers on fetch downloads and generate inp…

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -7,17 +7,20 @@ const requestTimeoutMs =
 const adminUsername = (import.meta.env.VITE_ADMIN_USERNAME || '').trim();
 const adminPassword = import.meta.env.VITE_ADMIN_PASSWORD || '';
 const apiKey = (import.meta.env.VITE_API_KEY || '').trim();
-const defaultHeaders = {
-  'Content-Type': 'application/json',
-};
+export const authHeaders = {};
 
 if (adminUsername && adminPassword) {
-  defaultHeaders.Authorization = `Basic ${btoa(`${adminUsername}:${adminPassword}`)}`;
+  authHeaders.Authorization = `Basic ${btoa(`${adminUsername}:${adminPassword}`)}`;
 }
 
 if (apiKey) {
-  defaultHeaders['X-API-Key'] = apiKey;
+  authHeaders['X-API-Key'] = apiKey;
 }
+
+const defaultHeaders = {
+  'Content-Type': 'application/json',
+  ...authHeaders,
+};
 
 const apiClient = axios.create({
   baseURL: apiBaseUrl,

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -1,6 +1,7 @@
 // @ts-check
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import { authHeaders } from '../api/client';
 import { simulationRunsApi } from '../api/simulationRunsApi';
 import ConfirmModal from '../components/ConfirmModal';
 import { handleApiError } from '../utils/errorHandlers';
@@ -159,7 +160,7 @@ function SimulationRunDetail() {
 
       try {
         setResultsError(null);
-        const response = await fetch(artefactDownloadUrl(artefact.path));
+        const response = await fetch(artefactDownloadUrl(artefact.path), { headers: authHeaders });
         if (!response.ok) {
           let errorMessage = `Unable to download ${artefact.name || 'artefact'}.`;
           const contentType = response.headers.get('content-type') || '';

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
 import { scenariosApi } from '../api/scenariosApi';
+import { authHeaders } from '../api/client';
 import { simulationRunsApi } from '../api/simulationRunsApi';
 import ConfirmModal from '../components/ConfirmModal';
 import { handleApiError } from '../utils/errorHandlers';
@@ -339,7 +340,7 @@ function Simulator() {
 
       try {
         setResultsError(null);
-        const response = await fetch(artefactDownloadUrl(artefact.path));
+        const response = await fetch(artefactDownloadUrl(artefact.path), { headers: authHeaders });
         if (!response.ok) {
           let errorMessage = `Unable to download ${artefact.name || 'artefact'}.`;
           const contentType = response.headers.get('content-type') || '';

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -52,12 +52,14 @@ public class SimulationRunExecutionService {
     private static final int PROGRESS_UPDATE_INTERVAL = 5;
     private static final String CONFIG_FILE_NAME = "config.json";
     private static final String SCENARIO_FILE_NAME = "scenario.json";
+    private static final String INPUT_SCENARIO_FILE_NAME = "input.scenario";
     private static final String LOG_FILE_NAME = "run.log";
     private static final String RESULTS_FILE_NAME = "results.json";
 
     private final SimulationRunRepository runRepository;
     private final ConfigValidationService configValidationService;
     private final ScenarioValidationService scenarioValidationService;
+    private final BatchInputGenerator batchInputGenerator;
     private final ObjectMapper objectMapper;
     private final ExecutorService executor;
     private final Map<Long, Future<?>> runningTasks = new ConcurrentHashMap<>();
@@ -71,10 +73,12 @@ public class SimulationRunExecutionService {
             SimulationRunRepository runRepository,
             ConfigValidationService configValidationService,
             ScenarioValidationService scenarioValidationService,
+            BatchInputGenerator batchInputGenerator,
             ObjectMapper objectMapper) {
         this.runRepository = runRepository;
         this.configValidationService = configValidationService;
         this.scenarioValidationService = scenarioValidationService;
+        this.batchInputGenerator = batchInputGenerator;
         this.objectMapper = objectMapper;
         this.executor = Executors.newCachedThreadPool(new SimulationRunnerThreadFactory());
     }
@@ -90,8 +94,9 @@ public class SimulationRunExecutionService {
         SimulationRun run = getRunById(runId);
         String configJson = run.getVersion().getConfig();
         String scenarioJson = run.getScenario() != null ? run.getScenario().getScenarioJson() : null;
+        String scenarioName = run.getScenario() != null ? run.getScenario().getName() : null;
 
-        RunExecutionRequest request = new RunExecutionRequest(run.getId(), configJson, scenarioJson);
+        RunExecutionRequest request = new RunExecutionRequest(run.getId(), configJson, scenarioJson, scenarioName);
         submitExecution(request);
     }
 
@@ -372,6 +377,13 @@ public class SimulationRunExecutionService {
         if (request.scenarioJson() != null) {
             Files.writeString(runDir.resolve(SCENARIO_FILE_NAME), request.scenarioJson(), StandardCharsets.UTF_8);
             log(logWriter, "Wrote scenario input to " + SCENARIO_FILE_NAME);
+
+            ScenarioDefinitionDTO scenarioDefinition = objectMapper.readValue(
+                    request.scenarioJson(), ScenarioDefinitionDTO.class);
+            String name = request.scenarioName() != null ? request.scenarioName() : "run";
+            batchInputGenerator.generateBatchInputFile(
+                    request.configJson(), scenarioDefinition, name, runDir.resolve(INPUT_SCENARIO_FILE_NAME));
+            log(logWriter, "Wrote batch input to " + INPUT_SCENARIO_FILE_NAME);
         }
     }
 
@@ -509,7 +521,7 @@ public class SimulationRunExecutionService {
         executor.shutdown();
     }
 
-    private record RunExecutionRequest(Long runId, String configJson, String scenarioJson) {
+    private record RunExecutionRequest(Long runId, String configJson, String scenarioJson, String scenarioName) {
     }
 
     private void submitExecution(RunExecutionRequest request) {

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -85,6 +85,9 @@ public class SimulationRunExecutionServiceTest {
     @Mock
     private ScenarioValidationService scenarioValidationService;
 
+    @Mock
+    private BatchInputGenerator batchInputGenerator;
+
     @TempDir
     private Path tempDir;
 
@@ -97,6 +100,7 @@ public class SimulationRunExecutionServiceTest {
                 runRepository,
                 configValidationService,
                 scenarioValidationService,
+                batchInputGenerator,
                 objectMapper
         );
     }


### PR DESCRIPTION
…ut.scenario

Two bugs found during v0.47.0 UAT:

1. Artefact fetch() calls in Simulator.jsx and SimulationRunDetail.jsx omitted authentication headers, causing the backend to reject downloads with 401 Authentication Required. Fix: export authHeaders from client.js and pass them to all fetch() calls.

2. input.scenario was never written to the run artefact directory because BatchInputGenerator was never invoked during execution. Fix: inject BatchInputGenerator into SimulationRunExecutionService and call it in writeInputFiles() alongside the existing config.json / scenario.json writes. The scenario name is threaded through RunExecutionRequest.