### PR TITLE
Add validation for scenario name in ScenarioRequest

### DIFF
--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioRequest.java
@@ -1,13 +1,16 @@
 package com.liftsimulator.admin.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 /**
  * Request DTO for creating or updating scenarios.
  */
 public record ScenarioRequest(
-    @NotNull(message = "Name is required")
+    @NotBlank(message = "Name is required")
+    @Size(max = 200, message = "Name must not exceed 200 characters")
     String name,
     @NotNull(message = "Scenario JSON is required")
     JsonNode scenarioJson,

--- a/src/test/java/com/liftsimulator/admin/controller/ScenarioControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/ScenarioControllerTest.java
@@ -195,6 +195,33 @@ public class ScenarioControllerTest extends LocalIntegrationTest {
     }
 
     @Test
+    public void testCreateScenario_BlankName_ReturnsBadRequest() throws Exception {
+        ScenarioRequest request = scenarioRequest("   ", ControllerApiFixtures.validScenario());
+
+        mockMvc.perform(post("/api/v1/scenarios")
+                .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors.name").value("Name is required"));
+    }
+
+    @Test
+    public void testCreateScenario_NameExceedsMaxLength_ReturnsBadRequest() throws Exception {
+        String longName = "A".repeat(201);
+        ScenarioRequest request = scenarioRequest(longName, ControllerApiFixtures.validScenario());
+
+        mockMvc.perform(post("/api/v1/scenarios")
+                .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors.name").value("Name must not exceed 200 characters"));
+    }
+
+    @Test
     public void testCreateScenario_MissingRequiredRequestFields() throws Exception {
         mockMvc.perform(post("/api/v1/scenarios")
                 .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD))


### PR DESCRIPTION
## Summary
Enhanced input validation for scenario creation by adding constraints to the scenario name field to ensure it is not blank and does not exceed a maximum length of 200 characters.

## Key Changes
- Updated `ScenarioRequest.java`:
  - Changed `@NotNull` to `@NotBlank` for the name field to reject blank/whitespace-only strings
  - Added `@Size(max = 200)` constraint to enforce maximum name length of 200 characters
  - Updated validation error messages to be more specific

- Added test coverage in `ScenarioControllerTest.java`:
  - `testCreateScenario_BlankName_ReturnsBadRequest()`: Validates that blank names (whitespace-only) are rejected with appropriate error message
  - `testCreateScenario_NameExceedsMaxLength_ReturnsBadRequest()`: Validates that names exceeding 200 characters are rejected with appropriate error message

## Implementation Details
The validation is now enforced at the DTO level using Jakarta Bean Validation annotations, ensuring that invalid scenario names are caught early and return a 400 Bad Request response with clear field-level error messages to the client.

https://claude.ai/code/session_01AnPEBSoCect3fKqMGb6HGS