### PR TITLE
fix: remove redundant log links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.49.25] - 2026-06-14
 
 ### Fixed
-- **Simulation results log navigation**: Removed the redundant `View logs` links from simulator result banners and run details, keeping log review within the existing results UI and avoiding unauthenticated direct log requests. Updated README and package metadata for the 0.49.25 patch release.
+- **Simulation results log navigation**: Removed the redundant `View logs` links from simulator result banners and run details, keeping log review within the existing results UI and avoiding unauthenticated direct log requests. Stabilized artefact download URL callbacks to clear React hook lint warnings, and updated README and package metadata for the 0.49.25 patch release.
 
 ## [0.49.24] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.49.25] - 2026-06-14
+
+### Fixed
+- **Simulation results log navigation**: Removed the redundant `View logs` links from simulator result banners and run details, keeping log review within the existing results UI and avoiding unauthenticated direct log requests. Updated README and package metadata for the 0.49.25 patch release.
+
 ## [0.49.24] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.24**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.49.25**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -111,12 +111,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.24.jar
+java -jar target/lift-simulator-0.49.25.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.24.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.49.25.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -128,21 +128,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.24.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -207,7 +207,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.24.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.25.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.24.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.49.25.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.24.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.24.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.24.jar \
+   java -cp target/lift-simulator-0.49.25.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.24.jar \
+java -cp target/lift-simulator-0.49.25.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.49.24",
+  "version": "0.49.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.49.24",
+      "version": "0.49.25",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.24",
+  "version": "0.49.25",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -374,11 +374,6 @@ function SimulationRunDetail() {
             <div className="result-banner error">
               <strong>Simulation failed.</strong>
               <p>{results?.errorMessage || runInfo.errorMessage || 'Unknown error.'}</p>
-              {results?.logsUrl && (
-                <a className="link" href={results.logsUrl}>
-                  View logs
-                </a>
-              )}
             </div>
           )}
 

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -136,19 +136,15 @@ function SimulationRunDetail() {
     return Math.min(100, (runInfo.currentTick / runInfo.totalTicks) * 100);
   }, [runInfo]);
 
-  const encodeArtefactPath = (path) => {
-    if (!path) return '';
+  const artefactDownloadUrl = useCallback((path) => {
+    if (!runInfo?.id || !path) return '#';
     const normalizedPath = path.replace(/\\/g, '/');
-    return normalizedPath
+    const encodedPath = normalizedPath
       .split('/')
       .map((segment) => encodeURIComponent(segment))
       .join('/');
-  };
-
-  const artefactDownloadUrl = (path) => {
-    if (!runInfo?.id || !path) return '#';
-    return `${normalizedApiBaseUrl}/simulation-runs/${runInfo.id}/artefacts/${encodeArtefactPath(path)}`;
-  };
+    return `${normalizedApiBaseUrl}/simulation-runs/${runInfo.id}/artefacts/${encodedPath}`;
+  }, [runInfo?.id]);
 
   const handleArtefactDownload = useCallback(
     async (event, artefact) => {

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -651,11 +651,6 @@ function Simulator() {
             <div className="result-banner error">
               <strong>Simulation failed.</strong>
               <p>{results?.errorMessage || runInfo.errorMessage || 'Unknown error.'}</p>
-              {results?.logsUrl && (
-                <a className="link" href={results.logsUrl}>
-                  View logs
-                </a>
-              )}
             </div>
           )}
 
@@ -670,11 +665,6 @@ function Simulator() {
               <div className="result-banner success">
                 <strong>Simulation completed successfully.</strong>
                 {results.errorMessage && <p>{results.errorMessage}</p>}
-                {results.logsUrl && (
-                  <a className="link" href={results.logsUrl}>
-                    View logs
-                  </a>
-                )}
               </div>
 
               <div className="kpi-grid">
@@ -789,11 +779,6 @@ function Simulator() {
             <div className="result-banner warning">
               <strong>Simulation completed, but results were unavailable.</strong>
               <p>{results?.errorMessage || 'Results file could not be read.'}</p>
-              {results?.logsUrl && (
-                <a className="link" href={results.logsUrl}>
-                  View logs
-                </a>
-              )}
             </div>
           )}
 

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -312,23 +312,17 @@ function Simulator() {
     return Math.min(100, (runInfo.currentTick / runInfo.totalTicks) * 100);
   }, [runInfo?.currentTick, runInfo?.totalTicks]);
 
-  const encodeArtefactPath = (path) => {
-    if (!path) {
-      return '';
-    }
-    const normalizedPath = path.replace(/\\/g, '/');
-    return normalizedPath
-      .split('/')
-      .map((segment) => encodeURIComponent(segment))
-      .join('/');
-  };
-
-  const artefactDownloadUrl = (path) => {
+  const artefactDownloadUrl = useCallback((path) => {
     if (!runInfo?.id || !path) {
       return '#';
     }
-    return `${normalizedApiBaseUrl}/simulation-runs/${runInfo.id}/artefacts/${encodeArtefactPath(path)}`;
-  };
+    const normalizedPath = path.replace(/\\/g, '/');
+    const encodedPath = normalizedPath
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+    return `${normalizedApiBaseUrl}/simulation-runs/${runInfo.id}/artefacts/${encodedPath}`;
+  }, [runInfo?.id]);
 
   const handleArtefactDownload = useCallback(
     async (event, artefact) => {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.24</version>
+    <version>0.49.25</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Users were seeing a duplicate "View logs" link that attempted an unauthenticated direct log request (resulting in 401) and also duplicated log content already present in the UI, so the link should be removed.

### Description
- Removed the inline `View logs` anchor from the simulator results banners in `frontend/src/pages/Simulator.jsx` and from the run detail failure banner in `frontend/src/pages/SimulationRunDetail.jsx` so logs are reviewed only via the existing results UI.
- Bumped the project version to `0.49.25` in `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json`, and updated README and docs JAR/CLI references to match.
- Added a `0.49.25` entry to `CHANGELOG.md` describing the UI fix and synchronized package/lockfile metadata.

### Testing
- Ran `npm run lint` in `frontend` which completed successfully (ESLint warnings for React hook deps remain but did not fail the run).
- Ran `npm run test:unit` (Vitest) which passed: 7 test files and 57 tests succeeded.
- Attempted `npm run test:unit -- --runInBand` which failed because Vitest does not recognize the Jest `--runInBand` option (this was an invocation error, not a test regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4dfcb8f083258dc3c32e34494dc7)