### PR TITLE
Extract totalTicks from scenario definition during simulation run creation

### DIFF
--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -1,5 +1,7 @@
 package com.liftsimulator.admin.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.Scenario;
@@ -66,6 +68,7 @@ public class SimulationRunService {
     private final String artefactsBasePath;
     private final SimulationRunExecutionService executionService;
     private final ArtefactService artefactService;
+    private final ObjectMapper objectMapper;
 
     @SuppressFBWarnings(
             value = "EI_EXPOSE_REP2",
@@ -78,6 +81,7 @@ public class SimulationRunService {
             ScenarioRepository scenarioRepository,
             SimulationRunExecutionService executionService,
             ArtefactService artefactService,
+            ObjectMapper objectMapper,
             @Value("${simulation.artefacts.base-path:./simulation-runs}") String artefactsBasePath) {
         this.runRepository = runRepository;
         this.liftSystemRepository = liftSystemRepository;
@@ -85,6 +89,7 @@ public class SimulationRunService {
         this.scenarioRepository = scenarioRepository;
         this.executionService = executionService;
         this.artefactService = artefactService;
+        this.objectMapper = objectMapper;
         this.artefactsBasePath = artefactsBasePath;
     }
 
@@ -160,8 +165,16 @@ public class SimulationRunService {
         // Set up artefact directory
         String artefactPath = setupArtefactDirectory(run.getId());
 
-        // Configure the run with default total ticks (this can be updated later)
-        run.setTotalTicks(10000L); // Default value, can be configured
+        // Derive total ticks from scenario duration if scenario is provided
+        Long totalTicks = null;
+        if (scenarioId != null) {
+            totalTicks = extractTotalTicksFromScenario(run.getScenario());
+        }
+
+        // Configure the run
+        if (totalTicks != null) {
+            run.setTotalTicks(totalTicks);
+        }
         run.setSeed(runSeed);
         run.setArtefactBasePath(artefactPath);
 
@@ -192,6 +205,23 @@ public class SimulationRunService {
                 executionService.submitRunForExecution(runId);
             }
         });
+    }
+
+    private Long extractTotalTicksFromScenario(Scenario scenario) {
+        if (scenario == null || scenario.getScenarioJson() == null) {
+            return null;
+        }
+
+        try {
+            ScenarioDefinitionDTO scenarioDefinition = objectMapper.readValue(
+                    scenario.getScenarioJson(), ScenarioDefinitionDTO.class);
+            if (scenarioDefinition.durationTicks() != null) {
+                return scenarioDefinition.durationTicks().longValue();
+            }
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to extract durationTicks from scenario {}: {}", scenario.getId(), ex.getMessage());
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -218,7 +218,7 @@ public class SimulationRunService {
             if (scenarioDefinition.durationTicks() != null) {
                 return scenarioDefinition.durationTicks().longValue();
             }
-        } catch (Exception ex) {
+        } catch (IOException ex) {
             LOGGER.warn("Failed to extract durationTicks from scenario {}: {}", scenario.getId(), ex.getMessage());
         }
         return null;

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -1,5 +1,6 @@
 package com.liftsimulator.admin.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.Scenario;
@@ -62,6 +63,9 @@ public class SimulationRunServiceTest {
     private ArtefactService artefactService;
 
     @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
     private EntityManager entityManager;
 
     private SimulationRunService runService;
@@ -82,6 +86,7 @@ public class SimulationRunServiceTest {
                 scenarioRepository,
                 executionService,
                 artefactService,
+                objectMapper,
                 tempDir.toString()
         );
 
@@ -229,7 +234,8 @@ public class SimulationRunServiceTest {
 
         assertEquals(42L, result.getId());
         assertEquals(RunStatus.RUNNING, result.getStatus());
-        assertEquals(10000L, result.getTotalTicks());
+        // totalTicks is null when no scenario is provided (will be set during execution)
+        assertEquals(null, result.getTotalTicks());
         assertEquals(12345L, result.getSeed());
         assertNotNull(result.getArtefactBasePath());
         assertTrue(Files.isDirectory(Path.of(result.getArtefactBasePath())));
@@ -264,6 +270,40 @@ public class SimulationRunServiceTest {
         } finally {
             TransactionSynchronizationManager.clearSynchronization();
         }
+    }
+
+    @Test
+    public void testCreateAndStartRun_DerivesTotalTicksFromScenario() throws Exception {
+        Scenario mockScenario = new Scenario();
+        mockScenario.setId(5L);
+        mockScenario.setName("Test Scenario");
+        mockScenario.setScenarioJson("{\"durationTicks\": 5000, \"passengerFlows\": []}");
+        mockScenario.setLiftSystemVersion(mockVersion);
+
+        when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(scenarioRepository.findById(5L)).thenReturn(Optional.of(mockScenario));
+        when(objectMapper.readValue(
+            "{\"durationTicks\": 5000, \"passengerFlows\": []}",
+            com.liftsimulator.admin.dto.ScenarioDefinitionDTO.class
+        )).thenReturn(new com.liftsimulator.admin.dto.ScenarioDefinitionDTO(5000, List.of(), null));
+        when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
+            SimulationRun savedRun = invocation.getArgument(0);
+            if (savedRun.getId() == null) {
+                savedRun.setId(42L);
+            }
+            return savedRun;
+        });
+
+        SimulationRun result = runService.createAndStartRun(1L, 1L, 5L, 12345L);
+
+        assertEquals(42L, result.getId());
+        assertEquals(RunStatus.RUNNING, result.getStatus());
+        assertEquals(5000L, result.getTotalTicks());
+        assertEquals(12345L, result.getSeed());
+        assertNotNull(result.getArtefactBasePath());
+        assertTrue(Files.isDirectory(Path.of(result.getArtefactBasePath())));
+        verify(executionService).submitRunForExecution(42L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Modified the simulation run creation logic to dynamically derive the `totalTicks` value from the scenario's JSON definition instead of using a hardcoded default value. This allows simulation runs to be configured with the correct duration based on the scenario being executed.

## Key Changes
- Added `ObjectMapper` dependency injection to `SimulationRunService` to parse scenario JSON definitions
- Introduced `extractTotalTicksFromScenario()` method that parses the scenario JSON and extracts the `durationTicks` field from the `ScenarioDefinitionDTO`
- Modified `createAndStartRun()` to conditionally set `totalTicks` only when a scenario is provided and a valid duration can be extracted
- Updated the service constructor to accept and store the `ObjectMapper` instance
- Added comprehensive test case `testCreateAndStartRun_DerivesTotalTicksFromScenario()` to verify the new behavior
- Updated existing test to reflect the new behavior where `totalTicks` is `null` when no scenario is provided

## Implementation Details
- The `extractTotalTicksFromScenario()` method gracefully handles null scenarios and JSON parsing failures by logging warnings and returning null
- When `scenarioId` is null or scenario extraction fails, `totalTicks` remains unset (null), allowing it to be configured during execution
- The implementation uses Jackson's `ObjectMapper` to deserialize the scenario JSON into a `ScenarioDefinitionDTO` record

https://claude.ai/code/session_01V2Zy3LnsyVUAbBLCRPt1dH