### PR TITLE
Add validation to enforce single lift requirement in v1.0.0

### DIFF
--- a/frontend/e2e/configuration-versions.spec.ts
+++ b/frontend/e2e/configuration-versions.spec.ts
@@ -104,19 +104,20 @@ test.describe('Configuration Version Management', () => {
     await expect(page.locator('.version-config-grid')).toBeVisible();
     await expect(page.locator('#config')).toBeHidden();
 
-    // Fields are pre-filled with sensible defaults; adjust the number of lifts
+    // Fields are pre-filled with sensible defaults
     const liftsInput = page.locator('#vcf-lifts');
     await expect(liftsInput).toBeVisible();
-    await liftsInput.fill('3');
+    // v1.0.0 supports only 1 lift
+    await expect(liftsInput).toHaveValue('1');
 
     // Switching to Advanced (JSON) preserves the entered data
     await page.locator('.editor-mode-toggle button:has-text("Advanced")').click();
     const jsonValue = await page.locator('#config').inputValue();
-    expect(jsonValue).toContain('"lifts": 3');
+    expect(jsonValue).toContain('"lifts": 1');
 
     // Switching back to the guided form retains the value
     await page.locator('.editor-mode-toggle button:has-text("Guided")').click();
-    await expect(page.locator('#vcf-lifts')).toHaveValue('3');
+    await expect(page.locator('#vcf-lifts')).toHaveValue('1');
 
     // Validate and create the version from the guided form
     await page.locator('.create-version-form button:has-text("Validate")').click();

--- a/frontend/e2e/helpers/test-helpers.ts
+++ b/frontend/e2e/helpers/test-helpers.ts
@@ -12,7 +12,7 @@ export const VALID_CONFIGS = {
   basicOffice: {
     minFloor: 0,
     maxFloor: 9,
-    lifts: 2,
+    lifts: 1,
     travelTicksPerFloor: 1,
     doorTransitionTicks: 2,
     doorDwellTicks: 3,
@@ -25,7 +25,7 @@ export const VALID_CONFIGS = {
   highRiseResidential: {
     minFloor: 0,
     maxFloor: 29,
-    lifts: 4,
+    lifts: 1,
     travelTicksPerFloor: 2,
     doorTransitionTicks: 3,
     doorDwellTicks: 5,
@@ -51,7 +51,7 @@ export const VALID_CONFIGS = {
   large: {
     minFloor: 0,
     maxFloor: 99,
-    lifts: 8,
+    lifts: 1,
     travelTicksPerFloor: 3,
     doorTransitionTicks: 4,
     doorDwellTicks: 6,
@@ -96,7 +96,7 @@ export const INVALID_CONFIGS = {
   homeFloorOutOfBounds: {
     minFloor: 0,
     maxFloor: 9,
-    lifts: 2,
+    lifts: 1,
     travelTicksPerFloor: 1,
     doorTransitionTicks: 2,
     doorDwellTicks: 3,

--- a/frontend/src/utils/configSchemaHelp.js
+++ b/frontend/src/utils/configSchemaHelp.js
@@ -1,7 +1,7 @@
 export const CONFIG_EXAMPLE = {
   minFloor: 0,
   maxFloor: 9,
-  lifts: 2,
+  lifts: 1,
   travelTicksPerFloor: 1,
   doorTransitionTicks: 2,
   doorDwellTicks: 3,

--- a/frontend/src/utils/versionConfigSchema.js
+++ b/frontend/src/utils/versionConfigSchema.js
@@ -38,6 +38,7 @@ export const IDLE_PARKING_MODE_OPTIONS = [
  * @property {'number'|'select'} type - Input control type.
  * @property {string} help - Inline help text describing the field.
  * @property {number} [min] - Minimum allowed value for numeric fields.
+ * @property {number} [max] - Maximum allowed value for numeric fields.
  * @property {Array<{value: string, label: string}>} [options] - Select options.
  */
 
@@ -66,7 +67,8 @@ export const VERSION_CONFIG_FIELDS = [
     label: 'Number of Lifts',
     type: FIELD_TYPE_NUMBER,
     min: 1,
-    help: 'How many lift cars the system has (at least 1).'
+    max: 1,
+    help: 'Number of lifts (v1.0.0 supports exactly 1 lift; multi-lift support coming in future versions).'
   },
   {
     name: 'travelTicksPerFloor',
@@ -225,6 +227,10 @@ export function validateVersionFormData(formData) {
     const value = Number(trimmed);
     if (field.min !== undefined && value < field.min) {
       errors[field.name] = `${field.label} must be at least ${field.min}.`;
+      continue;
+    }
+    if (field.max !== undefined && value > field.max) {
+      errors[field.name] = `${field.label} must be at most ${field.max}.`;
       continue;
     }
     numbers[field.name] = value;

--- a/src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java
@@ -212,6 +212,15 @@ public class ConfigValidationService {
             ));
         }
 
+        // Validate that lifts == 1 (multi-lift simulation not supported in v1.0.0)
+        if (config.lifts() != 1) {
+            errors.add(new ValidationIssue(
+                "lifts",
+                "Number of lifts must be 1. Multi-lift simulation is not supported in v1.0.0.",
+                ValidationIssue.Severity.ERROR
+            ));
+        }
+
         // Warning: If number of lifts is greater than number of floors
         if (config.maxFloor() > config.minFloor()) {
             int floorCount = config.maxFloor() - config.minFloor() + 1;

--- a/src/main/resources/scenarios/basic-office-building.json
+++ b/src/main/resources/scenarios/basic-office-building.json
@@ -1,7 +1,7 @@
 {
   "minFloor": 0,
   "maxFloor": 9,
-  "lifts": 2,
+  "lifts": 1,
   "travelTicksPerFloor": 1,
   "doorTransitionTicks": 2,
   "doorDwellTicks": 3,

--- a/src/main/resources/scenarios/high-rise-residential.json
+++ b/src/main/resources/scenarios/high-rise-residential.json
@@ -1,7 +1,7 @@
 {
   "minFloor": 0,
   "maxFloor": 29,
-  "lifts": 4,
+  "lifts": 1,
   "travelTicksPerFloor": 2,
   "doorTransitionTicks": 3,
   "doorDwellTicks": 5,

--- a/src/test/java/com/liftsimulator/admin/controller/LiftSystemVersionControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/LiftSystemVersionControllerTest.java
@@ -66,7 +66,7 @@ public class LiftSystemVersionControllerTest extends LocalIntegrationTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -87,7 +87,7 @@ public class LiftSystemVersionControllerTest extends LocalIntegrationTest {
             {
                 "minFloor": %d,
                 "maxFloor": %d,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -89,7 +89,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
         testSystem = liftSystemRepository.save(testSystem);
 
         testVersion = new LiftSystemVersion(testSystem, 1,
-            "{\"minFloor\": 0, \"maxFloor\": 10, \"lifts\": 2, \"travelTicksPerFloor\": 1, " +
+            "{\"minFloor\": 0, \"maxFloor\": 10, \"lifts\": 1, \"travelTicksPerFloor\": 1, " +
             "\"doorTransitionTicks\": 2, \"doorDwellTicks\": 3, \"doorReopenWindowTicks\": 2, " +
             "\"homeFloor\": 0, \"idleTimeoutTicks\": 5, \"controllerStrategy\": \"NEAREST_REQUEST_ROUTING\", " +
             "\"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}");

--- a/src/test/java/com/liftsimulator/admin/controller/fixtures/ControllerApiFixtures.java
+++ b/src/test/java/com/liftsimulator/admin/controller/fixtures/ControllerApiFixtures.java
@@ -13,7 +13,7 @@ public final class ControllerApiFixtures {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -98,7 +98,7 @@ public final class ControllerApiFixtures {
             {
                 "minFloor": 5,
                 "maxFloor": 5,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -116,7 +116,7 @@ public final class ControllerApiFixtures {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,

--- a/src/test/java/com/liftsimulator/admin/service/ConfigValidationServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ConfigValidationServiceTest.java
@@ -37,7 +37,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -89,7 +89,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 0,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -143,7 +143,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -171,7 +171,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -199,7 +199,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -223,7 +223,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -251,7 +251,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 1,
@@ -274,12 +274,12 @@ public class ConfigValidationServiceTest {
     }
 
     @Test
-    public void testValidate_WarningForMoreLiftsThanFloors() {
+    public void testValidate_ErrorForMultipleLifts() {
         String config = """
             {
                 "minFloor": 0,
                 "maxFloor": 4,
-                "lifts": 10,
+                "lifts": 2,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -293,12 +293,13 @@ public class ConfigValidationServiceTest {
 
         ConfigValidationResponse response = validationService.validate(config);
 
-        assertTrue(response.valid());
-        assertTrue(response.hasWarnings());
-        boolean hasLiftsWarning = response.warnings().stream()
+        assertFalse(response.valid());
+        assertTrue(response.hasErrors());
+        boolean hasLiftsError = response.errors().stream()
             .anyMatch(issue -> issue.field().equals("lifts")
-                && issue.severity() == ValidationIssue.Severity.WARNING);
-        assertTrue(hasLiftsWarning);
+                && issue.message().contains("must be 1")
+                && issue.severity() == ValidationIssue.Severity.ERROR);
+        assertTrue(hasLiftsError);
     }
 
     @Test
@@ -307,7 +308,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -360,7 +361,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -386,7 +387,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -416,7 +417,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFlor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -444,7 +445,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -475,7 +476,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": 0,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 5,
                 "doorTransitionTicks": 3,
                 "doorDwellTicks": 4,
@@ -503,7 +504,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": "A",
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -587,7 +588,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": true,
                 "maxFloor": 9,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,
@@ -615,7 +616,7 @@ public class ConfigValidationServiceTest {
             {
                 "minFloor": -2,
                 "maxFloor": 5,
-                "lifts": 2,
+                "lifts": 1,
                 "travelTicksPerFloor": 1,
                 "doorTransitionTicks": 2,
                 "doorDwellTicks": 3,

--- a/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
@@ -41,7 +41,7 @@ public class ScenarioServiceTest {
         {
             "minFloor": 0,
             "maxFloor": 9,
-            "lifts": 2,
+            "lifts": 1,
             "travelTicksPerFloor": 1,
             "doorTransitionTicks": 2,
             "doorDwellTicks": 3,

--- a/src/test/java/com/liftsimulator/admin/service/ScenarioValidationServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ScenarioValidationServiceTest.java
@@ -35,7 +35,7 @@ public class ScenarioValidationServiceTest {
         {
             "minFloor": 0,
             "maxFloor": 9,
-            "lifts": 2,
+            "lifts": 1,
             "travelTicksPerFloor": 1,
             "doorTransitionTicks": 2,
             "doorDwellTicks": 3,


### PR DESCRIPTION
## Summary
Added validation to enforce that only single-lift simulations are supported in v1.0.0. Multi-lift configurations are now rejected with a clear error message during configuration validation.

## Key Changes
- Added validation check in `ConfigValidationService.performDomainValidation()` to ensure `config.lifts()` equals 1
- Returns an ERROR severity `ValidationIssue` when multi-lift configurations are detected
- Provides clear user-facing error message explaining that multi-lift simulation is not supported in v1.0.0

## Implementation Details
- The validation is placed in the domain validation section alongside other configuration constraints
- Uses the existing `ValidationIssue` framework with ERROR severity to prevent invalid configurations from being accepted
- This is a temporary constraint for the v1.0.0 release, allowing for future multi-lift support

https://claude.ai/code/session_01DVR6EuLCFwjAkn8oWMuZnN