### PR TITLE
fix(frontend): prevent white screens from render errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+### Fixed
+- **Frontend white-screen recovery**: Added a top-level React error boundary with reload/dashboard recovery actions, guarded lift-system version configuration previews against malformed or already-parsed JSON, and made Config Validator error rendering tolerate missing `errors` arrays. Updated README and package metadata for the 0.52.8 patch release.
+
 ### Added
 - **High-level architecture documentation**: Added `docs/architecture.md` (linked from the README) with a Mermaid component diagram and a simulation-run sequence diagram — plus a standalone `docs/architecture-diagram.mermaid` source — describing the major components (React admin UI, Spring Boot backend layers, simulation engine, PostgreSQL, artefact storage) and the key configuration-management and simulation-run flows. Also refreshed the README "Project Structure" section to match the current source layout.
 - **Simulation Runs bulk actions**: Added multi-select checkboxes, select-all, guarded bulk action controls, confirmation dialogs, and per-operation outcome summaries so active runs can be cancelled together and completed runs can be deleted together from the Simulation Runs list. Updated README, Maven/JAR documentation, backend artifact metadata, and frontend package metadata for the 0.52.0 minor release.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.52.7**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.52.8**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -113,12 +113,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.52.7.jar
+java -jar target/lift-simulator-0.52.8.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.52.7.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.52.8.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -130,21 +130,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.52.7.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.52.7.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.52.7.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.52.7.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -216,7 +216,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.52.7.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.52.8.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.52.7.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.52.8.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.52.7.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.52.7.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -406,7 +406,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.52.7.jar \
+   java -cp target/lift-simulator-0.52.8.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -451,7 +451,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -543,7 +543,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.52.7.jar \
+java -cp target/lift-simulator-0.52.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.52.6",
+  "version": "0.52.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.52.6",
+      "version": "0.52.8",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.52.7",
+  "version": "0.52.8",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,3 +12,43 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.app-error-boundary {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  background: #f8fafc;
+  color: #1f2937;
+}
+
+.app-error-boundary__card {
+  width: min(100%, 42rem);
+  padding: 2rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  box-shadow: 0 10px 30px rgb(15 23 42 / 0.12);
+}
+
+.app-error-boundary__card h1 {
+  margin-top: 0;
+  color: #b91c1c;
+}
+
+.app-error-boundary__details {
+  overflow-x: auto;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: #f3f4f6;
+  color: #374151;
+  white-space: pre-wrap;
+}
+
+.app-error-boundary__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
+import ErrorBoundary from './components/ErrorBoundary';
 import Dashboard from './pages/Dashboard';
 import LiftSystems from './pages/LiftSystems';
 import LiftSystemDetail from './pages/LiftSystemDetail';
@@ -17,23 +18,25 @@ import './App.css';
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Dashboard />} />
-          <Route path="systems" element={<LiftSystems />} />
-          <Route path="systems/:id" element={<LiftSystemDetail />} />
-          <Route path="systems/:systemId/versions/:versionNumber/edit" element={<ConfigEditor />} />
-          <Route path="scenarios" element={<Scenarios />} />
-          <Route path="scenarios/new" element={<ScenarioForm />} />
-          <Route path="scenarios/:id/edit" element={<ScenarioForm />} />
-          <Route path="simulator" element={<SimulatorLanding />} />
-          <Route path="simulator/run" element={<Simulator />} />
-          <Route path="simulation-runs" element={<SimulationRuns />} />
-          <Route path="simulation-runs/:id" element={<SimulationRunDetail />} />
-          <Route path="config-validator" element={<ConfigValidator />} />
-          <Route path="health" element={<HealthCheck />} />
-        </Route>
-      </Routes>
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Dashboard />} />
+            <Route path="systems" element={<LiftSystems />} />
+            <Route path="systems/:id" element={<LiftSystemDetail />} />
+            <Route path="systems/:systemId/versions/:versionNumber/edit" element={<ConfigEditor />} />
+            <Route path="scenarios" element={<Scenarios />} />
+            <Route path="scenarios/new" element={<ScenarioForm />} />
+            <Route path="scenarios/:id/edit" element={<ScenarioForm />} />
+            <Route path="simulator" element={<SimulatorLanding />} />
+            <Route path="simulator/run" element={<Simulator />} />
+            <Route path="simulation-runs" element={<SimulationRuns />} />
+            <Route path="simulation-runs/:id" element={<SimulationRunDetail />} />
+            <Route path="config-validator" element={<ConfigValidator />} />
+            <Route path="health" element={<HealthCheck />} />
+          </Route>
+        </Routes>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,51 @@
+import { Component } from 'react';
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Unhandled application error', error, errorInfo);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="app-error-boundary" role="alert">
+          <div className="app-error-boundary__card">
+            <h1>Something went wrong</h1>
+            <p>
+              The admin UI hit an unexpected error. Reload the page to try again,
+              or return to the dashboard if the problem persists.
+            </p>
+            <pre className="app-error-boundary__details">
+              {this.state.error.message || 'Unknown error'}
+            </pre>
+            <div className="app-error-boundary__actions">
+              <button type="button" className="btn-primary" onClick={this.handleReload}>
+                Reload page
+              </button>
+              <a className="btn-secondary" href="/">
+                Go to dashboard
+              </a>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/pages/ConfigValidator.jsx
+++ b/frontend/src/pages/ConfigValidator.jsx
@@ -78,7 +78,7 @@ function ConfigValidator() {
             <div className="result-error">
               <h4>Validation Errors</h4>
               <ul>
-                {result.errors.map((error, index) => (
+                {(result.errors ?? []).map((error, index) => (
                   <li key={index}>
                     <strong>{error.field}:</strong> {error.message}
                   </li>

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -18,6 +18,19 @@ import {
 } from '../utils/versionConfigSchema';
 import './LiftSystemDetail.css';
 
+function formatVersionConfig(config) {
+  if (typeof config !== 'string') {
+    return JSON.stringify(config, null, 2);
+  }
+
+  try {
+    return JSON.stringify(JSON.parse(config), null, 2);
+  } catch (err) {
+    console.warn('Version configuration is not valid JSON; showing raw value instead', err);
+    return config;
+  }
+}
+
 /**
  * Detailed view page for a specific lift system.
  * Displays system information, version management, and provides version filtering, sorting, and pagination.
@@ -740,7 +753,7 @@ function LiftSystemDetail() {
                   )}
                   <details className="config-details">
                     <summary>View Configuration</summary>
-                    <pre className="config-preview">{JSON.stringify(JSON.parse(version.config), null, 2)}</pre>
+                    <pre className="config-preview">{formatVersionConfig(version.config)}</pre>
                   </details>
                 </div>
               </div>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.52.7</version>
+    <version>0.52.8</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Prevent the admin UI from showing a blank/white screen when an uncaught render-time error occurs or when `JSON.parse` is invoked during render on malformed/already-parsed config data.
- Make the config preview and validator rendering more defensive so malformed server data or unexpected shapes do not crash the entire SPA.

### Description
- Added a top-level React `ErrorBoundary` component that wraps the route tree and shows a recovery UI with reload and dashboard navigation when an unhandled error occurs.
- Introduced `formatVersionConfig` in `LiftSystemDetail.jsx` to safely parse `version.config` and fall back to the raw value when JSON parsing fails or when the value is already an object, and replaced the inline `JSON.parse` usage there.
- Hardened `ConfigValidator.jsx` rendering to tolerate validation results missing an `errors` array by using a null-coalescing pattern; added styling for the error-boundary in `App.css`.
- Bumped frontend and project metadata to version `0.52.8` (updated `frontend/package.json`, `frontend/package-lock.json`, `pom.xml`, `README.md`) and added a brief `CHANGELOG.md` entry documenting the fix.

### Testing
- Ran lint: `npm --prefix frontend run lint` and it completed without errors.
- Ran unit tests: `npm --prefix frontend run test:unit` (Vitest) and all tests passed (`10 files, 86 tests` reported passed).
- Built the frontend: `npm --prefix frontend run build` (Vite) and the production bundle was produced successfully.
- Performed `git diff --check` as a quality sanity check with no trailing whitespace / patch issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a378bac91688325adcda2097695a61b)