### PR TITLE
Remove Continue button from SimulatorLanding page

### DIFF
--- a/frontend/src/pages/SimulatorLanding.jsx
+++ b/frontend/src/pages/SimulatorLanding.jsx
@@ -96,15 +96,6 @@ function SimulatorLanding() {
             Choose a lift system and a published version to start a simulation run.
           </p>
         </div>
-        <div className="page-actions">
-          <button
-            className="btn-primary"
-            onClick={handleProceed}
-            disabled={!selectedSystemId || !selectedVersionId}
-          >
-            Continue to Simulation Setup
-          </button>
-        </div>
       </div>
 
       {loading ? (


### PR DESCRIPTION
## Summary
Removed the "Continue to Simulation Setup" button and its associated container from the SimulatorLanding page.

## Changes
- Removed the `page-actions` div containing the primary action button
- The button that triggered `handleProceed` with validation for `selectedSystemId` and `selectedVersionId` has been deleted

## Notes
This change removes the primary call-to-action from the landing page. Users will need an alternative method to proceed to the simulation setup (e.g., through a different UI element or navigation pattern).

https://claude.ai/code/session_013wJdps7AP795eFZqxiMcWq