### PR TITLE
Add test cleanup to prevent concurrent simulation run mutations

### DIFF
--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -114,6 +114,21 @@ public class SimulationRunExecutionService {
         return run;
     }
 
+    /**
+     * Indicates whether any simulation run is currently submitted or executing.
+     *
+     * <p>Runs are tracked from submission until their asynchronous execution
+     * completes (including artefact writing and lifecycle finalisation). This is
+     * primarily used to let integration tests wait for background executions to
+     * drain before they reset shared database state, preventing a concurrent
+     * {@code UPDATE} from the runner thread from colliding with cleanup deletes.</p>
+     *
+     * @return {@code true} if at least one run is in flight
+     */
+    public boolean hasActiveRuns() {
+        return !runningTasks.isEmpty();
+    }
+
     private void executeRun(RunExecutionRequest request) {
         CancellationToken cancelToken = cancellationTokens.computeIfAbsent(request.runId(), id -> new CancellationToken());
         boolean started = false;

--- a/src/test/java/com/liftsimulator/BaseIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/BaseIntegrationTest.java
@@ -1,6 +1,14 @@
 package com.liftsimulator;
 
 import com.liftsimulator.admin.LiftConfigServiceApplication;
+import com.liftsimulator.admin.repository.LiftSystemRepository;
+import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.repository.ScenarioRepository;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
+import com.liftsimulator.admin.service.SimulationRunExecutionService;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -30,6 +38,27 @@ import org.springframework.test.context.DynamicPropertySource;
 @ActiveProfiles("test")
 public abstract class BaseIntegrationTest {
 
+    /**
+     * Maximum time to wait for asynchronous simulation runs to finish before the
+     * shared database state is reset for the next test.
+     */
+    private static final Duration ASYNC_RUN_DRAIN_TIMEOUT = Duration.ofSeconds(15);
+
+    @Autowired(required = false)
+    private SimulationRunExecutionService simulationRunExecutionService;
+
+    @Autowired(required = false)
+    private SimulationRunRepository simulationRunRepository;
+
+    @Autowired(required = false)
+    private ScenarioRepository scenarioRepository;
+
+    @Autowired(required = false)
+    private LiftSystemVersionRepository liftSystemVersionRepository;
+
+    @Autowired(required = false)
+    private LiftSystemRepository liftSystemRepository;
+
     @DynamicPropertySource
     static void registerEnvironmentProperties(DynamicPropertyRegistry registry) {
         // Explicitly register environment variables as Spring properties so that
@@ -46,6 +75,53 @@ public abstract class BaseIntegrationTest {
         }
         if (datasourcePassword != null) {
             registry.add("spring.datasource.password", () -> datasourcePassword);
+        }
+    }
+
+    /**
+     * Resets the shared simulation tables before every test.
+     *
+     * <p>All integration tests share a single application context, so an
+     * asynchronous simulation run started by one test can still be executing when
+     * the next test begins. If such a background execution mutates a
+     * {@code simulation_run} row while the next test's cleanup deletes it, the two
+     * transactions can block each other indefinitely (manifesting as a CI hang on
+     * a Hibernate {@code UPDATE}) or fail with foreign-key violations. To make the
+     * suite deterministic this hook first waits for any in-flight runs to drain,
+     * then clears the simulation tables in foreign-key-safe order before the
+     * subclass {@code @BeforeEach} seeds its own data.</p>
+     *
+     * <p>JUnit 5 runs superclass {@code @BeforeEach} methods before subclass ones,
+     * so this executes ahead of any per-test setup.</p>
+     *
+     * @throws InterruptedException if interrupted while waiting for runs to drain
+     */
+    @BeforeEach
+    void resetSimulationState() throws InterruptedException {
+        drainAsyncRuns();
+
+        // Delete children before parents: simulation_run -> scenario -> version -> system.
+        if (simulationRunRepository != null) {
+            simulationRunRepository.deleteAll();
+        }
+        if (scenarioRepository != null) {
+            scenarioRepository.deleteAll();
+        }
+        if (liftSystemVersionRepository != null) {
+            liftSystemVersionRepository.deleteAll();
+        }
+        if (liftSystemRepository != null) {
+            liftSystemRepository.deleteAll();
+        }
+    }
+
+    private void drainAsyncRuns() throws InterruptedException {
+        if (simulationRunExecutionService == null) {
+            return;
+        }
+        long deadlineNanos = System.nanoTime() + ASYNC_RUN_DRAIN_TIMEOUT.toNanos();
+        while (simulationRunExecutionService.hasActiveRuns() && System.nanoTime() < deadlineNanos) {
+            Thread.sleep(25);
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds proper test isolation to the integration test suite by implementing a cleanup mechanism that waits for asynchronous simulation runs to complete before resetting shared database state between tests.

## Key Changes
- **BaseIntegrationTest**: Added a `@BeforeEach` hook that:
  - Waits up to 15 seconds for any in-flight simulation runs to drain
  - Clears simulation-related tables in foreign-key-safe order (simulation_run → scenario → version → system)
  - Executes before subclass setup methods to ensure clean state for each test

- **SimulationRunExecutionService**: Added `hasActiveRuns()` method to expose whether any simulation runs are currently submitted or executing

## Implementation Details
- The cleanup uses a polling mechanism with 25ms sleep intervals to wait for active runs to complete
- All repository autowiring is marked as optional (`required = false`) to support test classes that don't use all repositories
- Detailed Javadoc explains the race condition being prevented: concurrent `UPDATE` operations from runner threads colliding with cleanup deletes, which could cause CI hangs or foreign-key violations
- JUnit 5's execution order guarantees this superclass hook runs before subclass `@BeforeEach` methods

## Motivation
Shared application context across integration tests can cause background simulation executions from one test to still be running when the next test begins, leading to non-deterministic failures and CI hangs.

https://claude.ai/code/session_016zZSifBiHRaV5TTGYbJasr