### PR TITLE
Create ScenarioValidateRequest DTO for validation endpoint

### DIFF
--- a/frontend/src/pages/ScenarioForm.jsx
+++ b/frontend/src/pages/ScenarioForm.jsx
@@ -408,7 +408,6 @@ function ScenarioForm() {
       }
 
       const response = await scenariosApi.validateScenario({
-        name: scenarioName,
         scenarioJson: scenarioJson,
         liftSystemVersionId: parseInt(selectedVersionId, 10)
       });

--- a/src/main/java/com/liftsimulator/admin/controller/ScenarioController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/ScenarioController.java
@@ -3,6 +3,7 @@ package com.liftsimulator.admin.controller;
 import com.liftsimulator.admin.dto.CopyScenarioRequest;
 import com.liftsimulator.admin.dto.ScenarioRequest;
 import com.liftsimulator.admin.dto.ScenarioResponse;
+import com.liftsimulator.admin.dto.ScenarioValidateRequest;
 import com.liftsimulator.admin.dto.ScenarioValidationResponse;
 import com.liftsimulator.admin.service.ScenarioService;
 import com.liftsimulator.admin.service.ScenarioValidationService;
@@ -165,7 +166,7 @@ public class ScenarioController {
      */
     @PostMapping("/validate")
     public ResponseEntity<ScenarioValidationResponse> validateScenario(
-        @Valid @RequestBody ScenarioRequest request
+        @Valid @RequestBody ScenarioValidateRequest request
     ) {
         ScenarioValidationResponse response = scenarioValidationService.validate(
             request.scenarioJson(),

--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioValidateRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioValidateRequest.java
@@ -1,0 +1,16 @@
+package com.liftsimulator.admin.dto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request DTO for the /scenarios/validate endpoint.
+ * Omits {@code name} because validation does not persist the scenario.
+ */
+public record ScenarioValidateRequest(
+    @NotNull(message = "Scenario JSON is required")
+    JsonNode scenarioJson,
+    @NotNull(message = "Lift system version ID is required")
+    Long liftSystemVersionId
+) {
+}

--- a/src/test/java/com/liftsimulator/admin/controller/ScenarioControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/ScenarioControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.LocalIntegrationTest;
 import com.liftsimulator.admin.controller.fixtures.ControllerApiFixtures;
 import com.liftsimulator.admin.dto.ScenarioRequest;
+import com.liftsimulator.admin.dto.ScenarioValidateRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.repository.LiftSystemRepository;
@@ -161,10 +162,7 @@ public class ScenarioControllerTest extends LocalIntegrationTest {
 
     @Test
     public void testValidateScenario_UnknownProperty_ReturnsValidationResponse() throws Exception {
-        ScenarioRequest request = scenarioRequest(
-            "Unsupported Scenario",
-            ControllerApiFixtures.scenarioWithUnknownProperty()
-        );
+        ScenarioValidateRequest request = validateRequest(ControllerApiFixtures.scenarioWithUnknownProperty());
 
         mockMvc.perform(post("/api/v1/scenarios/validate")
                 .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD))
@@ -176,6 +174,31 @@ public class ScenarioControllerTest extends LocalIntegrationTest {
             .andExpect(jsonPath("$.errors[0].field").value("unsupportedMode"))
             .andExpect(jsonPath("$.errors[0].message")
                 .value("Unknown property 'unsupportedMode' is not allowed in scenario schema"));
+    }
+
+    @Test
+    public void testValidateScenario_WithoutName_Succeeds() throws Exception {
+        ScenarioValidateRequest request = validateRequest(ControllerApiFixtures.validScenario());
+
+        mockMvc.perform(post("/api/v1/scenarios/validate")
+                .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.valid").value(true));
+    }
+
+    @Test
+    public void testValidateScenario_MissingRequiredFields_ReturnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/v1/scenarios/validate")
+                .with(httpBasic(TEST_ADMIN_USER, TEST_ADMIN_PASSWORD))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("Validation failed"))
+            .andExpect(jsonPath("$.fieldErrors.scenarioJson").value("Scenario JSON is required"))
+            .andExpect(jsonPath("$.fieldErrors.liftSystemVersionId")
+                .value("Lift system version ID is required"));
     }
 
 
@@ -251,5 +274,9 @@ public class ScenarioControllerTest extends LocalIntegrationTest {
 
     private ScenarioRequest scenarioRequest(String name, String scenarioJson) throws Exception {
         return new ScenarioRequest(name, objectMapper.readTree(scenarioJson), version.getId());
+    }
+
+    private ScenarioValidateRequest validateRequest(String scenarioJson) throws Exception {
+        return new ScenarioValidateRequest(objectMapper.readTree(scenarioJson), version.getId());
     }
 }


### PR DESCRIPTION
## Summary
Introduced a new `ScenarioValidateRequest` DTO to replace `ScenarioRequest` for the scenario validation endpoint. This change separates concerns by creating a dedicated request object for validation that omits the `name` field, since validation does not persist scenarios.

## Key Changes
- **New DTO**: Created `ScenarioValidateRequest` record with `scenarioJson` and `liftSystemVersionId` fields, both marked as `@NotNull`
- **Controller Update**: Modified `ScenarioController.validateScenario()` to accept `ScenarioValidateRequest` instead of `ScenarioRequest`
- **Test Updates**: 
  - Updated existing validation test to use the new DTO
  - Added `testValidateScenario_WithoutName_Succeeds()` to verify validation works without a scenario name
  - Added `testValidateScenario_MissingRequiredFields_ReturnsBadRequest()` to test validation of required fields
  - Added helper method `validateRequest()` to construct the new DTO in tests

## Implementation Details
- The new DTO is a Java record with proper validation annotations
- Javadoc clarifies that the `name` field is omitted because validation doesn't persist scenarios
- Both required fields have descriptive validation messages for better error feedback
- The change maintains backward compatibility for the create scenario endpoint which continues to use `ScenarioRequest`

https://claude.ai/code/session_01ABG37XjEQXDEsyKrdyymiA