### PR TITLE
fix(ci): validate backend test schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         SPRING_DATASOURCE_USERNAME: lift_admin
         SPRING_DATASOURCE_PASSWORD: liftpassword
         PGPASSWORD: liftpassword
-        SPRING_JPA_HIBERNATE_DDL_AUTO: update
+        SPRING_JPA_HIBERNATE_DDL_AUTO: validate
         SPRING_JPA_PROPERTIES_HIBERNATE_HBM2DDL_CREATE_NAMESPACES: 'false'
 
     - name: Upload JaCoCo HTML report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 ### Fixed
+- **CI backend schema validation parity**: Changed the backend CI verify job to use Hibernate `ddl-auto=validate` instead of `update`, keeping CI aligned with the test profile and Flyway-owned schema management documented elsewhere. Updated README CI testing guidance.
 - **Frontend credential exposure hardening**: Replaced raw Axios error console logging with sanitized API-error details that omit request config and auth headers, documented that Vite-bundled credentials are local-development conveniences only and must not be used as a hosted SPA security boundary, refreshed JAR examples in the developer/workflow docs, and synchronized package metadata for the 0.52.16 patch release.
 - **DoS hardening for request and artefact reads**: Capped retained per-IP rate-limit buckets, added a configurable API request-body limit that rejects oversized JSON payloads with HTTP 413, constrained Jackson JSON nesting/string sizes, and bounded full simulation log/results artefact reads to prevent unbounded memory use. Updated README operational guidance for the new limits.
 - **Private OpenAPI default**: The base `application.yml` and `SecurityConfig` code fallback now default `security.openapi.public-access` to private access (`false`), keeping Swagger UI and `/api-docs` ADMIN-only unless an environment or profile explicitly opts into public documentation access. Updated README guidance and synchronized package metadata for the 0.52.15 patch release.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 # Terminal 2: frontend/
 E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD=local-admin-password E2E_API_KEY=local-api-key npm test
 ```
-In CI, the `e2e-playwright` job packages the backend with `mvn -Pfrontend package -DskipTests`, starts the packaged application, waits for `/api/v1/health` and the React root page, and runs `npm test` in `frontend/`.
+In CI, the backend test job runs with `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`, matching the checked-in test and runtime profile strategy so Flyway migrations remain the only source of schema changes and mapping drift fails the build. The `e2e-playwright` job packages the backend with `mvn -Pfrontend package -DskipTests`, starts the packaged application, waits for `/api/v1/health` and the React root page, and runs `npm test` in `frontend/`.
 
 ## Quality Checks
 


### PR DESCRIPTION
### Motivation
- Align CI backend test job with the repository's Flyway-first schema strategy so Hibernate does not mutate the database schema during tests, preventing silent schema drift and race conditions.

### Description
- Changed the backend CI verify job environment in `.github/workflows/ci.yml` from `SPRING_JPA_HIBERNATE_DDL_AUTO: update` to `SPRING_JPA_HIBERNATE_DDL_AUTO: validate` so Hibernate validates mappings instead of updating tables.
- Updated `README.md` testing guidance to document that the CI backend test job runs with `SPRING_JPA_HIBERNATE_DDL_AUTO=validate` and that Flyway remains the source of schema changes.
- Added an Unreleased entry to `CHANGELOG.md` describing the CI schema-validation parity fix.

### Testing
- Ran `git diff --check` to validate repository changes and whitespace; the check passed.
- Attempted `mvn -q -DskipTests compile` to verify the build, but execution was blocked by the environment resolving Maven Central (HTTP 403 for `org.springframework.boot:spring-boot-starter-parent:pom:3.4.13`), so no Maven test/compile phase completed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38059d326c8325aa4882a3a6c65840)