### PR TITLE
Enforce unique scenario names within lift system versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 ### Fixed
+- **Duplicate scenario names**: Scenario names are now unique within a lift system version, matching the uniqueness already enforced for `lift_system.system_key` and `lift_system_version(lift_system_id, version_number)`. Added a Flyway migration (`V11`) that deduplicates any existing same-named scenarios and creates a unique index on `scenario(lift_system_version_id, name)`, plus service-layer pre-checks on create and update that return HTTP 409 with an actionable message before hitting the database constraint. Scenario copy now auto-resolves name collisions (e.g. `Copy of X (2)`) so the new constraint stays satisfied. Updated API documentation and package metadata for the 0.52.9 patch release.
 - **Frontend white-screen recovery**: Added a top-level React error boundary with reload/dashboard recovery actions, guarded lift-system version configuration previews against malformed or already-parsed JSON, and made Config Validator error rendering tolerate missing `errors` arrays. Updated README and package metadata for the 0.52.8 patch release.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.52.8**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.52.9**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -113,12 +113,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.52.8.jar
+java -jar target/lift-simulator-0.52.9.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.52.8.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.52.9.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -130,21 +130,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.52.9.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.52.9.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.52.9.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.52.8.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.52.9.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -216,7 +216,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.52.8.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.52.9.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). It defaults to `true` to preserve local development behaviour; set it to `false` to require ADMIN-role authentication for the documentation endpoints.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -257,11 +257,13 @@ Scenario payloads define passenger flow for UI-driven simulation runs. The scena
       "updatedAt": "2026-01-11T10:00:00Z"
     }
     ```
+  - Error (409 Conflict): If a scenario with the same `name` already exists for the target lift system version. Scenario names must be unique within a lift system version.
 
 - **Update Scenario**: `PUT /api/v1/scenarios/{id}`
   - Updates an existing scenario payload after validation
   - Request body: same as create
   - Response (200 OK): Updated scenario details
+  - Error (409 Conflict): If renaming the scenario would collide with another scenario's `name` in the same lift system version
 
 - **Get Scenario**: `GET /api/v1/scenarios/{id}`
   - Returns a stored scenario by ID

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.52.8.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.52.9.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.52.8.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.52.8.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -406,7 +406,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.52.8.jar \
+   java -cp target/lift-simulator-0.52.9.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -451,7 +451,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -543,7 +543,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.52.8.jar \
+java -cp target/lift-simulator-0.52.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.52.8",
+  "version": "0.52.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.52.8",
+      "version": "0.52.9",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.52.8",
+  "version": "0.52.9",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.52.8</version>
+    <version>0.52.9</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/repository/ScenarioRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/ScenarioRepository.java
@@ -20,4 +20,24 @@ public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
      */
     @Query("SELECT COUNT(s) FROM Scenario s WHERE s.liftSystemVersion.liftSystem.id = :liftSystemId")
     long countByLiftSystemId(@Param("liftSystemId") Long liftSystemId);
+
+    /**
+     * Checks whether a scenario with the given name already exists for the lift system version.
+     *
+     * @param liftSystemVersionId the lift system version id
+     * @param name the scenario name
+     * @return {@code true} if a matching scenario exists
+     */
+    boolean existsByLiftSystemVersionIdAndName(Long liftSystemVersionId, String name);
+
+    /**
+     * Checks whether another scenario (excluding the given id) with the same name already exists
+     * for the lift system version. Used to allow a scenario to keep its own name on update.
+     *
+     * @param liftSystemVersionId the lift system version id
+     * @param name the scenario name
+     * @param id the id of the scenario being updated, which is excluded from the check
+     * @return {@code true} if a different scenario with the same name exists
+     */
+    boolean existsByLiftSystemVersionIdAndNameAndIdNot(Long liftSystemVersionId, String name, Long id);
 }

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
@@ -28,6 +28,7 @@ public class ScenarioService {
 
     private static final int SCENARIO_NAME_MAX_LENGTH = 200;
     private static final String COPY_NAME_PREFIX = "Copy of ";
+    private static final int MAX_COPY_NAME_ATTEMPTS = 100;
 
     private final ScenarioRepository scenarioRepository;
     private final LiftSystemVersionRepository versionRepository;
@@ -66,6 +67,12 @@ public class ScenarioService {
                 "Lift system version not found with id: " + request.liftSystemVersionId()
             ));
 
+        // Reject duplicate names within the same version before validating/saving
+        if (scenarioRepository.existsByLiftSystemVersionIdAndName(
+                request.liftSystemVersionId(), request.name())) {
+            throw new IllegalStateException(duplicateNameMessage(request.name()));
+        }
+
         // Validate scenario JSON with floor range validation
         validateScenarioJson(request.scenarioJson(), request.liftSystemVersionId());
 
@@ -100,6 +107,12 @@ public class ScenarioService {
             .orElseThrow(() -> new ResourceNotFoundException(
                 "Lift system version not found with id: " + request.liftSystemVersionId()
             ));
+
+        // Reject duplicate names within the same version, allowing this scenario to keep its name
+        if (scenarioRepository.existsByLiftSystemVersionIdAndNameAndIdNot(
+                request.liftSystemVersionId(), request.name(), id)) {
+            throw new IllegalStateException(duplicateNameMessage(request.name()));
+        }
 
         // Validate scenario JSON with floor range validation
         validateScenarioJson(request.scenarioJson(), request.liftSystemVersionId());
@@ -138,7 +151,7 @@ public class ScenarioService {
         validateScenarioJson(scenarioJson, targetLiftSystemVersionId);
 
         Scenario copiedScenario = new Scenario(
-            copiedScenarioName(sourceScenario.getName()),
+            uniqueCopyName(sourceScenario.getName(), targetLiftSystemVersionId),
             serializeScenarioJson(scenarioJson),
             targetVersion
         );
@@ -210,6 +223,41 @@ public class ScenarioService {
             ? sourceName.substring(0, sourceNameLimit)
             : sourceName;
         return COPY_NAME_PREFIX + boundedSourceName;
+    }
+
+    /**
+     * Generates a copy name that does not collide with an existing scenario name in the target
+     * version. Falls back to numbered suffixes (e.g. "Copy of X (2)") when the base name is taken,
+     * keeping the unique constraint on (lift_system_version_id, name) satisfied.
+     */
+    private String uniqueCopyName(String sourceName, Long targetLiftSystemVersionId) {
+        String baseName = copiedScenarioName(sourceName);
+        if (!scenarioRepository.existsByLiftSystemVersionIdAndName(targetLiftSystemVersionId, baseName)) {
+            return baseName;
+        }
+        for (int suffix = 2; suffix <= MAX_COPY_NAME_ATTEMPTS; suffix++) {
+            String candidate = withNumericSuffix(baseName, suffix);
+            if (!scenarioRepository.existsByLiftSystemVersionIdAndName(targetLiftSystemVersionId, candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException(
+            "Unable to generate a unique name for the copied scenario; "
+                + "please rename existing copies and try again"
+        );
+    }
+
+    private String withNumericSuffix(String baseName, int suffix) {
+        String suffixText = " (" + suffix + ")";
+        int baseLimit = SCENARIO_NAME_MAX_LENGTH - suffixText.length();
+        String boundedBase = baseName.length() > baseLimit
+            ? baseName.substring(0, baseLimit)
+            : baseName;
+        return boundedBase + suffixText;
+    }
+
+    private String duplicateNameMessage(String name) {
+        return "A scenario named '" + name + "' already exists for this lift system version";
     }
 
     private String serializeScenarioJson(JsonNode scenarioJson) {

--- a/src/main/resources/db/migration/V11__add_unique_scenario_name_per_version.sql
+++ b/src/main/resources/db/migration/V11__add_unique_scenario_name_per_version.sql
@@ -8,22 +8,50 @@ SET search_path TO lift_simulator;
 
 -- Existing databases may already contain duplicate scenario names within a version.
 -- Keep the earliest scenario (lowest id) untouched and rename later duplicates with a
--- " (#<id>)" suffix, truncating the base name so the result fits the 200-char column.
-WITH ranked_scenarios AS (
-    SELECT
-        id,
-        name,
-        ROW_NUMBER() OVER (
-            PARTITION BY lift_system_version_id, name
-            ORDER BY id
-        ) AS name_rank
-    FROM scenario
-)
-UPDATE scenario AS s
-SET name = LEFT(s.name, 200 - LENGTH(' (#' || s.id || ')')) || ' (#' || s.id || ')'
-FROM ranked_scenarios AS ranked
-WHERE s.id = ranked.id
-  AND ranked.name_rank > 1;
+-- " (#<n>)" suffix, truncating the base name so the result fits the 200-char column.
+-- The generated name is checked against ALL existing names in the same version (not just
+-- the duplicate group), incrementing the suffix until it is unique, so a pre-existing
+-- row such as "Morning (#2)" cannot collide with a renamed duplicate before the unique
+-- index is created.
+DO $$
+DECLARE
+    dup RECORD;
+    candidate TEXT;
+    suffix BIGINT;
+BEGIN
+    LOOP
+        -- Pick one row that shares its (version, name) with an earlier row (lower id).
+        SELECT s.id, s.name, s.lift_system_version_id
+        INTO dup
+        FROM scenario s
+        WHERE EXISTS (
+            SELECT 1
+            FROM scenario o
+            WHERE o.lift_system_version_id = s.lift_system_version_id
+              AND o.name = s.name
+              AND o.id < s.id
+        )
+        ORDER BY s.lift_system_version_id, s.name, s.id
+        LIMIT 1;
+
+        EXIT WHEN NOT FOUND;
+
+        -- Find a suffix that yields a name unique within the version.
+        suffix := dup.id;
+        LOOP
+            candidate := LEFT(dup.name, 200 - LENGTH(' (#' || suffix || ')')) || ' (#' || suffix || ')';
+            EXIT WHEN NOT EXISTS (
+                SELECT 1
+                FROM scenario o
+                WHERE o.lift_system_version_id = dup.lift_system_version_id
+                  AND o.name = candidate
+            );
+            suffix := suffix + 1;
+        END LOOP;
+
+        UPDATE scenario SET name = candidate WHERE id = dup.id;
+    END LOOP;
+END $$;
 
 -- Replace the non-unique index from V6 with a unique index on (version, name).
 DROP INDEX IF EXISTS idx_scenario_version;

--- a/src/main/resources/db/migration/V11__add_unique_scenario_name_per_version.sql
+++ b/src/main/resources/db/migration/V11__add_unique_scenario_name_per_version.sql
@@ -1,0 +1,34 @@
+-- Enforce unique scenario names per lift system version
+-- Version: 11
+-- Description: Prevents duplicate scenario names within the same lift system version,
+--              mirroring the uniqueness already enforced for lift_system.system_key and
+--              lift_system_version(lift_system_id, version_number).
+
+SET search_path TO lift_simulator;
+
+-- Existing databases may already contain duplicate scenario names within a version.
+-- Keep the earliest scenario (lowest id) untouched and rename later duplicates with a
+-- " (#<id>)" suffix, truncating the base name so the result fits the 200-char column.
+WITH ranked_scenarios AS (
+    SELECT
+        id,
+        name,
+        ROW_NUMBER() OVER (
+            PARTITION BY lift_system_version_id, name
+            ORDER BY id
+        ) AS name_rank
+    FROM scenario
+)
+UPDATE scenario AS s
+SET name = LEFT(s.name, 200 - LENGTH(' (#' || s.id || ')')) || ' (#' || s.id || ')'
+FROM ranked_scenarios AS ranked
+WHERE s.id = ranked.id
+  AND ranked.name_rank > 1;
+
+-- Replace the non-unique index from V6 with a unique index on (version, name).
+DROP INDEX IF EXISTS idx_scenario_version;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_scenario_version_name
+    ON scenario(lift_system_version_id, name);
+
+COMMENT ON INDEX uq_scenario_version_name IS 'Ensures scenario names are unique within a lift system version';

--- a/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
@@ -139,6 +139,70 @@ public class ScenarioServiceTest {
     }
 
     @Test
+    public void createScenarioThrowsConflictAndDoesNotSaveWhenDuplicateNameExists() throws Exception {
+        ScenarioRequest request = new ScenarioRequest("Morning rush", json(validScenario()), 20L);
+        when(versionRepository.findById(20L)).thenReturn(Optional.of(version));
+        when(scenarioRepository.existsByLiftSystemVersionIdAndName(20L, "Morning rush")).thenReturn(true);
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> scenarioService.createScenario(request)
+        );
+
+        assertTrue(exception.getMessage().contains("Morning rush"));
+        assertTrue(exception.getMessage().contains("already exists"));
+        verify(scenarioValidationService, never()).validate(any(), any());
+        verify(scenarioRepository, never()).save(any(Scenario.class));
+    }
+
+    @Test
+    public void updateScenarioThrowsConflictWhenAnotherScenarioHasSameName() throws Exception {
+        Scenario existing = new Scenario("Original", validScenario(), version);
+        existing.setId(30L);
+        ScenarioRequest request = new ScenarioRequest("Taken name", json(updatedScenario()), 20L);
+        when(scenarioRepository.findById(30L)).thenReturn(Optional.of(existing));
+        when(versionRepository.findById(20L)).thenReturn(Optional.of(version));
+        when(scenarioRepository.existsByLiftSystemVersionIdAndNameAndIdNot(20L, "Taken name", 30L))
+                .thenReturn(true);
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> scenarioService.updateScenario(30L, request)
+        );
+
+        assertTrue(exception.getMessage().contains("Taken name"));
+        verify(scenarioValidationService, never()).validate(any(), any());
+        verify(scenarioRepository, never()).save(any(Scenario.class));
+    }
+
+    @Test
+    public void copyScenarioGeneratesNumberedSuffixWhenBaseCopyNameIsTaken() throws Exception {
+        Scenario source = new Scenario("Morning rush", validScenario(), version);
+        source.setId(30L);
+        LiftSystemVersion targetVersion = version(22L);
+        when(scenarioRepository.findById(30L)).thenReturn(Optional.of(source));
+        when(versionRepository.findById(22L)).thenReturn(Optional.of(targetVersion));
+        when(scenarioValidationService.validate(objectMapper.readTree(validScenario()), 22L))
+                .thenReturn(validValidationResponse());
+        when(scenarioRepository.existsByLiftSystemVersionIdAndName(22L, "Copy of Morning rush"))
+                .thenReturn(true);
+        when(scenarioRepository.existsByLiftSystemVersionIdAndName(22L, "Copy of Morning rush (2)"))
+                .thenReturn(false);
+        when(scenarioRepository.save(any(Scenario.class))).thenAnswer(invocation -> {
+            Scenario saved = invocation.getArgument(0);
+            saved.setId(31L);
+            return saved;
+        });
+
+        ScenarioResponse response = scenarioService.copyScenario(30L, 22L);
+
+        assertEquals("Copy of Morning rush (2)", response.name());
+        ArgumentCaptor<Scenario> scenarioCaptor = ArgumentCaptor.forClass(Scenario.class);
+        verify(scenarioRepository).save(scenarioCaptor.capture());
+        assertEquals("Copy of Morning rush (2)", scenarioCaptor.getValue().getName());
+    }
+
+    @Test
     public void updateScenarioValidatesMutatesExistingScenarioAndReturnsUpdatedResponse() throws Exception {
         Scenario existing = new Scenario("Original", validScenario(), version);
         existing.setId(30L);


### PR DESCRIPTION
## Summary
This change enforces unique scenario names within each lift system version by adding database constraints and application-level validation. Scenario names must now be unique per version, preventing naming conflicts while allowing the same name to be used across different versions.

## Key Changes

- **Database Migration (V11)**: Added a unique index on `(lift_system_version_id, name)` to enforce uniqueness at the database level. Existing duplicate names are automatically renamed with a `(#<id>)` suffix to preserve data integrity.

- **Repository Methods**: Added two new query methods to `ScenarioRepository`:
  - `existsByLiftSystemVersionIdAndName()` — checks if a scenario name exists for a version
  - `existsByLiftSystemVersionIdAndNameAndIdNot()` — checks for duplicates while excluding the current scenario (used during updates)

- **Create Scenario Validation**: Added early duplicate name check in `createScenario()` that rejects requests with names already used in the target version, before validation and persistence.

- **Update Scenario Validation**: Added duplicate name check in `updateScenario()` that allows a scenario to keep its own name but prevents renaming to a name already used by another scenario in the same version.

- **Copy Scenario Enhancement**: Replaced simple `copiedScenarioName()` logic with `uniqueCopyName()` that generates numbered suffixes (e.g., "Copy of X (2)") when the base copy name is already taken. The method respects the 200-character name limit by truncating the base name as needed.

- **Test Coverage**: Added three comprehensive test cases covering duplicate name detection in create, update, and copy operations.

- **Version Bump**: Updated to 0.52.9 across all configuration files (pom.xml, package.json, README.md, docs).

## Implementation Details

- Duplicate name errors throw `IllegalStateException` with a clear message indicating the conflicting name and version context.
- The copy operation attempts up to 100 numbered suffixes before failing, providing robust handling for scenarios with many existing copies.
- All validation occurs before database writes, ensuring consistency and preventing constraint violations.

https://claude.ai/code/session_01QPjGck3rNbGcLmHff4AS2d