### PR TITLE
Add ability to delete completed simulation runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-06-14
+
+### Added
+- **Delete completed simulation runs**: Added the ability to delete completed simulation runs along with their run history and stored artefacts. A new `DELETE /api/v1/simulation-runs/{id}` endpoint removes the run record and recursively deletes its artefact directory (generated input, logs, and result files); only terminal runs (`SUCCEEDED`, `FAILED`, `CANCELLED`) can be deleted, while in-progress runs return `409 Conflict` and unknown runs return `404 Not Found`. Artefacts are removed before the database record so a file-system failure aborts cleanly without leaving an inconsistent state, surfacing a clear `500` error. The Simulation Runs list and run detail screens now expose a guarded **Delete** action with a confirmation dialog warning that history and artefacts will be removed, plus success/failure feedback. Expanded service, artefact, controller, and frontend test coverage, and synchronized README/JAR/package metadata for the 0.50.0 release.
+
 ## [0.49.25] - 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.49.25**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.50.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -111,12 +111,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.49.25.jar
+java -jar target/lift-simulator-0.50.0.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.49.25.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.50.0.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -128,21 +128,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.50.0.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.50.0.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.50.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.49.25.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.50.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -207,7 +207,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.49.25.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.50.0.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.49.25.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.50.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -101,7 +101,7 @@ idle_timeout_ticks: 5
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -114,7 +114,7 @@ java -cp target/lift-simulator-0.49.25.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -125,7 +125,7 @@ java -cp target/lift-simulator-0.49.25.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -401,7 +401,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.49.25.jar \
+   java -cp target/lift-simulator-0.50.0.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -446,7 +446,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -538,7 +538,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.49.25.jar \
+java -cp target/lift-simulator-0.50.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.49.25",
+  "version": "0.50.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/api/simulationRunsApi.js
+++ b/frontend/src/api/simulationRunsApi.js
@@ -25,4 +25,11 @@ export const simulationRunsApi = {
   getResults: (id) => apiClient.get(`/simulation-runs/${id}/results`),
   getArtefacts: (id) => apiClient.get(`/simulation-runs/${id}/artefacts`),
   cancelRun: (id) => apiClient.post(`/simulation-runs/${id}/cancel`),
+  /**
+   * Deletes a completed simulation run, removing its run history and stored artefacts.
+   * Only runs in a terminal state (SUCCEEDED, FAILED, CANCELLED) can be deleted.
+   * @param {number|string} id - Simulation run ID
+   * @returns {Promise} API response resolving on 204 No Content
+   */
+  deleteRun: (id) => apiClient.delete(`/simulation-runs/${id}`),
 };

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -1,10 +1,11 @@
 // @ts-check
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { authHeaders } from '../api/client';
 import { simulationRunsApi } from '../api/simulationRunsApi';
+import AlertModal from '../components/AlertModal';
 import ConfirmModal from '../components/ConfirmModal';
-import { handleApiError } from '../utils/errorHandlers';
+import { getApiErrorMessage, handleApiError } from '../utils/errorHandlers';
 import './SimulationRunDetail.css';
 
 const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
@@ -31,6 +32,7 @@ const kpiLabels = {
  */
 function SimulationRunDetail() {
   const { id } = useParams();
+  const navigate = useNavigate();
   const [runInfo, setRunInfo] = useState(null);
   const [results, setResults] = useState(null);
   const [artefacts, setArtefacts] = useState([]);
@@ -40,6 +42,9 @@ function SimulationRunDetail() {
   const [now, setNow] = useState(() => Date.now());
   const [isCancelling, setIsCancelling] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
 
   const runStatus = runInfo?.status;
   const isTerminal = runStatus ? terminalStatuses.has(runStatus) : false;
@@ -70,6 +75,27 @@ function SimulationRunDetail() {
       setIsCancelling(false);
     }
   }, [runInfo?.id]);
+
+  const handleDeleteRun = useCallback(async () => {
+    if (!runInfo?.id) {
+      return;
+    }
+    const runId = runInfo.id;
+    try {
+      setIsDeleting(true);
+      setDeleteError(null);
+      await simulationRunsApi.deleteRun(runId);
+      navigate('/simulation-runs', {
+        replace: true,
+        state: { notice: `Run #${runId} and its artefacts were deleted.` },
+      });
+    } catch (err) {
+      setDeleteError(getApiErrorMessage(err, `Failed to delete run #${runId}`));
+      console.error(err);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [runInfo?.id, navigate]);
 
   useEffect(() => {
     const loadInitial = async () => {
@@ -299,6 +325,19 @@ function SimulationRunDetail() {
                 disabled={isCancelling}
               >
                 {isCancelling ? 'Cancelling...' : 'Cancel Run'}
+              </button>
+            )}
+            {isTerminal && (
+              <button
+                className="btn-danger"
+                type="button"
+                onClick={() => {
+                  setDeleteError(null);
+                  setShowDeleteModal(true);
+                }}
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting...' : 'Delete Run'}
               </button>
             )}
           </div>
@@ -569,6 +608,29 @@ function SimulationRunDetail() {
         confirmText="Cancel run"
         cancelText="Keep running"
         confirmStyle="danger"
+      />
+
+      <ConfirmModal
+        isOpen={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        onConfirm={handleDeleteRun}
+        title="Delete simulation run?"
+        message={
+          `This will permanently delete run #${runInfo.id}, including its run history `
+          + 'and all stored artefacts (generated input, logs, and result files). '
+          + 'This action cannot be undone.'
+        }
+        confirmText="Delete run"
+        cancelText="Keep run"
+        confirmStyle="danger"
+      />
+
+      <AlertModal
+        isOpen={deleteError !== null}
+        onClose={() => setDeleteError(null)}
+        title="Failed to delete run"
+        message={deleteError || ''}
+        type="error"
       />
     </div>
   );

--- a/frontend/src/pages/SimulationRuns.css
+++ b/frontend/src/pages/SimulationRuns.css
@@ -189,6 +189,37 @@
   background: #bdc3c7;
 }
 
+.simulation-runs .btn-small.btn-danger {
+  background: #e74c3c;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+.simulation-runs .btn-small.btn-danger:hover:not(:disabled) {
+  background: #c0392b;
+}
+
+.simulation-runs .btn-small.btn-danger:disabled {
+  background: #bdc3c7;
+  cursor: not-allowed;
+}
+
+.simulation-runs .run-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.simulation-runs .action-notice {
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  background: #eafaf1;
+  color: #1e8449;
+  border: 1px solid #abebc6;
+}
+
 @media (max-width: 768px) {
   .simulation-runs .page-header {
     flex-direction: column;

--- a/frontend/src/pages/SimulationRuns.jsx
+++ b/frontend/src/pages/SimulationRuns.jsx
@@ -229,7 +229,12 @@ function SimulationRuns() {
       await simulationRunsApi.deleteRun(runId);
       setActionNotice(`Run #${runId} and its artefacts were deleted.`);
       setActionError(null);
-      await loadRuns(false);
+      // When the deleted run was the only row on a non-first page, that page no
+      // longer exists after removal, so step back a page to avoid landing on an
+      // out-of-range page that renders as an empty state.
+      const emptiesCurrentPage = runs.length === 1 && currentPage > 0;
+      const targetPage = emptiesCurrentPage ? currentPage - 1 : currentPage;
+      await loadRuns(false, targetPage);
     } catch (err) {
       setActionError(getApiErrorMessage(err, `Failed to delete run #${runId}`));
       console.error(err);
@@ -237,7 +242,7 @@ function SimulationRuns() {
       setIsDeleting(false);
       setRunToDelete(null);
     }
-  }, [runToDelete, loadRuns]);
+  }, [runToDelete, loadRuns, runs.length, currentPage]);
 
   const hasFilters = selectedSystemId || (selectedStatus && selectedStatus !== 'ALL');
 

--- a/frontend/src/pages/SimulationRuns.jsx
+++ b/frontend/src/pages/SimulationRuns.jsx
@@ -1,13 +1,16 @@
 // @ts-check
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
 import { simulationRunsApi } from '../api/simulationRunsApi';
-import { handleApiError } from '../utils/errorHandlers';
+import AlertModal from '../components/AlertModal';
+import ConfirmModal from '../components/ConfirmModal';
+import { getApiErrorMessage, handleApiError } from '../utils/errorHandlers';
 import './SimulationRuns.css';
 
 const statusOptions = ['ALL', 'SUCCEEDED', 'FAILED', 'RUNNING', 'CREATED', 'CANCELLED'];
 const activeStatuses = new Set(['RUNNING', 'CREATED']);
+const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
 
 /**
  * Simulation runs history page component.
@@ -23,6 +26,8 @@ const activeStatuses = new Set(['RUNNING', 'CREATED']);
  */
 function SimulationRuns() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [runs, setRuns] = useState([]);
   const [systems, setSystems] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -30,6 +35,10 @@ function SimulationRuns() {
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
+  const [runToDelete, setRunToDelete] = useState(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [actionError, setActionError] = useState(null);
+  const [actionNotice, setActionNotice] = useState(null);
 
   const [selectedSystemId, setSelectedSystemId] = useState(
     searchParams.get('systemId') || ''
@@ -84,6 +93,15 @@ function SimulationRuns() {
   useEffect(() => {
     loadRuns(false);
   }, [loadRuns]);
+
+  // Surface a one-time notice passed via navigation state (e.g. after deleting a
+  // run from the detail page), then clear it so it does not reappear on refresh.
+  useEffect(() => {
+    if (location.state?.notice) {
+      setActionNotice(location.state.notice);
+      navigate(location.pathname + location.search, { replace: true, state: null });
+    }
+  }, [location, navigate]);
 
   // Check if any runs are active (RUNNING or CREATED) and need polling
   const hasActiveRuns = useMemo(
@@ -195,6 +213,32 @@ function SimulationRuns() {
     loadRuns(false, newPage);
   };
 
+  const handleRequestDelete = (run) => {
+    setActionError(null);
+    setActionNotice(null);
+    setRunToDelete(run);
+  };
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!runToDelete) {
+      return;
+    }
+    const runId = runToDelete.id;
+    try {
+      setIsDeleting(true);
+      await simulationRunsApi.deleteRun(runId);
+      setActionNotice(`Run #${runId} and its artefacts were deleted.`);
+      setActionError(null);
+      await loadRuns(false);
+    } catch (err) {
+      setActionError(getApiErrorMessage(err, `Failed to delete run #${runId}`));
+      console.error(err);
+    } finally {
+      setIsDeleting(false);
+      setRunToDelete(null);
+    }
+  }, [runToDelete, loadRuns]);
+
   const hasFilters = selectedSystemId || (selectedStatus && selectedStatus !== 'ALL');
 
   return (
@@ -251,6 +295,12 @@ function SimulationRuns() {
           </button>
         )}
       </div>
+
+      {actionNotice && (
+        <p className="action-notice" role="status">
+          {actionNotice}
+        </p>
+      )}
 
       {loading ? (
         <p>Loading runs...</p>
@@ -324,12 +374,24 @@ function SimulationRuns() {
                   <td>{formatDuration(run.startedAt, run.endedAt)}</td>
                   <td>{formatDate(run.createdAt)}</td>
                   <td>
-                    <Link
-                      to={`/simulation-runs/${run.id}`}
-                      className="btn-small btn-secondary"
-                    >
-                      View
-                    </Link>
+                    <div className="run-actions">
+                      <Link
+                        to={`/simulation-runs/${run.id}`}
+                        className="btn-small btn-secondary"
+                      >
+                        View
+                      </Link>
+                      {terminalStatuses.has(run.status) && (
+                        <button
+                          type="button"
+                          className="btn-small btn-danger"
+                          onClick={() => handleRequestDelete(run)}
+                          disabled={isDeleting}
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}
@@ -358,6 +420,31 @@ function SimulationRuns() {
           )}
         </div>
       )}
+
+      <ConfirmModal
+        isOpen={runToDelete !== null}
+        onClose={() => setRunToDelete(null)}
+        onConfirm={handleConfirmDelete}
+        title="Delete simulation run?"
+        message={
+          runToDelete
+            ? `This will permanently delete run #${runToDelete.id}, including its run history `
+              + 'and all stored artefacts (generated input, logs, and result files). '
+              + 'This action cannot be undone.'
+            : ''
+        }
+        confirmText="Delete run"
+        cancelText="Keep run"
+        confirmStyle="danger"
+      />
+
+      <AlertModal
+        isOpen={actionError !== null}
+        onClose={() => setActionError(null)}
+        title="Failed to delete run"
+        message={actionError || ''}
+        type="error"
+      />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/SimulationRuns.delete.test.jsx
+++ b/frontend/src/pages/__tests__/SimulationRuns.delete.test.jsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SimulationRuns from '../SimulationRuns';
+import { simulationRunsApi } from '../../api/simulationRunsApi';
+import { liftSystemsApi } from '../../api/liftSystemsApi';
+
+vi.mock('../../api/simulationRunsApi', () => ({
+  simulationRunsApi: {
+    listRuns: vi.fn(),
+    deleteRun: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/liftSystemsApi', () => ({
+  liftSystemsApi: {
+    getAllSystems: vi.fn(),
+  },
+}));
+
+const buildPage = (runs) => ({
+  data: {
+    content: runs,
+    totalElements: runs.length,
+    totalPages: 1,
+    number: 0,
+  },
+});
+
+const succeededRun = {
+  id: 7,
+  liftSystemName: 'Tower A',
+  versionNumber: 1,
+  scenarioName: 'Morning',
+  status: 'SUCCEEDED',
+  currentTick: 100,
+  totalTicks: 100,
+  startedAt: '2026-01-01T00:00:00Z',
+  endedAt: '2026-01-01T00:01:00Z',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const runningRun = { ...succeededRun, id: 8, status: 'RUNNING' };
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/simulation-runs']}>
+      <SimulationRuns />
+    </MemoryRouter>
+  );
+
+describe('SimulationRuns delete action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    liftSystemsApi.getAllSystems.mockResolvedValue({ data: [] });
+  });
+
+  it('shows a Delete action only for completed runs', async () => {
+    simulationRunsApi.listRuns.mockResolvedValue(buildPage([succeededRun, runningRun]));
+    renderPage();
+
+    await screen.findByText('#7');
+    // One delete button for the SUCCEEDED run, none for the RUNNING run.
+    expect(screen.getAllByRole('button', { name: 'Delete' })).toHaveLength(1);
+  });
+
+  it('confirms then deletes a run and reloads the list with feedback', async () => {
+    simulationRunsApi.listRuns
+      .mockResolvedValueOnce(buildPage([succeededRun]))
+      .mockResolvedValueOnce(buildPage([]));
+    simulationRunsApi.deleteRun.mockResolvedValue({ status: 204 });
+    renderPage();
+
+    await screen.findByText('#7');
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    // Confirmation dialog warns about artefacts and history removal.
+    expect(screen.getByText(/stored artefacts/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete run' }));
+
+    await waitFor(() => expect(simulationRunsApi.deleteRun).toHaveBeenCalledWith(7));
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Run #7 and its artefacts were deleted.'
+    );
+    expect(simulationRunsApi.listRuns).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces an error when deletion fails', async () => {
+    simulationRunsApi.listRuns.mockResolvedValue(buildPage([succeededRun]));
+    simulationRunsApi.deleteRun.mockRejectedValue({
+      response: { data: { message: 'Run is still in progress' } },
+    });
+    renderPage();
+
+    await screen.findByText('#7');
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete run' }));
+
+    expect(await screen.findByText(/Run is still in progress/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/SimulationRuns.delete.test.jsx
+++ b/frontend/src/pages/__tests__/SimulationRuns.delete.test.jsx
@@ -85,6 +85,34 @@ describe('SimulationRuns delete action', () => {
     expect(simulationRunsApi.listRuns).toHaveBeenCalledTimes(2);
   });
 
+  it('steps back a page when deleting the only row on a non-first page', async () => {
+    // Page 0 holds run #7; page 1 holds the single run #21 (last page).
+    simulationRunsApi.listRuns.mockImplementation((params = {}) => {
+      const page = Number(params.page ?? 0);
+      const content = page >= 1 ? [{ ...succeededRun, id: 21 }] : [succeededRun];
+      return Promise.resolve({
+        data: { content, totalElements: 21, totalPages: 2, number: page },
+      });
+    });
+    simulationRunsApi.deleteRun.mockResolvedValue({ status: 204 });
+    renderPage();
+
+    await screen.findByText('#7');
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }));
+    await screen.findByText('#21');
+
+    const callsBeforeDelete = simulationRunsApi.listRuns.mock.calls.length;
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete run' }));
+
+    await waitFor(() => expect(simulationRunsApi.deleteRun).toHaveBeenCalledWith(21));
+    // The deletion emptied page 1, so the reload must step back to page 0.
+    await waitFor(() => {
+      const reloadCalls = simulationRunsApi.listRuns.mock.calls.slice(callsBeforeDelete);
+      expect(reloadCalls.some((call) => Number(call[0]?.page) === 0)).toBe(true);
+    });
+  });
+
   it('surfaces an error when deletion fails', async () => {
     simulationRunsApi.listRuns.mockResolvedValue(buildPage([succeededRun]));
     simulationRunsApi.deleteRun.mockRejectedValue({

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.49.25</version>
+    <version>0.50.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/liftsimulator/admin/controller/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.liftsimulator.admin.controller;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.ScenarioValidationResponse;
+import com.liftsimulator.admin.service.ArtefactDeletionException;
 import com.liftsimulator.admin.service.ConfigValidationException;
 import com.liftsimulator.admin.service.ResourceNotFoundException;
 import com.liftsimulator.admin.service.ScenarioValidationException;
@@ -76,6 +77,23 @@ public class GlobalExceptionHandler {
             OffsetDateTime.now()
         );
         return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+    }
+
+    /**
+     * Handles artefact deletion failures with 500 status.
+     * Surfaces a clear, actionable message instead of a generic server error so callers
+     * understand that the run was not deleted because its artefacts could not be removed.
+     */
+    @ExceptionHandler(ArtefactDeletionException.class)
+    public ResponseEntity<ErrorResponse> handleArtefactDeletionError(ArtefactDeletionException ex) {
+        logger.error("Artefact deletion failed: {}", ex.getMessage(), ex);
+
+        ErrorResponse error = new ErrorResponse(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            ex.getMessage(),
+            OffsetDateTime.now()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
     }
 
     /**

--- a/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
@@ -24,6 +24,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -144,6 +145,32 @@ public class SimulationRunController {
         SimulationRun run = executionService.cancelRun(id);
         SimulationRunResponse response = SimulationRunResponse.fromEntity(run);
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Deletes a completed simulation run along with its stored artefacts.
+     * Endpoint: DELETE /api/v1/simulation-runs/{id}
+     *
+     * <p>Only runs in a terminal state (SUCCEEDED, FAILED, CANCELLED) can be deleted.
+     * Deleting an in-progress run returns 409 Conflict; deleting an unknown run returns
+     * 404 Not Found.</p>
+     *
+     * @param id the run ID
+     * @return 204 No Content on successful deletion
+     */
+    @Operation(
+        summary = "Delete a simulation run",
+        description = "Permanently deletes a completed simulation run, removing its run history "
+            + "and all stored artefacts. Only runs in a terminal state (SUCCEEDED, FAILED, "
+            + "CANCELLED) can be deleted."
+    )
+    @ApiResponse(responseCode = "204", description = "Simulation run deleted")
+    @ApiResponse(responseCode = "404", description = "Simulation run not found")
+    @ApiResponse(responseCode = "409", description = "Run is still in progress and cannot be deleted")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSimulationRun(@PathVariable Long id) {
+        simulationRunService.deleteRun(id);
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/src/main/java/com/liftsimulator/admin/service/ArtefactDeletionException.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactDeletionException.java
@@ -1,0 +1,13 @@
+package com.liftsimulator.admin.service;
+
+/**
+ * Exception thrown when stored artefacts for a simulation run cannot be deleted.
+ * Signals a server-side failure (e.g. file system error) during run deletion so the
+ * API can surface a clear error without leaving the run in an inconsistent state.
+ */
+public class ArtefactDeletionException extends RuntimeException {
+
+    public ArtefactDeletionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
@@ -18,6 +18,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.stream.Stream;
@@ -141,6 +142,46 @@ public class ArtefactService {
         }
 
         return new ArtefactDownload(artefactPath, fileName, size, mimeType);
+    }
+
+    /**
+     * Deletes all stored artefacts for a simulation run by recursively removing its
+     * artefact directory. This is a no-op when the run has no artefact base path set
+     * or the directory does not exist, so callers can invoke it safely for runs that
+     * never produced artefacts.
+     *
+     * @param run the simulation run whose artefacts should be removed
+     * @throws IOException if the directory exists but cannot be fully deleted
+     * @throws IllegalStateException if the artefact base path points to a non-directory
+     */
+    public void deleteArtefacts(SimulationRun run) throws IOException {
+        String basePath = run.getArtefactBasePath();
+        if (basePath == null || basePath.isBlank()) {
+            return;
+        }
+
+        Path directory = validateAndResolvePath(basePath, null);
+
+        if (!Files.exists(directory)) {
+            return;
+        }
+
+        if (!Files.isDirectory(directory)) {
+            throw new IllegalStateException("Artefact base path is not a directory: " + basePath);
+        }
+
+        // Walk the tree and delete children before parents by sorting paths in
+        // reverse order, ensuring directories are emptied before removal.
+        try (Stream<Path> paths = Files.walk(directory)) {
+            List<Path> orderedForDeletion = paths
+                .sorted(Comparator.reverseOrder())
+                .toList();
+            for (Path path : orderedForDeletion) {
+                Files.deleteIfExists(path);
+            }
+        }
+
+        logger.info("Deleted artefact directory for run {}: {}", run.getId(), directory);
     }
 
     /**

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -46,6 +46,7 @@ public class SimulationRunService {
     private final ScenarioRepository scenarioRepository;
     private final String artefactsBasePath;
     private final SimulationRunExecutionService executionService;
+    private final ArtefactService artefactService;
 
     @SuppressFBWarnings(
             value = "EI_EXPOSE_REP2",
@@ -57,12 +58,14 @@ public class SimulationRunService {
             LiftSystemVersionRepository versionRepository,
             ScenarioRepository scenarioRepository,
             SimulationRunExecutionService executionService,
+            ArtefactService artefactService,
             @Value("${simulation.artefacts.base-path:./simulation-runs}") String artefactsBasePath) {
         this.runRepository = runRepository;
         this.liftSystemRepository = liftSystemRepository;
         this.versionRepository = versionRepository;
         this.scenarioRepository = scenarioRepository;
         this.executionService = executionService;
+        this.artefactService = artefactService;
         this.artefactsBasePath = artefactsBasePath;
     }
 
@@ -419,16 +422,39 @@ public class SimulationRunService {
     }
 
     /**
-     * Delete a simulation run.
+     * Delete a completed simulation run, removing both its database record and any
+     * stored artefact files.
+     *
+     * <p>Only runs in a terminal state (SUCCEEDED, FAILED, CANCELLED) may be deleted;
+     * attempting to delete an in-progress run (CREATED or RUNNING) fails fast so that
+     * an active execution is never orphaned.</p>
+     *
+     * <p>Artefacts are removed before the database record so that a file system
+     * failure aborts the operation without deleting the run history, keeping the
+     * stored state consistent.</p>
      *
      * @param id the run id
      * @throws ResourceNotFoundException if the run is not found
+     * @throws IllegalStateException if the run is not in a terminal state
+     * @throws ArtefactDeletionException if the stored artefacts cannot be removed
      */
     @Transactional
     public void deleteRun(Long id) {
-        if (!runRepository.existsById(id)) {
-            throw new ResourceNotFoundException("Simulation run not found with id: " + id);
+        SimulationRun run = getRunById(id);
+        RunStatus status = run.getStatus();
+        if (status != RunStatus.SUCCEEDED && status != RunStatus.FAILED && status != RunStatus.CANCELLED) {
+            throw new IllegalStateException(
+                    "Cannot delete a simulation run in " + status + " state. "
+                            + "Only completed runs (SUCCEEDED, FAILED, CANCELLED) can be deleted.");
         }
+
+        try {
+            artefactService.deleteArtefacts(run);
+        } catch (IOException e) {
+            throw new ArtefactDeletionException(
+                    "Failed to delete artefacts for simulation run " + id + ": " + e.getMessage(), e);
+        }
+
         runRepository.deleteById(id);
     }
 }

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -23,6 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -352,6 +354,89 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
                 .header(API_KEY_HEADER, API_KEY_VALUE))
             .andExpect(status().isNotFound())
             .andExpect(jsonPath("$.message").value("Artefact not found: missing.json"));
+    }
+
+    @Test
+    public void testDeleteSimulationRun_Success() throws Exception {
+        SimulationRun run = new SimulationRun(testSystem, testVersion);
+        run.setArtefactBasePath("./simulation-runs/run-delete");
+        run.start();
+        run.succeed();
+        run = runRepository.save(run);
+
+        // Create artefact directory with files that must be removed on deletion.
+        Path artefactDir = Paths.get(run.getArtefactBasePath());
+        Files.createDirectories(artefactDir);
+        Files.writeString(artefactDir.resolve("results.json"), "{\"ok\": true}");
+        Files.writeString(artefactDir.resolve("simulation.log"), "Log content");
+
+        Long runId = run.getId();
+
+        mockMvc.perform(delete("/api/v1/simulation-runs/" + runId)
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isNoContent());
+
+        // Run history removed from the database.
+        mockMvc.perform(get("/api/v1/simulation-runs/" + runId)
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isNotFound());
+
+        // Stored artefacts removed from disk.
+        assertFalse(Files.exists(artefactDir));
+    }
+
+    @Test
+    public void testDeleteSimulationRun_RemovesArtefactsAndReturns404Afterwards() throws Exception {
+        SimulationRun run = new SimulationRun(testSystem, testVersion);
+        run.setArtefactBasePath("./simulation-runs/run-delete-artefacts");
+        run.start();
+        run.succeed();
+        run = runRepository.save(run);
+
+        Path artefactDir = Paths.get(run.getArtefactBasePath());
+        Files.createDirectories(artefactDir);
+        Files.writeString(artefactDir.resolve("results.json"), "{\"ok\": true}");
+
+        Long runId = run.getId();
+
+        mockMvc.perform(delete("/api/v1/simulation-runs/" + runId)
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isNoContent());
+
+        // Artefact links for a deleted run return a clear 404, not a 500.
+        mockMvc.perform(get("/api/v1/simulation-runs/" + runId + "/artefacts/results.json")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void testDeleteSimulationRun_NotFound() throws Exception {
+        mockMvc.perform(delete("/api/v1/simulation-runs/999")
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("Simulation run not found with id: 999"));
+    }
+
+    @Test
+    public void testDeleteSimulationRun_RunningRejected() throws Exception {
+        SimulationRun run = new SimulationRun(testSystem, testVersion);
+        run.start();
+        run = runRepository.save(run);
+
+        mockMvc.perform(delete("/api/v1/simulation-runs/" + run.getId())
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isConflict());
+
+        // Run still present after a rejected deletion.
+        mockMvc.perform(get("/api/v1/simulation-runs/" + run.getId())
+                .header(API_KEY_HEADER, API_KEY_VALUE))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testDeleteSimulationRun_RequiresApiKey() throws Exception {
+        mockMvc.perform(delete("/api/v1/simulation-runs/1"))
+            .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
@@ -187,6 +187,36 @@ class ArtefactServiceTest {
         assertEquals("line-100000", tailedLines[tailedLines.length - 1]);
     }
 
+    @Test
+    void deleteArtefactsRemovesDirectoryAndNestedFiles() throws IOException {
+        Files.createDirectories(tempDir.resolve("metrics"));
+        Files.writeString(tempDir.resolve("results.json"), "{\"status\":\"SUCCEEDED\"}");
+        Files.writeString(tempDir.resolve("metrics/per-floor.csv"), "floor,requests\n0,1\n");
+
+        artefactService.deleteArtefacts(runForTempDir());
+
+        assertFalse(Files.exists(tempDir));
+    }
+
+    @Test
+    void deleteArtefactsIsNoOpForMissingDirectory() throws IOException {
+        SimulationRun run = new SimulationRun();
+        run.setId(1L);
+        run.setArtefactBasePath(tempDir.resolve("missing").toString());
+
+        // Should not throw even though the directory does not exist.
+        artefactService.deleteArtefacts(run);
+    }
+
+    @Test
+    void deleteArtefactsIsNoOpForBlankBasePath() throws IOException {
+        SimulationRun run = new SimulationRun();
+        run.setId(1L);
+        run.setArtefactBasePath("");
+
+        artefactService.deleteArtefacts(run);
+    }
+
     private void writeRunLog(int lines) throws IOException {
         List<String> content = new ArrayList<>(lines);
         for (int line = 1; line <= lines; line++) {

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -58,6 +59,9 @@ public class SimulationRunServiceTest {
     private SimulationRunExecutionService executionService;
 
     @Mock
+    private ArtefactService artefactService;
+
+    @Mock
     private EntityManager entityManager;
 
     private SimulationRunService runService;
@@ -77,6 +81,7 @@ public class SimulationRunServiceTest {
                 versionRepository,
                 scenarioRepository,
                 executionService,
+                artefactService,
                 tempDir.toString()
         );
 
@@ -489,18 +494,20 @@ public class SimulationRunServiceTest {
     }
 
     @Test
-    public void testDeleteRun_Success() {
-        when(runRepository.existsById(1L)).thenReturn(true);
+    public void testDeleteRun_Success() throws Exception {
+        mockRun.setStatus(RunStatus.SUCCEEDED);
+        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
 
         runService.deleteRun(1L);
 
-        verify(runRepository).existsById(1L);
+        verify(runRepository).findById(1L);
+        verify(artefactService).deleteArtefacts(mockRun);
         verify(runRepository).deleteById(1L);
     }
 
     @Test
     public void testDeleteRun_NotFound() {
-        when(runRepository.existsById(999L)).thenReturn(false);
+        when(runRepository.findById(999L)).thenReturn(Optional.empty());
 
         ResourceNotFoundException exception = assertThrows(
             ResourceNotFoundException.class,
@@ -508,7 +515,39 @@ public class SimulationRunServiceTest {
         );
 
         assertEquals("Simulation run not found with id: 999", exception.getMessage());
-        verify(runRepository).existsById(999L);
+        verify(runRepository).findById(999L);
+        verify(runRepository, never()).deleteById(any());
+    }
+
+    @Test
+    public void testDeleteRun_RunningRunRejected() throws Exception {
+        mockRun.setStatus(RunStatus.RUNNING);
+        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+
+        IllegalStateException exception = assertThrows(
+            IllegalStateException.class,
+            () -> runService.deleteRun(1L)
+        );
+
+        assertTrue(exception.getMessage().contains("RUNNING"));
+        verify(artefactService, never()).deleteArtefacts(any());
+        verify(runRepository, never()).deleteById(any());
+    }
+
+    @Test
+    public void testDeleteRun_ArtefactDeletionFailureLeavesRunIntact() throws Exception {
+        mockRun.setStatus(RunStatus.FAILED);
+        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        doThrow(new java.io.IOException("disk error")).when(artefactService).deleteArtefacts(mockRun);
+
+        ArtefactDeletionException exception = assertThrows(
+            ArtefactDeletionException.class,
+            () -> runService.deleteRun(1L)
+        );
+
+        assertTrue(exception.getMessage().contains("disk error"));
+        // The database record must not be removed when artefact cleanup fails.
+        verify(runRepository, never()).deleteById(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR adds the ability to delete completed simulation runs along with their run history and stored artefacts. Users can now permanently remove runs in terminal states (SUCCEEDED, FAILED, CANCELLED) from both the database and the file system.

## Key Changes

### Backend
- **New API endpoint**: `DELETE /api/v1/simulation-runs/{id}` to delete a completed run
  - Returns 204 No Content on success
  - Returns 404 if run not found
  - Returns 409 Conflict if run is still in progress (RUNNING or CREATED)
- **ArtefactService**: Added `deleteArtefacts()` method to recursively remove a run's artefact directory and all nested files
  - Safely handles missing directories and blank paths
  - Validates that the artefact base path is a directory before deletion
- **SimulationRunService**: Updated `deleteRun()` to validate terminal state and orchestrate artefact cleanup before database deletion
  - Prevents deletion of in-progress runs
  - Ensures artefacts are removed before the database record (fail-safe ordering)
  - Throws `ArtefactDeletionException` if file system cleanup fails, leaving the run intact
- **GlobalExceptionHandler**: Added handler for `ArtefactDeletionException` to return 500 with a clear error message
- **Comprehensive test coverage**: Added tests for successful deletion, missing runs, in-progress runs, artefact cleanup failures, and authorization

### Frontend
- **SimulationRuns list page**: 
  - Added Delete button for completed runs (visible only for SUCCEEDED, FAILED, CANCELLED)
  - Confirmation modal warns about permanent deletion of run history and artefacts
  - Error modal surfaces API failures
  - Success notice displayed after deletion with list automatically reloaded
  - Supports navigation state to show deletion notice when returning from detail page
- **SimulationRunDetail page**:
  - Added Delete button in the action bar for terminal runs
  - Confirmation modal with same warning as list page
  - Navigates back to list with success notice on completion
  - Error modal for failed deletions
- **Styling**: Added CSS for danger buttons, action notices, and run action layout
- **Test coverage**: Added comprehensive test suite for delete functionality on the list page

## Notable Implementation Details
- Artefacts are deleted **before** the database record to ensure consistency: if file system cleanup fails, the run remains in the database and can be retried
- Only terminal runs (SUCCEEDED, FAILED, CANCELLED) can be deleted; active runs (RUNNING, CREATED) are rejected with 409 Conflict to prevent orphaning active executions
- The frontend uses navigation state to pass success notices between pages, clearing them on refresh to prevent reappearance
- Recursive directory deletion uses reverse-order path sorting to ensure directories are emptied before removal

https://claude.ai/code/session_01HiK4FWv5LFCxeo3NUAcJm6