### PR TITLE
Add guided form for creating lift system versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+### Added
+- **Guided Create New Version form**: The Create New Version screen now defaults to a structured, guided form with a labelled input for every configuration parameter, inline help, and client-side validation that mirrors the backend constraints (minimum values, floor-range, home-floor-in-range, and door reopen window rules). The raw JSON editor is retained behind an **Advanced (JSON)** toggle for power users, and switching between modes preserves entered data where the JSON can be parsed. Added shared schema helpers and unit tests covering the form helpers and component.
+
 ## [0.51.0] - 2026-06-14
 
 ### Added

--- a/frontend/e2e/configuration-versions.spec.ts
+++ b/frontend/e2e/configuration-versions.spec.ts
@@ -93,6 +93,44 @@ test.describe('Configuration Version Management', () => {
     await expect(statusBadge).toHaveText(/DRAFT/i);
   });
 
+  test('Guided form is the default and creates a version', async ({ page }) => {
+    // Navigate to system detail page
+    await navigateToSystemDetail(page, testSystemKey);
+
+    // Open the create form; the guided form is the default experience
+    await openCreateVersionForm(page, 'guided');
+
+    // The guided form is shown and the raw JSON editor is hidden by default
+    await expect(page.locator('.version-config-grid')).toBeVisible();
+    await expect(page.locator('#config')).toBeHidden();
+
+    // Fields are pre-filled with sensible defaults; adjust the number of lifts
+    const liftsInput = page.locator('#vcf-lifts');
+    await expect(liftsInput).toBeVisible();
+    await liftsInput.fill('3');
+
+    // Switching to Advanced (JSON) preserves the entered data
+    await page.locator('.editor-mode-toggle button:has-text("Advanced")').click();
+    const jsonValue = await page.locator('#config').inputValue();
+    expect(jsonValue).toContain('"lifts": 3');
+
+    // Switching back to the guided form retains the value
+    await page.locator('.editor-mode-toggle button:has-text("Guided")').click();
+    await expect(page.locator('#vcf-lifts')).toHaveValue('3');
+
+    // Validate and create the version from the guided form
+    await page.locator('.create-version-form button:has-text("Validate")').click();
+    await expect(page.locator('.validation-success-banner')).toBeVisible({ timeout: 5000 });
+    await page.locator('.create-version-form button:has-text("Create Version")').click();
+    await expect(page.locator('.create-version-form')).toBeHidden({ timeout: 5000 });
+
+    // Verify the version appears with status DRAFT
+    await page.waitForTimeout(1000);
+    const versionCard = page.locator('.version-card').filter({ hasText: 'Version 1' });
+    await expect(versionCard).toBeVisible();
+    await expect(versionCard.locator('.status-badge')).toHaveText(/DRAFT/i);
+  });
+
   test('TC_0006: Reject Invalid Configuration Version', async ({ page }) => {
     // Navigate to system detail page
     await navigateToSystemDetail(page, testSystemKey);

--- a/frontend/e2e/helpers/test-helpers.ts
+++ b/frontend/e2e/helpers/test-helpers.ts
@@ -206,11 +206,28 @@ export async function navigateToSystemDetail(page: Page, systemKey: string): Pro
 }
 
 /**
- * Helper function to open the inline create-version form.
+ * Helper function to switch the create-version form to the Advanced (JSON)
+ * editor. The guided form is the default experience, so JSON-based flows must
+ * opt into the raw editor first.
  */
-export async function openCreateVersionForm(page: Page): Promise<void> {
+export async function switchToAdvancedJsonMode(page: Page): Promise<void> {
+  await page.locator('.editor-mode-toggle button:has-text("Advanced")').click();
+  await expect(page.locator('#config')).toBeVisible();
+}
+
+/**
+ * Helper function to open the inline create-version form.
+ *
+ * @param mode Which editor to surface once the form is open. Defaults to the
+ *   raw JSON editor ('json') so existing JSON-based flows keep working; pass
+ *   'guided' to remain on the default guided form.
+ */
+export async function openCreateVersionForm(page: Page, mode: 'guided' | 'json' = 'json'): Promise<void> {
   await page.locator('button:has-text("Create New Version")').click();
   await expect(page.locator('.create-version-form')).toBeVisible();
+  if (mode === 'json') {
+    await switchToAdvancedJsonMode(page);
+  }
 }
 
 /**

--- a/frontend/src/components/VersionConfigForm.jsx
+++ b/frontend/src/components/VersionConfigForm.jsx
@@ -1,0 +1,83 @@
+// @ts-check
+import { VERSION_CONFIG_FIELDS, FIELD_TYPE_SELECT } from '../utils/versionConfigSchema';
+
+/**
+ * Guided form for defining a lift system version configuration.
+ *
+ * Renders a structured input for each configuration field with inline help and
+ * validation messages. The component is controlled: the parent owns the form
+ * state and validation errors and receives updates through {@code onChange}.
+ *
+ * @param {Object} props - Component props.
+ * @param {Record<string, string>} props.value - Current form state keyed by field name.
+ * @param {Record<string, string>} [props.errors] - Map of field name to error message.
+ * @param {(name: string, value: string) => void} props.onChange - Field change handler.
+ * @returns {JSX.Element} The guided configuration form.
+ */
+function VersionConfigForm({ value, errors = {}, onChange }) {
+  return (
+    <div className="version-config-form">
+      <div className="version-config-grid">
+        {VERSION_CONFIG_FIELDS.map((field) => {
+          const fieldId = `vcf-${field.name}`;
+          const helpId = `${fieldId}-help`;
+          const errorId = `${fieldId}-error`;
+          const fieldError = errors[field.name];
+          const describedBy = fieldError ? `${helpId} ${errorId}` : helpId;
+          const handleChange = (e) => onChange(field.name, e.target.value);
+
+          return (
+            <div className="version-config-field" key={field.name}>
+              <label htmlFor={fieldId}>
+                {field.label} <span className="required">*</span>
+              </label>
+
+              {field.type === FIELD_TYPE_SELECT ? (
+                <select
+                  id={fieldId}
+                  value={value[field.name] ?? ''}
+                  onChange={handleChange}
+                  className={fieldError ? 'error' : ''}
+                  aria-describedby={describedBy}
+                  aria-invalid={fieldError ? 'true' : undefined}
+                >
+                  <option value="" disabled>
+                    Select…
+                  </option>
+                  {field.options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  id={fieldId}
+                  type="number"
+                  step="1"
+                  value={value[field.name] ?? ''}
+                  onChange={handleChange}
+                  className={fieldError ? 'error' : ''}
+                  aria-describedby={describedBy}
+                  aria-invalid={fieldError ? 'true' : undefined}
+                  {...(field.min !== undefined ? { min: field.min } : {})}
+                />
+              )}
+
+              <p className="version-config-help" id={helpId}>
+                {field.help}
+              </p>
+              {fieldError && (
+                <span className="error-message" id={errorId} role="alert">
+                  {fieldError}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default VersionConfigForm;

--- a/frontend/src/components/__tests__/VersionConfigForm.test.jsx
+++ b/frontend/src/components/__tests__/VersionConfigForm.test.jsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import VersionConfigForm from '../VersionConfigForm';
+import { getDefaultVersionFormData, VERSION_CONFIG_FIELDS } from '../../utils/versionConfigSchema';
+
+describe('VersionConfigForm', () => {
+  it('renders an input for every configuration field', () => {
+    render(<VersionConfigForm value={getDefaultVersionFormData()} onChange={vi.fn()} />);
+    for (const field of VERSION_CONFIG_FIELDS) {
+      expect(screen.getByLabelText(new RegExp(field.label, 'i'))).toBeInTheDocument();
+    }
+  });
+
+  it('renders the current values', () => {
+    const value = { ...getDefaultVersionFormData(), lifts: '7' };
+    render(<VersionConfigForm value={value} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/Number of Lifts/i)).toHaveValue(7);
+  });
+
+  it('calls onChange with field name and value when a field is edited', () => {
+    const onChange = vi.fn();
+    render(<VersionConfigForm value={getDefaultVersionFormData()} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText(/Number of Lifts/i), { target: { value: '4' } });
+    expect(onChange).toHaveBeenCalledWith('lifts', '4');
+  });
+
+  it('renders select options for enum fields', () => {
+    render(<VersionConfigForm value={getDefaultVersionFormData()} onChange={vi.fn()} />);
+    const select = screen.getByLabelText(/Controller Strategy/i);
+    expect(select.tagName).toBe('SELECT');
+    expect(screen.getByRole('option', { name: 'Directional Scan' })).toBeInTheDocument();
+  });
+
+  it('shows inline error messages and marks fields invalid', () => {
+    render(
+      <VersionConfigForm
+        value={getDefaultVersionFormData()}
+        errors={{ lifts: 'Number of Lifts must be at least 1.' }}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Number of Lifts must be at least 1.')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Number of Lifts/i)).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/frontend/src/pages/LiftSystemDetail.css
+++ b/frontend/src/pages/LiftSystemDetail.css
@@ -342,6 +342,102 @@
   gap: 0.5rem;
 }
 
+/* Guided / Advanced editor mode toggle */
+.editor-mode-toggle {
+  display: inline-flex;
+  margin-bottom: 1.25rem;
+  border: 1px solid #d6dee6;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.editor-mode-toggle .mode-btn {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #5d6d7e;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.editor-mode-toggle .mode-btn + .mode-btn {
+  border-left: 1px solid #d6dee6;
+}
+
+.editor-mode-toggle .mode-btn:hover {
+  background: #eef3f7;
+}
+
+.editor-mode-toggle .mode-btn.active {
+  background: #3498db;
+  color: #fff;
+}
+
+/* Guided version configuration form */
+.version-config-form {
+  margin-bottom: 1rem;
+}
+
+.version-config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.version-config-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.version-config-field label {
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+  color: #2c3e50;
+}
+
+.version-config-field .required {
+  color: #e74c3c;
+}
+
+.version-config-field input,
+.version-config-field select {
+  width: 100%;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  background: #fff;
+}
+
+.version-config-field input:focus,
+.version-config-field select:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.version-config-field input.error,
+.version-config-field select.error {
+  border-color: #e74c3c;
+}
+
+.version-config-help {
+  margin: 0.4rem 0 0 0;
+  font-size: 0.8rem;
+  color: #7f8c8d;
+  line-height: 1.4;
+}
+
+.version-config-field .error-message {
+  margin-top: 0.35rem;
+  font-size: 0.8rem;
+  color: #c0392b;
+  font-weight: 600;
+}
+
 .versions-list {
   display: flex;
   flex-direction: column;
@@ -659,6 +755,18 @@
 
   .create-version-editor {
     grid-template-columns: 1fr;
+  }
+
+  .version-config-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .editor-mode-toggle {
+    width: 100%;
+  }
+
+  .editor-mode-toggle .mode-btn {
+    flex: 1;
   }
 
   .form-actions {

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -6,9 +6,16 @@ import VersionActions from '../components/VersionActions';
 import ConfirmModal from '../components/ConfirmModal';
 import AlertModal from '../components/AlertModal';
 import EditSystemModal from '../components/EditSystemModal';
+import VersionConfigForm from '../components/VersionConfigForm';
 import { handleApiError } from '../utils/errorHandlers';
 import { getStatusBadgeClass } from '../utils/statusUtils';
 import { CONFIG_EXAMPLE_JSON, CONFIG_REQUIRED_FIELDS, CONFIG_SCHEMA_DOCS_URL, CONFIG_SCHEMA_HELP_TEXT } from '../utils/configSchemaHelp';
+import {
+  getDefaultVersionFormData,
+  configToFormData,
+  formDataToJson,
+  validateVersionFormData
+} from '../utils/versionConfigSchema';
 import './LiftSystemDetail.css';
 
 /**
@@ -40,7 +47,11 @@ function LiftSystemDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [showCreateVersion, setShowCreateVersion] = useState(false);
-  const [newVersionConfig, setNewVersionConfig] = useState('');
+  // 'guided' renders the structured form (default); 'json' renders the advanced JSON editor.
+  const [editorMode, setEditorMode] = useState('guided');
+  const [versionFormData, setVersionFormData] = useState(() => getDefaultVersionFormData());
+  const [versionFormErrors, setVersionFormErrors] = useState({});
+  const [newVersionConfig, setNewVersionConfig] = useState(() => formDataToJson(getDefaultVersionFormData()));
   const [creating, setCreating] = useState(false);
   const [validatingCreate, setValidatingCreate] = useState(false);
   /** @type {import('../types/models').ValidationResult | null} */
@@ -89,6 +100,87 @@ function LiftSystemDetail() {
     setCreateValidationError(null);
   };
 
+  /**
+   * Handles edits to a single guided form field. Keeps the JSON representation
+   * and client-side validation state in sync, and clears any stale server
+   * validation result so the user re-validates after changes.
+   *
+   * @param {string} name - Configuration field name.
+   * @param {string} value - New field value.
+   */
+  const handleVersionFormChange = (name, value) => {
+    const updated = { ...versionFormData, [name]: value };
+    setVersionFormData(updated);
+    setNewVersionConfig(formDataToJson(updated));
+    setVersionFormErrors(validateVersionFormData(updated));
+    setCreateValidationResult(null);
+    setCreateValidationError(null);
+  };
+
+  /**
+   * Resets the create-version form back to its default guided state.
+   */
+  const resetCreateVersionForm = () => {
+    const defaults = getDefaultVersionFormData();
+    setVersionFormData(defaults);
+    setVersionFormErrors({});
+    setNewVersionConfig(formDataToJson(defaults));
+    setEditorMode('guided');
+    setCreateValidationResult(null);
+    setCreateValidationError(null);
+  };
+
+  /**
+   * Switches to the advanced JSON editor, serializing the current guided form
+   * values so no data is lost when toggling modes.
+   */
+  const switchToJsonMode = () => {
+    setNewVersionConfig(formDataToJson(versionFormData));
+    setEditorMode('json');
+    setCreateValidationResult(null);
+    setCreateValidationError(null);
+  };
+
+  /**
+   * Switches back to the guided form, parsing the current JSON into form fields
+   * where feasible. If the JSON cannot be parsed, the previous guided values are
+   * retained and the user is informed.
+   */
+  const switchToGuidedMode = () => {
+    setCreateValidationResult(null);
+    setCreateValidationError(null);
+    try {
+      const parsed = JSON.parse(newVersionConfig);
+      const formData = configToFormData(parsed);
+      setVersionFormData(formData);
+      setVersionFormErrors(validateVersionFormData(formData));
+    } catch {
+      setCreateValidationError(
+        'The JSON could not be parsed into the guided form, so your last form values are shown. Fix the JSON or continue editing in the form.'
+      );
+    }
+    setEditorMode('guided');
+  };
+
+  /**
+   * Cancels version creation, hiding and resetting the form.
+   */
+  const handleCancelCreateVersion = () => {
+    resetCreateVersionForm();
+    setShowCreateVersion(false);
+  };
+
+  /**
+   * Toggles the create-version form visibility, resetting state when closing.
+   */
+  const toggleCreateVersion = () => {
+    if (showCreateVersion) {
+      handleCancelCreateVersion();
+    } else {
+      setShowCreateVersion(true);
+    }
+  };
+
   useEffect(() => {
     loadSystemData();
   }, [loadSystemData]);
@@ -121,9 +213,7 @@ function LiftSystemDetail() {
       }
       setCreating(true);
       await liftSystemsApi.createVersion(id, { config: newVersionConfig });
-      setNewVersionConfig('');
-      setCreateValidationResult(null);
-      setCreateValidationError(null);
+      resetCreateVersionForm();
       setShowCreateVersion(false);
       await loadSystemData();
     } catch (err) {
@@ -376,7 +466,7 @@ function LiftSystemDetail() {
         <div className="section-header">
           <h3>Versions ({filteredVersions.length} of {versions.length})</h3>
           <button
-            onClick={() => setShowCreateVersion(!showCreateVersion)}
+            onClick={toggleCreateVersion}
             className="btn-primary"
           >
             {showCreateVersion ? 'Cancel' : 'Create New Version'}
@@ -388,29 +478,70 @@ function LiftSystemDetail() {
             <div className="version-number-display">
               <h4>Version {versions.length > 0 ? Math.max(...versions.map(v => v.versionNumber)) + 1 : 1}</h4>
             </div>
-            <div className="config-label-row">
-              <label htmlFor="config">Configuration JSON</label>
-              <a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
-                View schema docs
-              </a>
+
+            <div className="editor-mode-toggle" role="group" aria-label="Configuration editor mode">
+              <button
+                type="button"
+                className={editorMode === 'guided' ? 'mode-btn active' : 'mode-btn'}
+                onClick={switchToGuidedMode}
+                aria-pressed={editorMode === 'guided'}
+              >
+                Guided Form
+              </button>
+              <button
+                type="button"
+                className={editorMode === 'json' ? 'mode-btn active' : 'mode-btn'}
+                onClick={switchToJsonMode}
+                aria-pressed={editorMode === 'json'}
+              >
+                Advanced (JSON)
+              </button>
             </div>
-            <p id="config-help" className="config-help-text">{CONFIG_SCHEMA_HELP_TEXT}</p>
-            <details className="config-example-help">
-              <summary>Show complete valid example</summary>
-              <pre>{CONFIG_EXAMPLE_JSON}</pre>
-            </details>
-            <textarea
-              id="config"
-              value={newVersionConfig}
-              onChange={handleNewVersionConfigChange}
-              placeholder={CONFIG_EXAMPLE_JSON}
-              rows="14"
-              required
-              aria-describedby="config-help config-required-fields"
-            />
-            <p id="config-required-fields" className="config-required-fields">
-              Required fields: {CONFIG_REQUIRED_FIELDS.map((field) => `\`${field}\``).join(', ')}.
-            </p>
+
+            {editorMode === 'guided' ? (
+              <>
+                <div className="config-label-row">
+                  <label>Version Configuration</label>
+                  <a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
+                    View schema docs
+                  </a>
+                </div>
+                <p className="config-help-text">
+                  Fill in the parameters below. Switch to Advanced (JSON) to edit the raw configuration directly.
+                </p>
+                <VersionConfigForm
+                  value={versionFormData}
+                  errors={versionFormErrors}
+                  onChange={handleVersionFormChange}
+                />
+              </>
+            ) : (
+              <>
+                <div className="config-label-row">
+                  <label htmlFor="config">Configuration JSON</label>
+                  <a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
+                    View schema docs
+                  </a>
+                </div>
+                <p id="config-help" className="config-help-text">{CONFIG_SCHEMA_HELP_TEXT}</p>
+                <details className="config-example-help">
+                  <summary>Show complete valid example</summary>
+                  <pre>{CONFIG_EXAMPLE_JSON}</pre>
+                </details>
+                <textarea
+                  id="config"
+                  value={newVersionConfig}
+                  onChange={handleNewVersionConfigChange}
+                  placeholder={CONFIG_EXAMPLE_JSON}
+                  rows="14"
+                  required
+                  aria-describedby="config-help config-required-fields"
+                />
+                <p id="config-required-fields" className="config-required-fields">
+                  Required fields: {CONFIG_REQUIRED_FIELDS.map((field) => `\`${field}\``).join(', ')}.
+                </p>
+              </>
+            )}
             <div className="form-actions">
               <button
                 type="button"
@@ -435,7 +566,7 @@ function LiftSystemDetail() {
               </button>
               <button
                 type="button"
-                onClick={() => setShowCreateVersion(false)}
+                onClick={handleCancelCreateVersion}
                 className="btn-secondary"
               >
                 Cancel

--- a/frontend/src/utils/__tests__/versionConfigSchema.test.js
+++ b/frontend/src/utils/__tests__/versionConfigSchema.test.js
@@ -56,6 +56,14 @@ describe('versionConfigSchema', () => {
       expect(config.maxFloor).toBeNull();
     });
 
+    it('does not coerce form-invalid numeric strings into JSON numbers', () => {
+      // "1e3" is rejected by the form validator; it must not be silently
+      // normalized to 1000 in the serialized config.
+      const data = { ...getDefaultVersionFormData(), lifts: '1e3' };
+      expect(validateVersionFormData(data).lifts).toBeDefined();
+      expect(formDataToConfig(data).lifts).toBeNull();
+    });
+
     it('round-trips through JSON back into matching form data', () => {
       const original = getDefaultVersionFormData();
       const json = formDataToJson(original);

--- a/frontend/src/utils/__tests__/versionConfigSchema.test.js
+++ b/frontend/src/utils/__tests__/versionConfigSchema.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VERSION_CONFIG_FIELDS,
+  getDefaultVersionFormData,
+  configToFormData,
+  formDataToConfig,
+  formDataToJson,
+  validateVersionFormData,
+  isVersionFormValid
+} from '../versionConfigSchema';
+import { CONFIG_EXAMPLE, CONFIG_REQUIRED_FIELDS } from '../configSchemaHelp';
+
+describe('versionConfigSchema', () => {
+  it('defines a field for every required configuration key', () => {
+    const fieldNames = VERSION_CONFIG_FIELDS.map((f) => f.name).sort();
+    expect(fieldNames).toEqual([...CONFIG_REQUIRED_FIELDS].sort());
+  });
+
+  describe('getDefaultVersionFormData', () => {
+    it('pre-fills the canonical example as string values', () => {
+      const data = getDefaultVersionFormData();
+      expect(data.minFloor).toBe(String(CONFIG_EXAMPLE.minFloor));
+      expect(data.controllerStrategy).toBe(CONFIG_EXAMPLE.controllerStrategy);
+      expect(data.idleParkingMode).toBe(CONFIG_EXAMPLE.idleParkingMode);
+    });
+
+    it('produces a form that passes client validation', () => {
+      expect(isVersionFormValid(getDefaultVersionFormData())).toBe(true);
+    });
+  });
+
+  describe('configToFormData', () => {
+    it('stringifies present values and blanks missing ones', () => {
+      const data = configToFormData({ minFloor: 0, lifts: 3 });
+      expect(data.minFloor).toBe('0');
+      expect(data.lifts).toBe('3');
+      expect(data.maxFloor).toBe('');
+    });
+
+    it('tolerates null and undefined input', () => {
+      expect(configToFormData(null).minFloor).toBe('');
+      expect(configToFormData(undefined).maxFloor).toBe('');
+    });
+  });
+
+  describe('formDataToConfig / formDataToJson', () => {
+    it('parses numeric fields to numbers and keeps selects as strings', () => {
+      const config = formDataToConfig(getDefaultVersionFormData());
+      expect(config.minFloor).toBe(CONFIG_EXAMPLE.minFloor);
+      expect(typeof config.lifts).toBe('number');
+      expect(config.controllerStrategy).toBe(CONFIG_EXAMPLE.controllerStrategy);
+    });
+
+    it('maps blank values to null', () => {
+      const config = formDataToConfig({ ...getDefaultVersionFormData(), maxFloor: '' });
+      expect(config.maxFloor).toBeNull();
+    });
+
+    it('round-trips through JSON back into matching form data', () => {
+      const original = getDefaultVersionFormData();
+      const json = formDataToJson(original);
+      const roundTripped = configToFormData(JSON.parse(json));
+      expect(roundTripped).toEqual(original);
+    });
+  });
+
+  describe('validateVersionFormData', () => {
+    it('returns no errors for the default form', () => {
+      expect(validateVersionFormData(getDefaultVersionFormData())).toEqual({});
+    });
+
+    it('flags required fields that are blank', () => {
+      const data = { ...getDefaultVersionFormData(), lifts: '' };
+      expect(validateVersionFormData(data).lifts).toMatch(/required/i);
+    });
+
+    it('enforces minimum values', () => {
+      const data = { ...getDefaultVersionFormData(), lifts: '0' };
+      expect(validateVersionFormData(data).lifts).toMatch(/at least 1/i);
+    });
+
+    it('rejects non-integer numeric input', () => {
+      const data = { ...getDefaultVersionFormData(), lifts: '1.5' };
+      expect(validateVersionFormData(data).lifts).toMatch(/whole number/i);
+    });
+
+    it('requires maxFloor greater than minFloor', () => {
+      const data = { ...getDefaultVersionFormData(), minFloor: '5', maxFloor: '5' };
+      expect(validateVersionFormData(data).maxFloor).toMatch(/greater than minimum/i);
+    });
+
+    it('requires homeFloor within the floor range', () => {
+      const data = { ...getDefaultVersionFormData(), minFloor: '0', maxFloor: '9', homeFloor: '20' };
+      expect(validateVersionFormData(data).homeFloor).toMatch(/within the floor range/i);
+    });
+
+    it('requires doorReopenWindowTicks not to exceed doorTransitionTicks', () => {
+      const data = {
+        ...getDefaultVersionFormData(),
+        doorTransitionTicks: '2',
+        doorReopenWindowTicks: '5'
+      };
+      expect(validateVersionFormData(data).doorReopenWindowTicks).toMatch(/must not exceed/i);
+    });
+
+    it('rejects unsupported select values', () => {
+      const data = { ...getDefaultVersionFormData(), controllerStrategy: 'BOGUS' };
+      expect(validateVersionFormData(data).controllerStrategy).toMatch(/unsupported/i);
+    });
+  });
+});

--- a/frontend/src/utils/versionConfigSchema.js
+++ b/frontend/src/utils/versionConfigSchema.js
@@ -12,6 +12,9 @@ import { CONFIG_EXAMPLE } from './configSchemaHelp';
 export const FIELD_TYPE_NUMBER = 'number';
 export const FIELD_TYPE_SELECT = 'select';
 
+/** Matches whole integers (optionally negative); rejects decimals, exponents, hex, etc. */
+const NUMERIC_PATTERN = /^-?\d+$/;
+
 /** Allowed controller strategies (mirrors ControllerStrategy enum). */
 export const CONTROLLER_STRATEGY_OPTIONS = [
   { value: 'NEAREST_REQUEST_ROUTING', label: 'Nearest Request Routing' },
@@ -162,8 +165,10 @@ export function formDataToConfig(formData) {
     if (trimmed === '' || trimmed === null || trimmed === undefined) {
       config[field.name] = null;
     } else if (field.type === FIELD_TYPE_NUMBER) {
-      const num = Number(trimmed);
-      config[field.name] = Number.isNaN(num) ? null : num;
+      // Only serialize values that pass the same integer check the form validator
+      // applies, so input the UI flags as invalid (e.g. "1e3") cannot be silently
+      // coerced into a valid JSON number that the server would accept.
+      config[field.name] = NUMERIC_PATTERN.test(trimmed) ? Number(trimmed) : null;
     } else {
       config[field.name] = trimmed;
     }
@@ -180,8 +185,6 @@ export function formDataToConfig(formData) {
 export function formDataToJson(formData) {
   return JSON.stringify(formDataToConfig(formData), null, 2);
 }
-
-const NUMERIC_PATTERN = /^-?\d+$/;
 
 /**
  * Performs client-side validation of the guided form, mirroring the backend

--- a/frontend/src/utils/versionConfigSchema.js
+++ b/frontend/src/utils/versionConfigSchema.js
@@ -1,0 +1,269 @@
+import { CONFIG_EXAMPLE } from './configSchemaHelp';
+
+/**
+ * Shared schema metadata for the guided "Create New Version" form.
+ *
+ * The field definitions, default values, and client-side validation rules in
+ * this module mirror the backend contract enforced by {@code LiftConfigDTO} and
+ * {@code ConfigValidationService}. Keeping them in one place lets the guided
+ * form and the advanced JSON editor stay in sync and produce equivalent output.
+ */
+
+export const FIELD_TYPE_NUMBER = 'number';
+export const FIELD_TYPE_SELECT = 'select';
+
+/** Allowed controller strategies (mirrors ControllerStrategy enum). */
+export const CONTROLLER_STRATEGY_OPTIONS = [
+  { value: 'NEAREST_REQUEST_ROUTING', label: 'Nearest Request Routing' },
+  { value: 'DIRECTIONAL_SCAN', label: 'Directional Scan' }
+];
+
+/** Allowed idle parking modes (mirrors IdleParkingMode enum). */
+export const IDLE_PARKING_MODE_OPTIONS = [
+  { value: 'STAY_AT_CURRENT_FLOOR', label: 'Stay at Current Floor' },
+  { value: 'PARK_TO_HOME_FLOOR', label: 'Park to Home Floor' }
+];
+
+/**
+ * Ordered field definitions rendered by the guided form. Order is grouped for
+ * usability (floors together, door timings together) and does not affect the
+ * generated JSON.
+ *
+ * @typedef {Object} VersionConfigField
+ * @property {string} name - Configuration key.
+ * @property {string} label - Human-readable label.
+ * @property {'number'|'select'} type - Input control type.
+ * @property {string} help - Inline help text describing the field.
+ * @property {number} [min] - Minimum allowed value for numeric fields.
+ * @property {Array<{value: string, label: string}>} [options] - Select options.
+ */
+
+/** @type {VersionConfigField[]} */
+export const VERSION_CONFIG_FIELDS = [
+  {
+    name: 'minFloor',
+    label: 'Minimum Floor',
+    type: FIELD_TYPE_NUMBER,
+    help: 'Lowest floor the lifts serve.'
+  },
+  {
+    name: 'maxFloor',
+    label: 'Maximum Floor',
+    type: FIELD_TYPE_NUMBER,
+    help: 'Highest floor the lifts serve. Must be greater than the minimum floor.'
+  },
+  {
+    name: 'homeFloor',
+    label: 'Home Floor',
+    type: FIELD_TYPE_NUMBER,
+    help: 'Floor lifts return to when idle. Must be within the floor range.'
+  },
+  {
+    name: 'lifts',
+    label: 'Number of Lifts',
+    type: FIELD_TYPE_NUMBER,
+    min: 1,
+    help: 'How many lift cars the system has (at least 1).'
+  },
+  {
+    name: 'travelTicksPerFloor',
+    label: 'Travel Ticks per Floor',
+    type: FIELD_TYPE_NUMBER,
+    min: 1,
+    help: 'Simulation ticks to travel one floor (at least 1).'
+  },
+  {
+    name: 'doorTransitionTicks',
+    label: 'Door Transition Ticks',
+    type: FIELD_TYPE_NUMBER,
+    min: 1,
+    help: 'Ticks for doors to open or close (at least 1).'
+  },
+  {
+    name: 'doorDwellTicks',
+    label: 'Door Dwell Ticks',
+    type: FIELD_TYPE_NUMBER,
+    min: 1,
+    help: 'Ticks doors stay open before closing (at least 1).'
+  },
+  {
+    name: 'doorReopenWindowTicks',
+    label: 'Door Reopen Window Ticks',
+    type: FIELD_TYPE_NUMBER,
+    min: 0,
+    help: 'Ticks while closing during which doors can reopen. Cannot exceed door transition ticks.'
+  },
+  {
+    name: 'idleTimeoutTicks',
+    label: 'Idle Timeout Ticks',
+    type: FIELD_TYPE_NUMBER,
+    min: 0,
+    help: 'Ticks of inactivity before a lift is treated as idle.'
+  },
+  {
+    name: 'controllerStrategy',
+    label: 'Controller Strategy',
+    type: FIELD_TYPE_SELECT,
+    options: CONTROLLER_STRATEGY_OPTIONS,
+    help: 'Algorithm used to dispatch lifts to requests.'
+  },
+  {
+    name: 'idleParkingMode',
+    label: 'Idle Parking Mode',
+    type: FIELD_TYPE_SELECT,
+    options: IDLE_PARKING_MODE_OPTIONS,
+    help: 'What a lift does once it becomes idle.'
+  }
+];
+
+/**
+ * Builds the default form state, pre-filled with the canonical example
+ * configuration so the guided form starts in a valid, editable state.
+ *
+ * @returns {Record<string, string>} Form state keyed by field name (string values).
+ */
+export function getDefaultVersionFormData() {
+  return configToFormData(CONFIG_EXAMPLE);
+}
+
+/**
+ * Converts a parsed configuration object into form state. Every value is
+ * represented as a string (the native representation of form inputs); missing
+ * values become empty strings.
+ *
+ * @param {Record<string, unknown> | null | undefined} config - Parsed config object.
+ * @returns {Record<string, string>} Form state keyed by field name.
+ */
+export function configToFormData(config) {
+  const source = config && typeof config === 'object' ? config : {};
+  /** @type {Record<string, string>} */
+  const formData = {};
+  for (const field of VERSION_CONFIG_FIELDS) {
+    const value = source[field.name];
+    formData[field.name] = value === null || value === undefined ? '' : String(value);
+  }
+  return formData;
+}
+
+/**
+ * Converts form state back into a configuration object suitable for JSON
+ * serialization. Numeric fields are parsed to numbers; blank values become
+ * null so that downstream validation reports them as missing.
+ *
+ * @param {Record<string, string>} formData - Form state keyed by field name.
+ * @returns {Record<string, unknown>} Configuration object.
+ */
+export function formDataToConfig(formData) {
+  /** @type {Record<string, unknown>} */
+  const config = {};
+  for (const field of VERSION_CONFIG_FIELDS) {
+    const raw = formData?.[field.name];
+    const trimmed = typeof raw === 'string' ? raw.trim() : raw;
+    if (trimmed === '' || trimmed === null || trimmed === undefined) {
+      config[field.name] = null;
+    } else if (field.type === FIELD_TYPE_NUMBER) {
+      const num = Number(trimmed);
+      config[field.name] = Number.isNaN(num) ? null : num;
+    } else {
+      config[field.name] = trimmed;
+    }
+  }
+  return config;
+}
+
+/**
+ * Serializes form state into a pretty-printed JSON configuration string.
+ *
+ * @param {Record<string, string>} formData - Form state keyed by field name.
+ * @returns {string} Pretty-printed JSON.
+ */
+export function formDataToJson(formData) {
+  return JSON.stringify(formDataToConfig(formData), null, 2);
+}
+
+const NUMERIC_PATTERN = /^-?\d+$/;
+
+/**
+ * Performs client-side validation of the guided form, mirroring the backend
+ * structural and cross-field rules. Returns a map of field name to the first
+ * error message for that field so the form can surface inline feedback.
+ *
+ * @param {Record<string, string>} formData - Form state keyed by field name.
+ * @returns {Record<string, string>} Map of field name to error message.
+ */
+export function validateVersionFormData(formData) {
+  /** @type {Record<string, string>} */
+  const errors = {};
+  /** @type {Record<string, number>} */
+  const numbers = {};
+
+  for (const field of VERSION_CONFIG_FIELDS) {
+    const raw = formData?.[field.name];
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+
+    if (trimmed === '') {
+      errors[field.name] = `${field.label} is required.`;
+      continue;
+    }
+
+    if (field.type === FIELD_TYPE_SELECT) {
+      const allowed = field.options.some((option) => option.value === trimmed);
+      if (!allowed) {
+        errors[field.name] = `${field.label} has an unsupported value.`;
+      }
+      continue;
+    }
+
+    if (!NUMERIC_PATTERN.test(trimmed)) {
+      errors[field.name] = `${field.label} must be a whole number.`;
+      continue;
+    }
+
+    const value = Number(trimmed);
+    if (field.min !== undefined && value < field.min) {
+      errors[field.name] = `${field.label} must be at least ${field.min}.`;
+      continue;
+    }
+    numbers[field.name] = value;
+  }
+
+  // Cross-field rules (only checked when both operands parsed cleanly).
+  if (
+    numbers.maxFloor !== undefined &&
+    numbers.minFloor !== undefined &&
+    numbers.maxFloor <= numbers.minFloor
+  ) {
+    errors.maxFloor = `Maximum floor must be greater than minimum floor (${numbers.minFloor}).`;
+  }
+
+  if (
+    numbers.homeFloor !== undefined &&
+    numbers.minFloor !== undefined &&
+    numbers.maxFloor !== undefined &&
+    (numbers.homeFloor < numbers.minFloor || numbers.homeFloor > numbers.maxFloor)
+  ) {
+    errors.homeFloor =
+      `Home floor must be within the floor range (${numbers.minFloor} to ${numbers.maxFloor}).`;
+  }
+
+  if (
+    numbers.doorReopenWindowTicks !== undefined &&
+    numbers.doorTransitionTicks !== undefined &&
+    numbers.doorReopenWindowTicks > numbers.doorTransitionTicks
+  ) {
+    errors.doorReopenWindowTicks =
+      `Door reopen window ticks must not exceed door transition ticks (${numbers.doorTransitionTicks}).`;
+  }
+
+  return errors;
+}
+
+/**
+ * Convenience helper indicating whether the form passes client-side validation.
+ *
+ * @param {Record<string, string>} formData - Form state keyed by field name.
+ * @returns {boolean} True when there are no validation errors.
+ */
+export function isVersionFormValid(formData) {
+  return Object.keys(validateVersionFormData(formData)).length === 0;
+}


### PR DESCRIPTION
## Summary
This PR introduces a guided form interface for creating new lift system versions, complementing the existing advanced JSON editor. Users can now choose between a structured form with labeled inputs and validation or the raw JSON editor.

## Key Changes

- **New schema module** (`versionConfigSchema.js`): Centralized configuration field definitions, type conversions, and validation logic that mirrors backend constraints. Includes:
  - Field metadata (labels, types, help text, constraints)
  - Conversion functions between form state and configuration objects
  - Client-side validation matching backend rules (cross-field constraints, numeric ranges, enum values)

- **New guided form component** (`VersionConfigForm.jsx`): Renders a responsive grid of labeled inputs with inline help text and validation error messages. Supports both numeric and select fields with proper accessibility attributes.

- **Enhanced version creation flow** (`LiftSystemDetail.jsx`): 
  - Added editor mode toggle (Guided/Advanced) allowing users to switch between form and JSON
  - Form state is synchronized with JSON representation in real-time
  - Switching modes preserves data where possible (JSON → form parses and validates; form → JSON serializes)
  - Form validation runs on every change, providing immediate feedback
  - Resets form to defaults when closing the create dialog

- **Styling** (`LiftSystemDetail.css`): Added styles for the mode toggle buttons, form grid layout, field inputs, help text, and error messages with responsive behavior.

- **Comprehensive tests**: Unit tests for schema utilities and component rendering/interaction.

## Implementation Details

- Form state is stored as strings (native form input representation) and converted to typed values only when serializing to JSON
- Validation is performed client-side before submission, mirroring backend rules for floor ranges, door timing constraints, and enum values
- The canonical example configuration pre-fills the form on first load, ensuring users start with a valid state
- Mode switching is non-destructive: guided form values are serialized to JSON when switching to advanced mode, and JSON is parsed back when returning to guided mode

https://claude.ai/code/session_01E2ymgGQfkD6TzP4CRoGTSp