### PR TITLE
fix(security): bound request and artefact reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 ### Fixed
+- **DoS hardening for request and artefact reads**: Capped retained per-IP rate-limit buckets, added a configurable API request-body limit that rejects oversized JSON payloads with HTTP 413, constrained Jackson JSON nesting/string sizes, and bounded full simulation log/results artefact reads to prevent unbounded memory use. Updated README operational guidance for the new limits.
 - **Private OpenAPI default**: The base `application.yml` and `SecurityConfig` code fallback now default `security.openapi.public-access` to private access (`false`), keeping Swagger UI and `/api-docs` ADMIN-only unless an environment or profile explicitly opts into public documentation access. Updated README guidance and synchronized package metadata for the 0.52.15 patch release.
 - **Placeholder startup secrets**: Backend startup validation now rejects the template `CHANGE_ME` placeholder for the runtime API key and legacy admin password, preventing copied development templates from starting with predictable credentials. Updated README guidance and synchronized package metadata for the 0.52.14 patch release.
 - **Friendly backend-unreachable errors**: Frontend API error formatting now maps network failures, Vite proxy gateway errors (`502`/`503`/`504`), connection refusals, and timeouts to a plain-language server-reachability message while keeping the original technical error in the console for debugging. Updated README and package metadata for the 0.52.13 patch release.

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ When the limit is exceeded the server responds with **HTTP 429 Too Many Requests
 rate-limiting:
   enabled: true               # set to false to disable entirely (e.g. in integration tests)
   trust-forwarded-for: false  # set to true only behind a trusted reverse proxy
+  max-buckets-per-group: 10000 # caps retained client-IP buckets per API group
   admin:
     capacity: 100             # bucket capacity (max burst)
     refill-tokens: 100        # tokens added per period
@@ -273,6 +274,18 @@ rate-limiting:
 **`trust-forwarded-for`** — when `false` (the default), the rate-limiter uses `getRemoteAddr()` as the bucket key, which prevents callers from bypassing limits by spoofing `X-Forwarded-For`. Set to `true` only when the service runs exclusively behind a trusted reverse proxy that controls this header.
 
 Override individual fields per Spring profile to tighten limits in production or loosen them for load testing.
+
+## Request and Artefact Size Limits
+
+The backend rejects oversized API request bodies before JSON deserialization and constrains Jackson JSON nesting/string sizes to reduce denial-of-service risk from very large or deeply nested JSON payloads. By default, `/api/v1/**` and `/actuator/**` request bodies are capped at **1 MiB** and oversized requests receive **HTTP 413 Payload Too Large**.
+
+```yaml
+request-size-limits:
+  enabled: true
+  max-body-bytes: 1048576
+```
+
+Simulation artefact reads are also bounded: full log reads and `results.json` parsing are capped at **1 MiB** each. Prefer the existing `tail` query parameter for large logs; tailed log reads remain capped by line count and do not materialize the entire file in memory.
 
 ## Database Setup
 

--- a/src/main/java/com/liftsimulator/admin/config/JacksonConfiguration.java
+++ b/src/main/java/com/liftsimulator/admin/config/JacksonConfiguration.java
@@ -1,5 +1,7 @@
 package com.liftsimulator.admin.config;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +13,9 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 public class JacksonConfiguration {
+
+    private static final int MAX_JSON_NESTING_DEPTH = 100;
+    private static final int MAX_JSON_STRING_LENGTH = 1_048_576;
 
     /**
      * Customizes the auto-configured ObjectMapper with strict validation settings.
@@ -25,6 +30,16 @@ public class JacksonConfiguration {
      */
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
-        return builder -> builder.featuresToEnable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        StreamReadConstraints readConstraints = StreamReadConstraints.builder()
+            .maxNestingDepth(MAX_JSON_NESTING_DEPTH)
+            .maxStringLength(MAX_JSON_STRING_LENGTH)
+            .build();
+        JsonFactory jsonFactory = JsonFactory.builder()
+            .streamReadConstraints(readConstraints)
+            .build();
+
+        return builder -> builder
+            .factory(jsonFactory)
+            .featuresToEnable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 }

--- a/src/main/java/com/liftsimulator/admin/config/RateLimitingConfig.java
+++ b/src/main/java/com/liftsimulator/admin/config/RateLimitingConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
  * and available as a bean in all Spring contexts, including {@code @WebMvcTest} slices.
  */
 @Configuration
-@EnableConfigurationProperties(RateLimitingProperties.class)
+@EnableConfigurationProperties({RateLimitingProperties.class, RequestSizeLimitProperties.class})
 public class RateLimitingConfig {
 
     /**
@@ -22,6 +22,17 @@ public class RateLimitingConfig {
      * ({@code SecurityProperties.DEFAULT_FILTER_ORDER - 1}) so it runs before authentication
      * and can throttle all traffic including unauthenticated brute-force or flood requests.
      */
+    @Bean
+    public FilterRegistrationBean<RequestSizeLimitFilter> requestSizeLimitFilterRegistration(
+            RequestSizeLimitProperties properties) {
+        FilterRegistrationBean<RequestSizeLimitFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(new RequestSizeLimitFilter(properties));
+        registration.addUrlPatterns("/api/v1/*", "/actuator/*");
+        registration.setOrder(SecurityProperties.DEFAULT_FILTER_ORDER - 2);
+        registration.setName("requestSizeLimitFilter");
+        return registration;
+    }
+
     @Bean
     public FilterRegistrationBean<RateLimitingFilter> rateLimitingFilterRegistration(
             RateLimitingProperties properties) {

--- a/src/main/java/com/liftsimulator/admin/config/RateLimitingFilter.java
+++ b/src/main/java/com/liftsimulator/admin/config/RateLimitingFilter.java
@@ -91,11 +91,11 @@ public class RateLimitingFilter extends OncePerRequestFilter {
         int limit;
         if (isRuntime) {
             RateLimitingProperties.EndpointLimits runtimeLimits = properties.getRuntime();
-            bucket = runtimeBuckets.computeIfAbsent(clientIp, k -> buildBucket(runtimeLimits));
+            bucket = bucketFor(runtimeBuckets, clientIp, runtimeLimits);
             limit = runtimeLimits.getCapacity();
         } else {
             RateLimitingProperties.EndpointLimits adminLimits = properties.getAdmin();
-            bucket = adminBuckets.computeIfAbsent(clientIp, k -> buildBucket(adminLimits));
+            bucket = bucketFor(adminBuckets, clientIp, adminLimits);
             limit = adminLimits.getCapacity();
         }
 
@@ -118,6 +118,23 @@ public class RateLimitingFilter extends OncePerRequestFilter {
                 + "\"retryAfterSeconds\":%d}",
                 retryAfterSeconds, retryAfterSeconds));
         }
+    }
+
+    private Bucket bucketFor(ConcurrentHashMap<String, Bucket> buckets, String clientIp,
+            RateLimitingProperties.EndpointLimits limits) {
+        int maxBuckets = properties.getMaxBucketsPerGroup();
+        if (!buckets.containsKey(clientIp) && maxBuckets > 0 && buckets.size() >= maxBuckets) {
+            buckets.keySet().stream().findAny().ifPresent(buckets::remove);
+        }
+        return buckets.computeIfAbsent(clientIp, k -> buildBucket(limits));
+    }
+
+    int adminBucketCount() {
+        return adminBuckets.size();
+    }
+
+    int runtimeBucketCount() {
+        return runtimeBuckets.size();
     }
 
     private Bucket buildBucket(RateLimitingProperties.EndpointLimits limits) {

--- a/src/main/java/com/liftsimulator/admin/config/RateLimitingProperties.java
+++ b/src/main/java/com/liftsimulator/admin/config/RateLimitingProperties.java
@@ -32,6 +32,7 @@ public class RateLimitingProperties {
 
     private boolean enabled = true;
     private boolean trustForwardedFor = false;
+    private int maxBucketsPerGroup = 10_000;
     private EndpointLimits admin = new EndpointLimits(100, 100, 60);
     private EndpointLimits runtime = new EndpointLimits(1000, 1000, 60);
 
@@ -49,6 +50,14 @@ public class RateLimitingProperties {
 
     public void setTrustForwardedFor(boolean trustForwardedFor) {
         this.trustForwardedFor = trustForwardedFor;
+    }
+
+    public int getMaxBucketsPerGroup() {
+        return maxBucketsPerGroup;
+    }
+
+    public void setMaxBucketsPerGroup(int maxBucketsPerGroup) {
+        this.maxBucketsPerGroup = maxBucketsPerGroup;
     }
 
     @SuppressFBWarnings(

--- a/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
+++ b/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
@@ -12,6 +12,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +22,8 @@ import java.nio.charset.StandardCharsets;
  * Rejects oversized API request bodies before JSON deserialization can allocate unbounded memory.
  */
 public class RequestSizeLimitFilter extends OncePerRequestFilter {
+
+    private static final int BUFFER_SIZE = 8192;
 
     private final RequestSizeLimitProperties properties;
 
@@ -47,11 +51,30 @@ public class RequestSizeLimitFilter extends OncePerRequestFilter {
             return;
         }
 
-        try {
-            filterChain.doFilter(new LimitedBodyRequest(request, maxBodyBytes), response);
-        } catch (PayloadTooLargeException e) {
+        byte[] body = readBodyWithinLimit(request, maxBodyBytes);
+        if (body == null) {
             writePayloadTooLarge(response, maxBodyBytes);
+            return;
         }
+
+        filterChain.doFilter(new CachedBodyRequest(request, body), response);
+    }
+
+    private byte[] readBodyWithinLimit(HttpServletRequest request, long maxBodyBytes) throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        byte[] buffer = new byte[BUFFER_SIZE];
+        long bytesRead = 0;
+        int read;
+        try (ServletInputStream inputStream = request.getInputStream()) {
+            while ((read = inputStream.read(buffer)) != -1) {
+                bytesRead += read;
+                if (bytesRead > maxBodyBytes) {
+                    return null;
+                }
+                body.write(buffer, 0, read);
+            }
+        }
+        return body.toByteArray();
     }
 
     private void writePayloadTooLarge(
@@ -65,78 +88,67 @@ public class RequestSizeLimitFilter extends OncePerRequestFilter {
             maxBodyBytes));
     }
 
-    private static final class LimitedBodyRequest extends HttpServletRequestWrapper {
-        private final long maxBodyBytes;
+    private static final class CachedBodyRequest extends HttpServletRequestWrapper {
+        private final byte[] body;
 
-        private LimitedBodyRequest(HttpServletRequest request, long maxBodyBytes) {
+        private CachedBodyRequest(HttpServletRequest request, byte[] body) {
             super(request);
-            this.maxBodyBytes = maxBodyBytes;
+            this.body = body.clone();
         }
 
         @Override
-        public ServletInputStream getInputStream() throws IOException {
-            return new LimitedServletInputStream(super.getInputStream(), maxBodyBytes);
+        public ServletInputStream getInputStream() {
+            return new CachedBodyServletInputStream(body);
         }
 
         @Override
-        public BufferedReader getReader() throws IOException {
+        public BufferedReader getReader() {
             return new BufferedReader(
                 new InputStreamReader(getInputStream(), StandardCharsets.UTF_8)
             );
         }
+
+        @Override
+        public int getContentLength() {
+            return body.length;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return body.length;
+        }
     }
 
-    private static final class LimitedServletInputStream extends ServletInputStream {
-        private final ServletInputStream delegate;
-        private final long maxBodyBytes;
-        private long bytesRead;
+    private static final class CachedBodyServletInputStream extends ServletInputStream {
+        private final ByteArrayInputStream delegate;
 
-        private LimitedServletInputStream(ServletInputStream delegate, long maxBodyBytes) {
-            this.delegate = delegate;
-            this.maxBodyBytes = maxBodyBytes;
+        private CachedBodyServletInputStream(byte[] body) {
+            this.delegate = new ByteArrayInputStream(body);
         }
 
         @Override
-        public int read() throws IOException {
-            int value = delegate.read();
-            if (value != -1) {
-                incrementAndCheck(1);
-            }
-            return value;
+        public int read() {
+            return delegate.read();
         }
 
         @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            int read = delegate.read(b, off, len);
-            if (read > 0) {
-                incrementAndCheck(read);
-            }
-            return read;
+        public int read(byte[] b, int off, int len) {
+            return delegate.read(b, off, len);
         }
 
         @Override
         public boolean isFinished() {
-            return delegate.isFinished();
+            return delegate.available() == 0;
         }
 
         @Override
         public boolean isReady() {
-            return delegate.isReady();
+            return true;
         }
 
         @Override
         public void setReadListener(ReadListener readListener) {
-            delegate.setReadListener(readListener);
+            throw new UnsupportedOperationException("Asynchronous reads are not supported");
         }
-
-        private void incrementAndCheck(int count) throws IOException {
-            bytesRead += count;
-            if (bytesRead > maxBodyBytes) {
-                throw new PayloadTooLargeException();
-            }
-        }
-    }
-
-    private static final class PayloadTooLargeException extends IOException {
     }
 }

--- a/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
+++ b/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
@@ -1,5 +1,6 @@
 package com.liftsimulator.admin.config;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.ServletException;
@@ -27,6 +28,10 @@ public class RequestSizeLimitFilter extends OncePerRequestFilter {
 
     private final RequestSizeLimitProperties properties;
 
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "RequestSizeLimitProperties is a Spring-managed singleton bound via "
+                    + "@ConfigurationProperties. Defensive copying would break property binding.")
     public RequestSizeLimitFilter(RequestSizeLimitProperties properties) {
         this.properties = properties;
     }

--- a/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
+++ b/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
@@ -1,0 +1,142 @@
+package com.liftsimulator.admin.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Rejects oversized API request bodies before JSON deserialization can allocate unbounded memory.
+ */
+public class RequestSizeLimitFilter extends OncePerRequestFilter {
+
+    private final RequestSizeLimitProperties properties;
+
+    public RequestSizeLimitFilter(RequestSizeLimitProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !properties.isEnabled()
+            || properties.getMaxBodyBytes() <= 0
+            || (!request.getRequestURI().startsWith("/api/v1/")
+                && !request.getRequestURI().startsWith("/actuator/"));
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        long maxBodyBytes = properties.getMaxBodyBytes();
+        long contentLength = request.getContentLengthLong();
+        if (contentLength > maxBodyBytes) {
+            writePayloadTooLarge(response, maxBodyBytes);
+            return;
+        }
+
+        try {
+            filterChain.doFilter(new LimitedBodyRequest(request, maxBodyBytes), response);
+        } catch (PayloadTooLargeException e) {
+            writePayloadTooLarge(response, maxBodyBytes);
+        }
+    }
+
+    private void writePayloadTooLarge(
+            HttpServletResponse response,
+            long maxBodyBytes) throws IOException {
+        response.setStatus(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(String.format(
+            "{\"status\":413,\"error\":\"Payload Too Large\","
+                + "\"message\":\"Request body exceeds the %d byte limit.\"}",
+            maxBodyBytes));
+    }
+
+    private static final class LimitedBodyRequest extends HttpServletRequestWrapper {
+        private final long maxBodyBytes;
+
+        private LimitedBodyRequest(HttpServletRequest request, long maxBodyBytes) {
+            super(request);
+            this.maxBodyBytes = maxBodyBytes;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return new LimitedServletInputStream(super.getInputStream(), maxBodyBytes);
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return new BufferedReader(
+                new InputStreamReader(getInputStream(), StandardCharsets.UTF_8)
+            );
+        }
+    }
+
+    private static final class LimitedServletInputStream extends ServletInputStream {
+        private final ServletInputStream delegate;
+        private final long maxBodyBytes;
+        private long bytesRead;
+
+        private LimitedServletInputStream(ServletInputStream delegate, long maxBodyBytes) {
+            this.delegate = delegate;
+            this.maxBodyBytes = maxBodyBytes;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = delegate.read();
+            if (value != -1) {
+                incrementAndCheck(1);
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int read = delegate.read(b, off, len);
+            if (read > 0) {
+                incrementAndCheck(read);
+            }
+            return read;
+        }
+
+        @Override
+        public boolean isFinished() {
+            return delegate.isFinished();
+        }
+
+        @Override
+        public boolean isReady() {
+            return delegate.isReady();
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            delegate.setReadListener(readListener);
+        }
+
+        private void incrementAndCheck(int count) throws IOException {
+            bytesRead += count;
+            if (bytesRead > maxBodyBytes) {
+                throw new PayloadTooLargeException();
+            }
+        }
+    }
+
+    private static final class PayloadTooLargeException extends IOException {
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitProperties.java
+++ b/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitProperties.java
@@ -1,0 +1,29 @@
+package com.liftsimulator.admin.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for inbound request body size limits.
+ */
+@ConfigurationProperties(prefix = "request-size-limits")
+public class RequestSizeLimitProperties {
+
+    private boolean enabled = true;
+    private long maxBodyBytes = 1_048_576;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public long getMaxBodyBytes() {
+        return maxBodyBytes;
+    }
+
+    public void setMaxBodyBytes(long maxBodyBytes) {
+        this.maxBodyBytes = maxBodyBytes;
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
@@ -32,6 +32,8 @@ public class ArtefactService {
     private static final Logger logger = LoggerFactory.getLogger(ArtefactService.class);
     private static final int DEFAULT_TAIL_LINES = 100;
     private static final int MAX_TAIL_LINES = 10000;
+    private static final long MAX_LOG_BYTES = 1_048_576L;
+    private static final long MAX_RESULTS_BYTES = 1_048_576L;
 
     private final ObjectMapper objectMapper;
 
@@ -218,7 +220,7 @@ public class ArtefactService {
         int linesToRead = tail != null ? Math.min(tail, MAX_TAIL_LINES) : -1;
 
         if (linesToRead < 0) {
-            // Read entire file
+            ensureFileSizeWithinLimit(logPath, MAX_LOG_BYTES, "Log file");
             return Files.readString(logPath);
         } else {
             // Read last N lines
@@ -255,7 +257,15 @@ public class ArtefactService {
             throw new IOException("No results file found for simulation run " + run.getId());
         }
 
+        ensureFileSizeWithinLimit(resultsPath, MAX_RESULTS_BYTES, "Results file");
         return objectMapper.readTree(resultsPath.toFile());
+    }
+
+    private void ensureFileSizeWithinLimit(Path path, long maxBytes, String label) throws IOException {
+        long size = Files.size(path);
+        if (size > maxBytes) {
+            throw new IOException(label + " exceeds the " + maxBytes + " byte read limit: " + path.getFileName());
+        }
     }
 
     private boolean isSafeRegularFile(Path path, Path realDirectory) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,7 @@ api:
 rate-limiting:
   enabled: true
   trust-forwarded-for: false
+  max-buckets-per-group: 10000
   admin:
     capacity: 100
     refill-tokens: 100
@@ -94,6 +95,11 @@ rate-limiting:
     capacity: 1000
     refill-tokens: 1000
     refill-period-seconds: 60
+
+# Request Size Limits
+request-size-limits:
+  enabled: true
+  max-body-bytes: 1048576
 
 # OpenAPI / Swagger Configuration
 springdoc:

--- a/src/test/java/com/liftsimulator/admin/config/RateLimitingConfigTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/RateLimitingConfigTest.java
@@ -9,6 +9,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RateLimitingConfigTest {
 
     @Test
+    void requestSizeLimitFilterRegistration_IncludesApiAndActuatorUrlPatternsBeforeRateLimit() {
+        RateLimitingConfig config = new RateLimitingConfig();
+        RequestSizeLimitProperties properties = new RequestSizeLimitProperties();
+
+        FilterRegistrationBean<RequestSizeLimitFilter> registration =
+            config.requestSizeLimitFilterRegistration(properties);
+
+        assertThat(registration.getUrlPatterns())
+            .containsExactlyInAnyOrder("/api/v1/*", "/actuator/*");
+        assertThat(registration.getOrder()).isEqualTo(SecurityProperties.DEFAULT_FILTER_ORDER - 2);
+        assertThat(registration.getFilter()).isInstanceOf(RequestSizeLimitFilter.class);
+    }
+
+    @Test
     void rateLimitingFilterRegistration_IncludesApiAndActuatorUrlPatterns() {
         RateLimitingConfig config = new RateLimitingConfig();
         RateLimitingProperties properties = new RateLimitingProperties();

--- a/src/test/java/com/liftsimulator/admin/config/RateLimitingTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/RateLimitingTest.java
@@ -228,6 +228,30 @@ class RateLimitingTest {
     }
 
     @Test
+    void doFilter_EvictsBucketsWhenGroupLimitIsReached() throws Exception {
+        properties.setMaxBucketsPerGroup(2);
+
+        for (int i = 0; i < 4; i++) {
+            MockHttpServletRequest request = buildRequest("/api/v1/lift-systems", "198.51.100." + i);
+            filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+        }
+
+        assertThat(filter.adminBucketCount()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void doFilter_EvictsRuntimeBucketsWhenGroupLimitIsReached() throws Exception {
+        properties.setMaxBucketsPerGroup(2);
+
+        for (int i = 0; i < 4; i++) {
+            MockHttpServletRequest request = buildRequest("/api/v1/runtime/systems/test/config", "203.0.113." + i);
+            filter.doFilter(request, new MockHttpServletResponse(), filterChain);
+        }
+
+        assertThat(filter.runtimeBucketCount()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
     void doFilter_AdminAndRuntimeBuckets_AreIndependent() throws Exception {
         // Exhaust admin bucket for this IP
         for (int i = 0; i < 2; i++) {

--- a/src/test/java/com/liftsimulator/admin/config/RequestSizeLimitFilterTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/RequestSizeLimitFilterTest.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.config;
 
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -48,14 +50,45 @@ class RequestSizeLimitFilterTest {
     }
 
     @Test
+    void doFilterRejectsOversizedStreamBeforeDispatch() throws Exception {
+        MockHttpServletRequest request = new UnknownLengthRequest("POST", "/api/v1/lift-systems");
+        request.setContent("too-large".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        assertThat(response.getContentAsString()).contains("Request body exceeds");
+        verify(filterChain, never()).doFilter(any(), eq(response));
+    }
+
+    @Test
     void doFilterAllowsRequestsWithinLimit() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/lift-systems");
         request.setContent("ok".getBytes(StandardCharsets.UTF_8));
         MockHttpServletResponse response = new MockHttpServletResponse();
 
+        doAnswer(invocation -> {
+            ServletRequest wrappedRequest = invocation.getArgument(0);
+            byte[] body = wrappedRequest.getInputStream().readAllBytes();
+            assertThat(new String(body, StandardCharsets.UTF_8)).isEqualTo("ok");
+            return null;
+        }).when(filterChain).doFilter(any(), eq(response));
+
         filter.doFilter(request, response, filterChain);
 
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
         verify(filterChain).doFilter(any(), eq(response));
+    }
+
+    private static final class UnknownLengthRequest extends MockHttpServletRequest {
+        private UnknownLengthRequest(String method, String requestUri) {
+            super(method, requestUri);
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return -1;
+        }
     }
 }

--- a/src/test/java/com/liftsimulator/admin/config/RequestSizeLimitFilterTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/RequestSizeLimitFilterTest.java
@@ -1,0 +1,61 @@
+package com.liftsimulator.admin.config;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RequestSizeLimitFilterTest {
+
+    @Mock
+    private FilterChain filterChain;
+
+    private RequestSizeLimitProperties properties;
+    private RequestSizeLimitFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        properties = new RequestSizeLimitProperties();
+        properties.setMaxBodyBytes(8);
+        filter = new RequestSizeLimitFilter(properties);
+    }
+
+    @Test
+    void doFilterRejectsOversizedContentLength() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/lift-systems");
+        request.setContent("too-large".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        assertThat(response.getContentAsString()).contains("Request body exceeds");
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterAllowsRequestsWithinLimit() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/v1/lift-systems");
+        request.setContent("ok".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+        verify(filterChain).doFilter(any(), eq(response));
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
@@ -130,7 +130,7 @@ class ArtefactServiceTest {
 
     @Test
     void readResultsRejectsOversizedResultsFile() throws IOException {
-        Files.writeString(tempDir.resolve("results.json"), "{"data":"" + "x".repeat(1_048_577) + ""}");
+        Files.writeString(tempDir.resolve("results.json"), "{\"data\":\"" + "x".repeat(1_048_577) + "\"}");
 
         IOException exception = assertThrows(
             IOException.class,

--- a/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
@@ -129,6 +129,18 @@ class ArtefactServiceTest {
     }
 
     @Test
+    void readResultsRejectsOversizedResultsFile() throws IOException {
+        Files.writeString(tempDir.resolve("results.json"), "{"data":"" + "x".repeat(1_048_577) + ""}");
+
+        IOException exception = assertThrows(
+            IOException.class,
+            () -> artefactService.readResults(runForTempDir())
+        );
+
+        assertTrue(exception.getMessage().contains("Results file exceeds"));
+    }
+
+    @Test
     void readResultsThrowsWhenResultsFileIsMissing() {
         IOException exception = assertThrows(
             IOException.class,
@@ -143,6 +155,18 @@ class ArtefactServiceTest {
         String logs = artefactService.readLogs(runForTempDir(), 25);
 
         assertEquals("No log file found for simulation run 1", logs);
+    }
+
+    @Test
+    void readLogsRejectsOversizedFullLogRead() throws IOException {
+        Files.writeString(tempDir.resolve("simulation.log"), "x".repeat(1_048_577));
+
+        IOException exception = assertThrows(
+            IOException.class,
+            () -> artefactService.readLogs(runForTempDir(), null)
+        );
+
+        assertTrue(exception.getMessage().contains("Log file exceeds"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Harden the backend against DoS by preventing unbounded growth and unbounded reads: rate-limit bucket maps could grow without bound, request bodies/JSON could be arbitrarily large or deeply nested, and artefact/log reads could materialize huge files into memory.
- Provide configurable, conservative defaults that reject oversized payloads early and constrain JSON parser resource usage to avoid CPU/heap exhaustion.
- Document the operational limits so operators can tune them per environment.

### Description
- Add `RequestSizeLimitProperties` and `RequestSizeLimitFilter` to reject oversized API/actuator request bodies (HTTP 413) and stream-enforce a `max-body-bytes` limit before JSON deserialization. The filter is registered to run before the rate limiter.
- Add `maxBucketsPerGroup` to `RateLimitingProperties` and implement eviction in `RateLimitingFilter` so admin/runtime bucket maps are capped; provide helper accessors for tests (`adminBucketCount`, `runtimeBucketCount`).
- Constrain Jackson JSON parsing by setting `StreamReadConstraints` (max nesting depth and max string length) via `JacksonConfiguration` to mitigate deeply nested/huge JSON objects.
- Bound artefact reads in `ArtefactService` by enforcing byte-size limits for full log reads and `results.json` parsing (default 1 MiB) and add `ensureFileSizeWithinLimit` to centralise the check while preserving existing tail-by-lines behaviour.
- Update `RateLimitingConfig` to register the new request-size filter and enable configuration binding for the new properties.
- Documentation: update `README.md` and `CHANGELOG.md` to describe new configuration options and the DoS hardening changes.
- Tests: add and/or extend focused unit tests for the new behaviour (`RequestSizeLimitFilterTest`, updated `RateLimitingTest` with eviction checks, updated `RateLimitingConfigTest`, and additional `ArtefactServiceTest` cases for oversized reads).

### Testing
- Ran `git diff --check` to validate formatting and diff hygiene (no issues).
- Added unit tests covering request-size rejection, rate-limit-bucket eviction, config filter registration, and oversized artefact reads; these tests are included under `src/test/java/...` (`RequestSizeLimitFilterTest`, additions to `RateLimitingTest`, `RateLimitingConfigTest`, `ArtefactServiceTest`).
- Attempted to run targeted Maven unit tests (`mvn -Dtest=RateLimitingTest,RateLimitingConfigTest,RequestSizeLimitFilterTest,ArtefactServiceTest test`) but the CI-local Maven invocation was blocked by dependency resolution (failed to fetch Spring Boot parent POM from Maven Central; HTTP 403 in this environment), so full automated test execution could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37f245100083258eec4955f61a1462)