### PR TITLE
Add validation for durationTicks maximum limit of 1,000,000

### DIFF
--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioDefinitionDTO.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioDefinitionDTO.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -15,6 +16,7 @@ import java.util.List;
 public record ScenarioDefinitionDTO(
     @NotNull(message = "durationTicks is required")
     @Min(value = 1, message = "durationTicks must be at least 1")
+    @Max(value = 1000000, message = "durationTicks must not exceed 1,000,000")
     Integer durationTicks,
 
     @NotNull(message = "passengerFlows is required")

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java
@@ -197,6 +197,16 @@ public class ScenarioValidationService {
         }
 
         int duration = scenario.durationTicks();
+
+        if (duration > 1000000) {
+            errors.add(new ValidationIssue(
+                "durationTicks",
+                "durationTicks must not exceed 1,000,000",
+                ValidationIssue.Severity.ERROR
+            ));
+            return;
+        }
+
         List<PassengerFlowDTO> flows = scenario.passengerFlows();
         for (int i = 0; i < flows.size(); i++) {
             PassengerFlowDTO flow = flows.get(i);


### PR DESCRIPTION
## Summary
This PR adds validation to enforce a maximum limit of 1,000,000 ticks for scenario duration, preventing excessively long simulations that could impact system performance.

## Key Changes
- Added `@Max` constraint annotation to `durationTicks` field in `ScenarioDefinitionDTO` with a limit of 1,000,000
- Added corresponding domain validation logic in `ScenarioValidationService.performDomainValidation()` to check the duration limit and return early if exceeded
- Both validation layers provide consistent error messaging: "durationTicks must not exceed 1,000,000"

## Implementation Details
- The validation is implemented at two levels:
  - **Bean validation layer**: Uses Jakarta validation `@Max` annotation for declarative constraint checking
  - **Domain validation layer**: Explicit check in the service with early return to prevent further processing of invalid scenarios
- The domain validation error is marked with `Severity.ERROR` to indicate a critical validation failure
- Early return in the service prevents unnecessary validation of passenger flows when duration is invalid

https://claude.ai/code/session_011EggcuFBHRxibGHctTb7Rz