### PR TITLE
feat(api)!: use versionNumber for simulation runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+
+## [0.53.0] - 2026-06-23
+
+### Changed
+- **Simulation run version identifier alignment**: Changed `POST /api/v1/simulation-runs` to accept `versionNumber` scoped to `liftSystemId` instead of the surrogate `versionId`, and updated simulation run status/result payloads, frontend simulator navigation, README/API/workflow documentation, and package metadata for the 0.53.0 minor release.
+
+
 ### Fixed
 - **Simulation log tail validation**: Added controller-level validation for `GET /api/v1/simulation-runs/{id}/logs?tail=N` so non-positive or greater-than-10,000 tail values return HTTP 400 before log access, and added global `ConstraintViolationException` handling so request-parameter constraint failures no longer fall through as HTTP 500 responses. Updated README/API documentation and package metadata for the 0.52.20 patch release.
 - **Simulation run sort allowlist**: Restricted `GET /api/v1/simulation-runs` sorting to documented properties (`createdAt`, `startedAt`, `endedAt`, `status`, and `id`) and now returns HTTP 400 for unsupported sort fields or ignore-case sort modifiers instead of allowing Spring Data property lookup or non-string `lower(...)` failures to surface as HTTP 500. Updated README/API documentation and package metadata for the 0.52.19 patch release.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.52.20**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -90,7 +90,7 @@ The **frontend admin UI** provides:
 - **Lift Systems Management** — full CRUD with list and detail views
 - **Version Management** — create, publish, and archive versioned configurations with optimistic locking, single-published-version enforcement, pagination, sorting, filtering, complete JSON examples, and schema guidance in the configuration editor
 - **Scenario Builder** — template-based or custom passenger-flow scenarios with server-side validation, validated copy-to-version reuse, and an advanced JSON editor
-- **Simulator Runs** — launch published versions with scenarios, poll status, recover orphaned active runs after restarts, list runs with capped pagination and documented sorting (`createdAt`, `startedAt`, `endedAt`, `status`, `id`; ignore-case modifiers rejected), bulk-cancel active runs, bulk-delete completed runs with post-commit artefact cleanup, and review pickup-latency KPI results with artefact downloads and CLI reproduction hints
+- **Simulator Runs** — launch published versions with scenarios, poll status, recover orphaned active runs after restarts, list runs with capped pagination and documented sorting (`createdAt`, `startedAt`, `endedAt`, `status`, `id`; ignore-case modifiers rejected), bulk-cancel active runs, bulk-delete completed runs with post-commit artefact cleanup, and review pickup-latency KPI results with artefact downloads and CLI reproduction hints. Run creation uses the same lift-system-scoped `versionNumber` identifier as the version-management API, avoiding surrogate version row IDs in client requests.
 - **Configuration Editor & Validator** — edit and validate configuration JSON before publishing
 - **Health Check** — monitor backend service status
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.52.20.jar
+java -jar target/lift-simulator-0.53.0.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.52.20.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.0.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,21 +133,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.52.20.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.52.20.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.0.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.0.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.52.20.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.53.0.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.52.20.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -219,7 +219,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.52.20.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.0.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -440,7 +440,7 @@ api:
 ```bash
 curl -H "X-API-Key: <your-api-key>" \\
   -H "Content-Type: application/json" \\
-  -d '{"liftSystemId":1,"versionId":2,"scenarioId":3,"seed":12345}' \\
+  -d '{"liftSystemId":1,"versionNumber":2,"scenarioId":3,"seed":12345}' \\
   http://localhost:8080/api/v1/simulation-runs
 ```
 
@@ -493,7 +493,7 @@ Run artefacts are stored on disk using the configured `simulation.artefacts.base
     "durationTicks": 120,
     "seed": 123,
     "liftSystemId": 1,
-    "versionId": 3,
+    "versionNumber": 3,
     "scenarioId": 5
   },
   "kpis": {
@@ -581,7 +581,7 @@ All simulation run endpoints require the configured API key header.
 ```json
 {
   "liftSystemId": 1,
-  "versionId": 2,
+  "versionNumber": 2,
   "scenarioId": 3,
   "seed": 12345
 }
@@ -589,7 +589,7 @@ All simulation run endpoints require the configured API key header.
 
 **Request Fields:**
 - `liftSystemId` (required): ID of the lift system to simulate
-- `versionId` (required): ID of the version to use
+- `versionNumber` (required): version number to use within the selected lift system
 - `scenarioId` (optional): ID of the scenario to run (null for ad-hoc runs)
 - `seed` (optional): Random seed for reproducibility (auto-generated if not provided)
 
@@ -598,7 +598,7 @@ All simulation run endpoints require the configured API key header.
 {
   "id": 1,
   "liftSystemId": 1,
-  "versionId": 2,
+  "versionNumber": 2,
   "scenarioId": 3,
   "status": "RUNNING",
   "createdAt": "2026-01-23T10:00:00Z",
@@ -634,7 +634,7 @@ Retrieves the current status and details of a simulation run, including progress
 {
   "id": 1,
   "liftSystemId": 1,
-  "versionId": 2,
+  "versionNumber": 2,
   "scenarioId": 3,
   "status": "RUNNING",
   "createdAt": "2026-01-23T10:00:00Z",
@@ -673,7 +673,7 @@ Cancels a running simulation run and transitions it to a terminal `CANCELLED` st
 {
   "id": 1,
   "liftSystemId": 1,
-  "versionId": 2,
+  "versionNumber": 2,
   "scenarioId": 3,
   "status": "CANCELLED",
   "createdAt": "2026-01-23T10:00:00Z",

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.52.20.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.52.20.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.52.20.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -204,7 +204,7 @@ Behind the scenes, the UI uses these APIs:
 POST /api/simulation-runs
 {
   "liftSystemId": 1,
-  "versionId": 3,
+  "versionNumber": 3,
   "scenarioId": 5,
   "seed": 12345
 }
@@ -324,7 +324,7 @@ Comprehensive results with KPIs and metrics:
     "seed": 12345,
     "ticks": 1000,
     "liftSystemId": 1,
-    "versionId": 3,
+    "versionNumber": 3,
     "scenarioId": 5
   },
   "kpis": {
@@ -408,7 +408,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.52.20.jar \
+   java -cp target/lift-simulator-0.53.0.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -453,7 +453,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -545,7 +545,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.52.20.jar \
+java -cp target/lift-simulator-0.53.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.52.20",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.52.20",
+      "version": "0.53.0",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.52.20",
+  "version": "0.53.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/components/VersionActions.jsx
+++ b/frontend/src/components/VersionActions.jsx
@@ -16,7 +16,7 @@ import { Link } from 'react-router-dom';
  * @param {number} props.versionNumber - Version number being acted upon
  * @param {'DRAFT'|'PUBLISHED'|'ARCHIVED'} props.status - Current status of the version
  * @param {Function} props.onPublish - Callback function invoked when Publish button is clicked, receives versionNumber
- * @param {Function} props.onRunSimulation - Callback function invoked when Run Simulator button is clicked, receives versionId
+ * @param {Function} props.onRunSimulation - Callback function invoked when Run Simulator button is clicked, receives versionNumber
  * @returns {JSX.Element} The version actions component
  */
 function VersionActions({
@@ -48,7 +48,7 @@ function VersionActions({
       ) : (
         isPublished && (
           <button
-            onClick={() => onRunSimulation(versionId)}
+            onClick={() => onRunSimulation(versionNumber)}
             className="btn-primary btn-sm"
           >
             Run Simulator

--- a/frontend/src/components/VersionActions.jsx
+++ b/frontend/src/components/VersionActions.jsx
@@ -12,7 +12,6 @@ import { Link } from 'react-router-dom';
  *
  * @param {Object} props - Component props
  * @param {string|number} props.systemId - Unique identifier of the lift system
- * @param {string|number} props.versionId - Unique identifier of the version
  * @param {number} props.versionNumber - Version number being acted upon
  * @param {'DRAFT'|'PUBLISHED'|'ARCHIVED'} props.status - Current status of the version
  * @param {Function} props.onPublish - Callback function invoked when Publish button is clicked, receives versionNumber
@@ -21,7 +20,6 @@ import { Link } from 'react-router-dom';
  */
 function VersionActions({
   systemId,
-  versionId,
   versionNumber,
   status,
   onPublish,

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -733,7 +733,6 @@ function LiftSystemDetail() {
                   </div>
                   <VersionActions
                     systemId={id}
-                    versionId={version.id}
                     versionNumber={version.versionNumber}
                     status={version.status}
                     onPublish={handlePublishVersion}

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -284,10 +284,10 @@ function LiftSystemDetail() {
   /**
    * Navigates to the simulator flow for a specific version.
    *
-   * @param {number} versionId - Version ID to run simulation for
+   * @param {number} versionNumber - Version number to run simulation for
    */
-  const handleRunSimulation = (versionId) => {
-    navigate(`/simulator/run?systemId=${id}&versionId=${versionId}`);
+  const handleRunSimulation = (versionNumber) => {
+    navigate(`/simulator/run?systemId=${id}&versionNumber=${versionNumber}`);
   };
 
   /**

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -359,7 +359,7 @@ function SimulationRunDetail() {
           </div>
           <div>
             <span className="label">Version</span>
-            <p>{runInfo.versionId}</p>
+            <p>{runInfo.versionNumber}</p>
           </div>
           <div>
             <span className="label">Scenario</span>

--- a/frontend/src/pages/SimulationRuns.jsx
+++ b/frontend/src/pages/SimulationRuns.jsx
@@ -471,7 +471,7 @@ function SimulationRuns() {
                   </td>
                   <td className="run-id">#{run.id}</td>
                   <td>{run.liftSystemName || `System ${run.liftSystemId}`}</td>
-                  <td>v{run.versionNumber || run.versionId}</td>
+                  <td>v{run.versionNumber}</td>
                   <td>{run.scenarioName || '—'}</td>
                   <td>
                     <span className={`status-badge ${getStatusClass(run.status)}`}>

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -42,8 +42,8 @@ function Simulator() {
   const [selectedSystemId, setSelectedSystemId] = useState(
     searchParams.get('systemId') || ''
   );
-  const [selectedVersionId, setSelectedVersionId] = useState(
-    searchParams.get('versionId') || ''
+  const [selectedVersionNumber, setSelectedVersionNumber] = useState(
+    searchParams.get('versionNumber') || ''
   );
   const [selectedScenarioId, setSelectedScenarioId] = useState('');
   const [seed, setSeed] = useState('');
@@ -83,14 +83,14 @@ function Simulator() {
     }
 
     const incomingSystemId = searchParams.get('systemId');
-    const incomingVersionId = searchParams.get('versionId');
+    const incomingVersionNumber = searchParams.get('versionNumber');
 
     if (incomingSystemId) {
       setSelectedSystemId(incomingSystemId);
     }
 
-    if (incomingVersionId) {
-      setSelectedVersionId(incomingVersionId);
+    if (incomingVersionNumber) {
+      setSelectedVersionNumber(incomingVersionNumber);
     }
 
     hasSyncedFromParams.current = true;
@@ -99,7 +99,7 @@ function Simulator() {
   const loadVersions = useCallback(async () => {
     if (!selectedSystemId) {
       setVersions([]);
-      setSelectedVersionId('');
+      setSelectedVersionNumber('');
       return;
     }
 
@@ -123,48 +123,48 @@ function Simulator() {
 
   useEffect(() => {
     if (!publishedVersions.length) {
-      setSelectedVersionId('');
+      setSelectedVersionNumber('');
       return;
     }
 
-    if (selectedVersionId) {
+    if (selectedVersionNumber) {
       const match = publishedVersions.find(
-        (version) => String(version.id) === String(selectedVersionId)
+        (version) => String(version.versionNumber) === String(selectedVersionNumber)
       );
       if (!match) {
-        setSelectedVersionId('');
+        setSelectedVersionNumber('');
       }
       return;
     }
 
-    const preferredVersionId = searchParams.get('versionId');
-    const resolvedVersion = preferredVersionId
+    const preferredVersionNumber = searchParams.get('versionNumber');
+    const resolvedVersion = preferredVersionNumber
       ? publishedVersions.find(
-          (version) => String(version.id) === String(preferredVersionId)
+          (version) => String(version.versionNumber) === String(preferredVersionNumber)
         )
       : null;
 
     if (resolvedVersion) {
-      setSelectedVersionId(String(resolvedVersion.id));
+      setSelectedVersionNumber(String(resolvedVersion.versionNumber));
     }
-  }, [publishedVersions, searchParams, selectedVersionId]);
+  }, [publishedVersions, searchParams, selectedVersionNumber]);
 
   const selectedSystem = systems.find(
     (system) => String(system.id) === String(selectedSystemId)
   );
   const selectedVersion = publishedVersions.find(
-    (version) => String(version.id) === String(selectedVersionId)
+    (version) => String(version.versionNumber) === String(selectedVersionNumber)
   );
 
   // Filter scenarios to only show those belonging to the selected version
   const filteredScenarios = useMemo(() => {
-    if (!selectedVersionId) {
+    if (!selectedVersionNumber) {
       return [];
     }
     return scenarios.filter(
-      (scenario) => String(scenario.liftSystemVersionId) === String(selectedVersionId)
+      (scenario) => selectedVersion && String(scenario.liftSystemVersionId) === String(selectedVersion.id)
     );
-  }, [scenarios, selectedVersionId]);
+  }, [scenarios, selectedVersion, selectedVersionNumber]);
 
   const selectedScenario = scenarios.find(
     (scenario) => String(scenario.id) === String(selectedScenarioId)
@@ -175,7 +175,7 @@ function Simulator() {
 
   // Clear selected scenario when version changes if it's not compatible
   useEffect(() => {
-    if (selectedScenarioId && selectedVersionId) {
+    if (selectedScenarioId && selectedVersionNumber) {
       const isScenarioCompatible = filteredScenarios.some(
         (scenario) => String(scenario.id) === String(selectedScenarioId)
       );
@@ -184,7 +184,7 @@ function Simulator() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedVersionId, filteredScenarios]);
+  }, [selectedVersionNumber, filteredScenarios]);
 
   useEffect(() => {
     if (!runInfo || isTerminal) {
@@ -256,7 +256,7 @@ function Simulator() {
   }, [isTerminal, runInfo?.id, runStatus]);
 
   const handleStartRun = async () => {
-    if (!selectedSystemId || !selectedVersionId || !selectedScenarioId) {
+    if (!selectedSystemId || !selectedVersionNumber || !selectedScenarioId) {
       setFormError('Select a lift system, published version, and scenario to continue.');
       return;
     }
@@ -265,7 +265,7 @@ function Simulator() {
       setIsStarting(true);
       const payload = {
         liftSystemId: Number(selectedSystemId),
-        versionId: Number(selectedVersionId),
+        versionNumber: Number(selectedVersionNumber),
         scenarioId: Number(selectedScenarioId),
         seed: seed ? Number(seed) : null,
       };
@@ -456,7 +456,7 @@ function Simulator() {
                 value={selectedSystemId}
                 onChange={(event) => {
                   setSelectedSystemId(event.target.value);
-                  setSelectedVersionId('');
+                  setSelectedVersionNumber('');
                 }}
               >
                 <option value="">Select a lift system</option>
@@ -471,8 +471,8 @@ function Simulator() {
             <label className="field">
               <span>Published Version</span>
               <select
-                value={selectedVersionId}
-                onChange={(event) => setSelectedVersionId(event.target.value)}
+                value={selectedVersionNumber}
+                onChange={(event) => setSelectedVersionNumber(event.target.value)}
                 disabled={!selectedSystemId || publishedVersions.length === 0}
               >
                 <option value="">Select a published version</option>
@@ -497,7 +497,7 @@ function Simulator() {
               <select
                 value={selectedScenarioId}
                 onChange={(event) => setSelectedScenarioId(event.target.value)}
-                disabled={!selectedVersionId || filteredScenarios.length === 0}
+                disabled={!selectedVersionNumber || filteredScenarios.length === 0}
               >
                 <option value="">Select a scenario</option>
                 {filteredScenarios.map((scenario) => (
@@ -506,10 +506,10 @@ function Simulator() {
                   </option>
                 ))}
               </select>
-              {!selectedVersionId && (
+              {!selectedVersionNumber && (
                 <small>Select a version to view compatible scenarios.</small>
               )}
-              {selectedVersionId && filteredScenarios.length === 0 && (
+              {selectedVersionNumber && filteredScenarios.length === 0 && (
                 <small className="warning">
                   No scenarios available for this version. Create one from the Scenarios page.
                 </small>
@@ -534,7 +534,7 @@ function Simulator() {
                   isStarting ||
                   (runInfo && !isTerminal) ||
                   !selectedSystemId ||
-                  !selectedVersionId ||
+                  !selectedVersionNumber ||
                   !selectedScenarioId
                 }
               >
@@ -588,7 +588,7 @@ function Simulator() {
             </div>
             <div>
               <span className="label">Version</span>
-              <p>{selectedVersion ? `Version ${selectedVersion.versionNumber}` : runInfo.versionId}</p>
+              <p>{selectedVersion ? `Version ${selectedVersion.versionNumber}` : runInfo.versionNumber}</p>
             </div>
             <div>
               <span className="label">Scenario</span>

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -137,8 +137,11 @@ function Simulator() {
       return;
     }
 
+    const querySystemId = searchParams.get('systemId');
     const preferredVersionNumber = searchParams.get('versionNumber');
-    const resolvedVersion = preferredVersionNumber
+    const queryMatchesSelectedSystem =
+      querySystemId && String(querySystemId) === String(selectedSystemId);
+    const resolvedVersion = queryMatchesSelectedSystem && preferredVersionNumber
       ? publishedVersions.find(
           (version) => String(version.versionNumber) === String(preferredVersionNumber)
         )
@@ -147,7 +150,7 @@ function Simulator() {
     if (resolvedVersion) {
       setSelectedVersionNumber(String(resolvedVersion.versionNumber));
     }
-  }, [publishedVersions, searchParams, selectedVersionNumber]);
+  }, [publishedVersions, searchParams, selectedSystemId, selectedVersionNumber]);
 
   const selectedSystem = systems.find(
     (system) => String(system.id) === String(selectedSystemId)

--- a/frontend/src/pages/SimulatorLanding.jsx
+++ b/frontend/src/pages/SimulatorLanding.jsx
@@ -13,7 +13,7 @@ function SimulatorLanding() {
   const [error, setError] = useState(null);
   const [versionsError, setVersionsError] = useState(null);
   const [selectedSystemId, setSelectedSystemId] = useState('');
-  const [selectedVersionId, setSelectedVersionId] = useState('');
+  const [selectedVersionNumber, setSelectedVersionNumber] = useState('');
   const [versions, setVersions] = useState([]);
   const [isLoadingVersions, setIsLoadingVersions] = useState(false);
   const versionsRequestId = useRef(0);
@@ -38,7 +38,7 @@ function SimulatorLanding() {
   useEffect(() => {
     if (!selectedSystemId) {
       setVersions([]);
-      setSelectedVersionId('');
+      setSelectedVersionNumber('');
       return;
     }
 
@@ -58,7 +58,7 @@ function SimulatorLanding() {
           return;
         }
         setVersions([]);
-        setSelectedVersionId('');
+        setSelectedVersionNumber('');
         handleApiError(err, setVersionsError, 'Failed to load versions');
       } finally {
         if (versionsRequestId.current === requestId) {
@@ -80,11 +80,11 @@ function SimulatorLanding() {
   );
 
   const handleProceed = () => {
-    if (!selectedSystemId || !selectedVersionId) {
+    if (!selectedSystemId || !selectedVersionNumber) {
       return;
     }
 
-    navigate(`/simulator/run?systemId=${selectedSystemId}&versionId=${selectedVersionId}`);
+    navigate(`/simulator/run?systemId=${selectedSystemId}&versionNumber=${selectedVersionNumber}`);
   };
 
   return (
@@ -129,7 +129,7 @@ function SimulatorLanding() {
                       className={isSelected ? 'btn-secondary' : 'btn-primary'}
                       onClick={() => {
                         setSelectedSystemId(String(system.id));
-                        setSelectedVersionId('');
+                        setSelectedVersionNumber('');
                       }}
                     >
                       {isSelected ? 'Selected' : 'Select System'}
@@ -164,13 +164,13 @@ function SimulatorLanding() {
             <label className="field">
               <span>Published Version</span>
               <select
-                value={selectedVersionId}
-                onChange={(event) => setSelectedVersionId(event.target.value)}
+                value={selectedVersionNumber}
+                onChange={(event) => setSelectedVersionNumber(event.target.value)}
                 disabled={!selectedSystemId || isLoadingVersions}
               >
                 <option value="">Select a published version</option>
                 {publishedVersions.map((version) => (
-                  <option key={version.id} value={version.id}>
+                  <option key={version.versionNumber} value={version.versionNumber}>
                     Version {version.versionNumber}
                   </option>
                 ))}
@@ -186,7 +186,7 @@ function SimulatorLanding() {
             <button
               className="btn-primary"
               onClick={handleProceed}
-              disabled={!selectedSystemId || !selectedVersionId}
+              disabled={!selectedSystemId || !selectedVersionNumber}
             >
               Continue to Simulation Setup
             </button>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.52.20</version>
+    <version>0.53.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
@@ -108,7 +108,7 @@ public class SimulationRunController {
      * Creates and starts a new simulation run.
      * Endpoint: POST /api/simulation-runs
      *
-     * @param request the creation request containing liftSystemId, versionId, scenarioId (optional),
+     * @param request the creation request containing liftSystemId, versionNumber, scenarioId (optional),
      *                seed (optional)
      * @return the created and started simulation run with 201 status
      */
@@ -118,7 +118,7 @@ public class SimulationRunController {
     ) throws IOException {
         SimulationRun run = simulationRunService.createAndStartRun(
                 request.liftSystemId(),
-                request.versionId(),
+                request.versionNumber(),
                 request.scenarioId(),
                 request.seed()
         );

--- a/src/main/java/com/liftsimulator/admin/dto/CreateSimulationRunRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/CreateSimulationRunRequest.java
@@ -11,9 +11,9 @@ public record CreateSimulationRunRequest(
     @JsonProperty("liftSystemId")
     Long liftSystemId,
 
-    @NotNull(message = "versionId is required")
-    @JsonProperty("versionId")
-    Long versionId,
+    @NotNull(message = "versionNumber is required")
+    @JsonProperty("versionNumber")
+    Integer versionNumber,
 
     @JsonProperty("scenarioId")
     Long scenarioId,

--- a/src/main/java/com/liftsimulator/admin/dto/SimulationRunResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/SimulationRunResponse.java
@@ -11,7 +11,7 @@ import java.time.OffsetDateTime;
 public record SimulationRunResponse(
     Long id,
     Long liftSystemId,
-    Long versionId,
+    Integer versionNumber,
     Long scenarioId,
     RunStatus status,
     OffsetDateTime createdAt,
@@ -33,7 +33,7 @@ public record SimulationRunResponse(
         return new SimulationRunResponse(
             run.getId(),
             run.getLiftSystem() != null ? run.getLiftSystem().getId() : null,
-            run.getVersion() != null ? run.getVersion().getId() : null,
+            run.getVersion() != null ? run.getVersion().getVersionNumber() : null,
             run.getScenario() != null ? run.getScenario().getId() : null,
             run.getStatus(),
             run.getCreatedAt(),

--- a/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
@@ -14,12 +14,26 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Spring Data JPA repository for SimulationRun entities.
  */
 @Repository
 public interface SimulationRunRepository extends JpaRepository<SimulationRun, Long> {
+
+    /**
+     * Find a run by id with its relationships eagerly loaded.
+     *
+     * @param id the simulation run id
+     * @return the run with lift system, version, and scenario loaded if found
+     */
+    @Query("SELECT r FROM SimulationRun r "
+            + "LEFT JOIN FETCH r.liftSystem "
+            + "LEFT JOIN FETCH r.version "
+            + "LEFT JOIN FETCH r.scenario "
+            + "WHERE r.id = :id")
+    Optional<SimulationRun> findByIdWithDetails(@Param("id") Long id);
 
     /**
      * Find all runs with their relationships eagerly loaded.

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -506,7 +506,7 @@ public class SimulationRunExecutionService {
         try {
             SimulationRun run = getRunById(runId);
             runSummary.put("liftSystemId", run.getLiftSystem().getId());
-            runSummary.put("versionId", run.getVersion().getId());
+            runSummary.put("versionNumber", run.getVersion().getVersionNumber());
         } catch (Exception ex) {
             logger.warn("Failed to resolve run summary metadata for run {}", runId, ex);
         }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -97,7 +97,7 @@ public class SimulationRunService {
      * Create a new simulation run.
      *
      * @param liftSystemId the lift system id
-     * @param versionId the version id
+     * @param versionNumber the version number
      * @param scenarioId the scenario id (optional)
      * @return the created run
      * @throws ResourceNotFoundException if the lift system, version, or scenario is not found
@@ -105,19 +105,15 @@ public class SimulationRunService {
      *                                  or the scenario does not belong to the version
      */
     @Transactional
-    public SimulationRun createRun(Long liftSystemId, Long versionId, Long scenarioId) {
+    public SimulationRun createRun(Long liftSystemId, Integer versionNumber, Long scenarioId) {
         LiftSystem liftSystem = liftSystemRepository.findById(liftSystemId)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Lift system not found with id: " + liftSystemId));
 
-        LiftSystemVersion version = versionRepository.findById(versionId)
+        LiftSystemVersion version = versionRepository.findByLiftSystemIdAndVersionNumber(liftSystemId, versionNumber)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        "Lift system version not found with id: " + versionId));
-
-        if (!version.getLiftSystem().getId().equals(liftSystemId)) {
-            throw new IllegalArgumentException(
-                    "Version " + versionId + " does not belong to lift system " + liftSystemId);
-        }
+                        "Lift system version not found with lift system id " + liftSystemId
+                                + " and version number: " + versionNumber));
 
         SimulationRun run = new SimulationRun(liftSystem, version);
 
@@ -128,9 +124,10 @@ public class SimulationRunService {
                             "Scenario not found with id: " + scenarioId));
 
             // Validate that the scenario belongs to the same version
-            if (!scenario.getLiftSystemVersion().getId().equals(versionId)) {
+            if (!scenario.getLiftSystemVersion().getId().equals(version.getId())) {
                 throw new IllegalArgumentException(
-                        "Scenario " + scenarioId + " does not belong to version " + versionId);
+                        "Scenario " + scenarioId + " does not belong to version " + versionNumber
+                                + " of lift system " + liftSystemId);
             }
 
             run.setScenario(scenario);
@@ -144,7 +141,7 @@ public class SimulationRunService {
      * This method creates the run, sets up the artefact directory, configures it, and starts execution.
      *
      * @param liftSystemId the lift system id
-     * @param versionId the version id
+     * @param versionNumber the version number
      * @param scenarioId the scenario id (optional)
      * @param seed the random seed (optional, will be generated if not provided)
      * @return the started run
@@ -154,10 +151,10 @@ public class SimulationRunService {
      * @throws IOException if artefact directory creation fails
      */
     @Transactional
-    public SimulationRun createAndStartRun(Long liftSystemId, Long versionId, Long scenarioId, Long seed)
+    public SimulationRun createAndStartRun(Long liftSystemId, Integer versionNumber, Long scenarioId, Long seed)
             throws IOException {
         // Create the run
-        SimulationRun run = createRun(liftSystemId, versionId, scenarioId);
+        SimulationRun run = createRun(liftSystemId, versionNumber, scenarioId);
 
         // Generate seed if not provided
         Long runSeed = seed != null ? seed : ThreadLocalRandom.current().nextLong();

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -353,7 +353,7 @@ public class SimulationRunService {
      * @throws ResourceNotFoundException if the run is not found
      */
     public SimulationRun getRunById(Long id) {
-        return runRepository.findById(id)
+        return runRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Simulation run not found with id: " + id));
     }

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -99,7 +99,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
     public void testCreateSimulationRun_Success() throws Exception {
         CreateSimulationRunRequest request = new CreateSimulationRunRequest(
             testSystem.getId(),
-            testVersion.getId(),
+            testVersion.getVersionNumber(),
             null,
             12345L
         );
@@ -111,7 +111,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.id").exists())
             .andExpect(jsonPath("$.liftSystemId").value(testSystem.getId()))
-            .andExpect(jsonPath("$.versionId").value(testVersion.getId()))
+            .andExpect(jsonPath("$.versionNumber").value(testVersion.getVersionNumber()))
             .andExpect(jsonPath("$.status").value("RUNNING"))
             .andExpect(jsonPath("$.seed").value(12345L))
             .andExpect(jsonPath("$.createdAt").exists())
@@ -122,7 +122,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
     public void testCreateSimulationRun_InvalidLiftSystem() throws Exception {
         CreateSimulationRunRequest request = new CreateSimulationRunRequest(
             999L,
-            testVersion.getId(),
+            testVersion.getVersionNumber(),
             null,
             null
         );
@@ -156,7 +156,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(run.getId()))
             .andExpect(jsonPath("$.liftSystemId").value(testSystem.getId()))
-            .andExpect(jsonPath("$.versionId").value(testVersion.getId()))
+            .andExpect(jsonPath("$.versionNumber").value(testVersion.getVersionNumber()))
             .andExpect(jsonPath("$.status").value("CREATED"));
     }
 

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -108,7 +108,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
 
         CreateSimulationRunRequest request = new CreateSimulationRunRequest(
                 testSystem.getId(),
-                testVersion.getId(),
+                testVersion.getVersionNumber(),
                 scenario.getId(),
                 4242L
         );

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunDirectoryIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunDirectoryIntegrationTest.java
@@ -89,7 +89,7 @@ public class SimulationRunDirectoryIntegrationTest extends LocalIntegrationTest 
 
     @Test
     void createAndStartRun_createsExactlyOneDirectory() throws Exception {
-        SimulationRun run = runService.createAndStartRun(testSystem.getId(), testVersion.getId(), null, 1L);
+        SimulationRun run = runService.createAndStartRun(testSystem.getId(), testVersion.getVersionNumber(), null, 1L);
         awaitTerminalRun(run.getId());
 
         // The persisted path must be inside artefactsRoot
@@ -115,7 +115,7 @@ public class SimulationRunDirectoryIntegrationTest extends LocalIntegrationTest 
 
     @Test
     void createAndStartRun_directoryNameMatchesRunId() throws Exception {
-        SimulationRun run = runService.createAndStartRun(testSystem.getId(), testVersion.getId(), null, 2L);
+        SimulationRun run = runService.createAndStartRun(testSystem.getId(), testVersion.getVersionNumber(), null, 2L);
         awaitTerminalRun(run.getId());
 
         Path runDir = Path.of(run.getArtefactBasePath());

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -116,15 +116,15 @@ public class SimulationRunServiceTest {
     @Test
     public void testCreateRun_Success() {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
         when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
 
-        SimulationRun result = runService.createRun(1L, 1L, null);
+        SimulationRun result = runService.createRun(1L, 1, null);
 
         assertNotNull(result);
         assertEquals(1L, result.getId());
         verify(liftSystemRepository).findById(1L);
-        verify(versionRepository).findById(1L);
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
@@ -134,7 +134,7 @@ public class SimulationRunServiceTest {
 
         ResourceNotFoundException exception = assertThrows(
             ResourceNotFoundException.class,
-            () -> runService.createRun(999L, 1L, null)
+            () -> runService.createRun(999L, 1, null)
         );
 
         assertEquals("Lift system not found with id: 999", exception.getMessage());
@@ -144,39 +144,31 @@ public class SimulationRunServiceTest {
     @Test
     public void testCreateRun_VersionNotFound() {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(999L)).thenReturn(Optional.empty());
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 999)).thenReturn(Optional.empty());
 
         ResourceNotFoundException exception = assertThrows(
             ResourceNotFoundException.class,
-            () -> runService.createRun(1L, 999L, null)
+            () -> runService.createRun(1L, 999, null)
         );
 
-        assertEquals("Lift system version not found with id: 999", exception.getMessage());
-        verify(versionRepository).findById(999L);
+        assertEquals("Lift system version not found with lift system id 1 and version number: 999", exception.getMessage());
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 999);
     }
 
     @Test
-    public void testCreateRun_VersionBelongsToDifferentSystem() {
-        LiftSystem otherSystem = new LiftSystem();
-        otherSystem.setId(2L);
-        otherSystem.setSystemKey("other-system");
-
-        LiftSystemVersion versionFromOtherSystem = new LiftSystemVersion();
-        versionFromOtherSystem.setId(5L);
-        versionFromOtherSystem.setVersionNumber(1);
-        versionFromOtherSystem.setLiftSystem(otherSystem);
-
+    public void testCreateRun_VersionNumberNotFoundForLiftSystem() {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(5L)).thenReturn(Optional.of(versionFromOtherSystem));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 5)).thenReturn(Optional.empty());
 
-        IllegalArgumentException exception = assertThrows(
-            IllegalArgumentException.class,
-            () -> runService.createRun(1L, 5L, null)
+        ResourceNotFoundException exception = assertThrows(
+            ResourceNotFoundException.class,
+            () -> runService.createRun(1L, 5, null)
         );
 
-        assertEquals("Version 5 does not belong to lift system 1", exception.getMessage());
+        assertEquals("Lift system version not found with lift system id 1 and version number: 5",
+                exception.getMessage());
         verify(liftSystemRepository).findById(1L);
-        verify(versionRepository).findById(5L);
+        verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 5);
     }
 
     @Test
@@ -184,11 +176,11 @@ public class SimulationRunServiceTest {
         Scenario scenario = new Scenario("Morning Rush", "{}", mockVersion);
         scenario.setId(7L);
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
         when(scenarioRepository.findById(7L)).thenReturn(Optional.of(scenario));
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        SimulationRun result = runService.createRun(1L, 1L, 7L);
+        SimulationRun result = runService.createRun(1L, 1, 7L);
 
         assertNotNull(result);
         assertEquals(scenario, result.getScenario());
@@ -206,22 +198,22 @@ public class SimulationRunServiceTest {
         Scenario scenario = new Scenario("Other Scenario", "{}", otherVersion);
         scenario.setId(7L);
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
         when(scenarioRepository.findById(7L)).thenReturn(Optional.of(scenario));
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> runService.createRun(1L, 1L, 7L)
+            () -> runService.createRun(1L, 1, 7L)
         );
 
-        assertEquals("Scenario 7 does not belong to version 1", exception.getMessage());
+        assertEquals("Scenario 7 does not belong to version 1 of lift system 1", exception.getMessage());
         verify(runRepository, never()).save(any(SimulationRun.class));
     }
 
     @Test
     public void testCreateAndStartRun_ConfiguresRunStartsAndSubmitsExecution() throws Exception {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
             SimulationRun savedRun = invocation.getArgument(0);
             if (savedRun.getId() == null) {
@@ -230,7 +222,7 @@ public class SimulationRunServiceTest {
             return savedRun;
         });
 
-        SimulationRun result = runService.createAndStartRun(1L, 1L, null, 12345L);
+        SimulationRun result = runService.createAndStartRun(1L, 1, null, 12345L);
 
         assertEquals(42L, result.getId());
         assertEquals(RunStatus.RUNNING, result.getStatus());
@@ -245,7 +237,7 @@ public class SimulationRunServiceTest {
     @Test
     public void testCreateAndStartRun_SubmitsExecutionAfterTransactionCommit() throws Exception {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
             SimulationRun savedRun = invocation.getArgument(0);
             if (savedRun.getId() == null) {
@@ -256,7 +248,7 @@ public class SimulationRunServiceTest {
 
         TransactionSynchronizationManager.initSynchronization();
         try {
-            SimulationRun result = runService.createAndStartRun(1L, 1L, null, 12345L);
+            SimulationRun result = runService.createAndStartRun(1L, 1, null, 12345L);
 
             assertEquals(42L, result.getId());
             verify(executionService, never()).submitRunForExecution(42L);
@@ -281,7 +273,7 @@ public class SimulationRunServiceTest {
         mockScenario.setLiftSystemVersion(mockVersion);
 
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
-        when(versionRepository.findById(1L)).thenReturn(Optional.of(mockVersion));
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
         when(scenarioRepository.findById(5L)).thenReturn(Optional.of(mockScenario));
         when(objectMapper.readValue(
             "{\"durationTicks\": 5000, \"passengerFlows\": []}",
@@ -295,7 +287,7 @@ public class SimulationRunServiceTest {
             return savedRun;
         });
 
-        SimulationRun result = runService.createAndStartRun(1L, 1L, 5L, 12345L);
+        SimulationRun result = runService.createAndStartRun(1L, 1, 5L, 12345L);
 
         assertEquals(42L, result.getId());
         assertEquals(RunStatus.RUNNING, result.getStatus());

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -300,18 +300,18 @@ public class SimulationRunServiceTest {
 
     @Test
     public void testGetRunById_Success() {
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         SimulationRun result = runService.getRunById(1L);
 
         assertNotNull(result);
         assertEquals(1L, result.getId());
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
     }
 
     @Test
     public void testGetRunById_NotFound() {
-        when(runRepository.findById(999L)).thenReturn(Optional.empty());
+        when(runRepository.findByIdWithDetails(999L)).thenReturn(Optional.empty());
 
         ResourceNotFoundException exception = assertThrows(
             ResourceNotFoundException.class,
@@ -319,7 +319,7 @@ public class SimulationRunServiceTest {
         );
 
         assertEquals("Simulation run not found with id: 999", exception.getMessage());
-        verify(runRepository).findById(999L);
+        verify(runRepository).findByIdWithDetails(999L);
     }
 
     @Test
@@ -357,127 +357,127 @@ public class SimulationRunServiceTest {
 
     @Test
     public void testStartRun_Success() {
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
 
         SimulationRun result = runService.startRun(1L);
 
         assertNotNull(result);
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
     @Test
     public void testStartRun_InvalidStatus() {
         mockRun.setStatus(RunStatus.RUNNING);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         assertThrows(
             IllegalStateException.class,
             () -> runService.startRun(1L)
         );
 
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
     }
 
     @Test
     public void testSucceedRun_Success() {
         mockRun.setStatus(RunStatus.RUNNING);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
 
         SimulationRun result = runService.succeedRun(1L);
 
         assertNotNull(result);
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
     @Test
     public void testSucceedRun_InvalidStatus() {
         mockRun.setStatus(RunStatus.CREATED);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         assertThrows(
             IllegalStateException.class,
             () -> runService.succeedRun(1L)
         );
 
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
     }
 
     @Test
     public void testFailRun_Success() {
         mockRun.setStatus(RunStatus.RUNNING);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
 
         SimulationRun result = runService.failRun(1L, "Test error");
 
         assertNotNull(result);
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
     @Test
     public void testFailRun_InvalidStatus() {
         mockRun.setStatus(RunStatus.CREATED);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         assertThrows(
             IllegalStateException.class,
             () -> runService.failRun(1L, "Test error")
         );
 
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
     }
 
     @Test
     public void testCancelRun_Success() {
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
 
         SimulationRun result = runService.cancelRun(1L);
 
         assertNotNull(result);
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
     @Test
     public void testCancelRun_InvalidStatus() {
         mockRun.setStatus(RunStatus.SUCCEEDED);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         assertThrows(
             IllegalStateException.class,
             () -> runService.cancelRun(1L)
         );
 
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
     }
 
     @Test
     public void testUpdateProgress_Success() {
         when(runRepository.updateCurrentTick(1L, 500L)).thenReturn(1);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         SimulationRun result = runService.updateProgress(1L, 500L);
 
         assertNotNull(result);
         verify(runRepository).updateCurrentTick(1L, 500L);
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
     }
 
     @Test
     public void testConfigureRun_Success() {
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenReturn(mockRun);
 
         SimulationRun result = runService.configureRun(1L, 1000L, 12345L, "/path/to/artefacts");
 
         assertNotNull(result);
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
@@ -487,7 +487,7 @@ public class SimulationRunServiceTest {
         mockRun.setTotalTicks(5000L);
         mockRun.setSeed(99999L);
         mockRun.setArtefactBasePath("/original/path");
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // Configure with only artefactBasePath, keeping other values null
@@ -499,7 +499,7 @@ public class SimulationRunServiceTest {
         assertEquals(99999L, result.getSeed());
         // New value should be updated
         assertEquals("/new/path", result.getArtefactBasePath());
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
@@ -509,7 +509,7 @@ public class SimulationRunServiceTest {
         mockRun.setTotalTicks(5000L);
         mockRun.setSeed(99999L);
         mockRun.setArtefactBasePath("/original/path");
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         // Update only totalTicks, keeping seed null
@@ -521,7 +521,7 @@ public class SimulationRunServiceTest {
         // Existing values should be preserved
         assertEquals(99999L, result.getSeed());
         assertEquals("/original/path", result.getArtefactBasePath());
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 
@@ -554,11 +554,11 @@ public class SimulationRunServiceTest {
     @Test
     public void testDeleteRun_Success() throws Exception {
         mockRun.setStatus(RunStatus.SUCCEEDED);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         runService.deleteRun(1L);
 
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).deleteById(1L);
         verify(artefactService).deleteArtefacts(mockRun);
     }
@@ -566,7 +566,7 @@ public class SimulationRunServiceTest {
     @Test
     public void testDeleteRun_DefersArtefactDeletionUntilAfterCommit() throws Exception {
         mockRun.setStatus(RunStatus.SUCCEEDED);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         TransactionSynchronizationManager.initSynchronization();
         try {
@@ -587,7 +587,7 @@ public class SimulationRunServiceTest {
 
     @Test
     public void testDeleteRun_NotFound() {
-        when(runRepository.findById(999L)).thenReturn(Optional.empty());
+        when(runRepository.findByIdWithDetails(999L)).thenReturn(Optional.empty());
 
         ResourceNotFoundException exception = assertThrows(
             ResourceNotFoundException.class,
@@ -595,14 +595,14 @@ public class SimulationRunServiceTest {
         );
 
         assertEquals("Simulation run not found with id: 999", exception.getMessage());
-        verify(runRepository).findById(999L);
+        verify(runRepository).findByIdWithDetails(999L);
         verify(runRepository, never()).deleteById(any());
     }
 
     @Test
     public void testDeleteRun_RunningRunRejected() throws Exception {
         mockRun.setStatus(RunStatus.RUNNING);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
 
         IllegalStateException exception = assertThrows(
             IllegalStateException.class,
@@ -617,7 +617,7 @@ public class SimulationRunServiceTest {
     @Test
     public void testDeleteRun_ArtefactDeletionFailureAfterCommitIsReported() throws Exception {
         mockRun.setStatus(RunStatus.FAILED);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         doThrow(new java.io.IOException("disk error")).when(artefactService).deleteArtefacts(mockRun);
 
         TransactionSynchronizationManager.initSynchronization();
@@ -640,7 +640,7 @@ public class SimulationRunServiceTest {
     @Test
     public void testConfigureRun_WithNullDurationTicks() {
         mockRun.setTotalTicks(null);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(mockRun));
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         SimulationRun result = runService.configureRun(1L, null, 12345L, "/path/to/artefacts");
@@ -648,7 +648,7 @@ public class SimulationRunServiceTest {
         assertNotNull(result);
         // Verify that the run can be configured even with null durationTicks
         // The null check occurs during execution, not configuration
-        verify(runRepository).findById(1L);
+        verify(runRepository).findByIdWithDetails(1L);
         verify(runRepository).save(any(SimulationRun.class));
     }
 }


### PR DESCRIPTION
### Motivation
- The simulation-run API used a surrogate `versionId` (database row id) while the rest of the version APIs use the lift-system-scoped `versionNumber`, causing inconsistent client usage and surprising coupling to persistence ids.
- Align the run creation and result payloads with the version-management contract so clients can refer to versions by their stable `versionNumber` within a lift system.

### Description
- Changed the create-run DTO to accept `versionNumber` and updated `SimulationRunController` to pass `versionNumber` into the service which resolves the version via `LiftSystemVersionRepository.findByLiftSystemIdAndVersionNumber(...)` instead of by row id.
- Updated `SimulationRunResponse` and the run `results.json` generation to expose `versionNumber` (not the version row id), and adjusted validation and scenario ownership checks to use the resolved version entity.
- Updated the React frontend (simulator pages, landing, run list/detail, and version actions) to use `versionNumber` in query params and create-run payloads while preserving internal use of version row id where required for scenario lookups.
- Synced documentation (README, `docs/API.md`, workflows), bumped package metadata and project version to `0.53.0`, and refreshed CHANGELOG with a note about the breaking API alignment.

### Testing
- Ran frontend build with `npm run build` in `frontend/`, which completed successfully and produced a production bundle. 
- Ran `git diff --check` (no whitespace or obvious diff-check issues) and included basic static verification locally. 
- Attempted to compile the backend with `mvn -q -DskipTests compile`, but the command failed in this environment while resolving the Spring Boot parent POM (Maven Central returned HTTP 403), so backend compilation/tests could not be completed here. 
- Attempted to run frontend E2E tests with `npm test`, but Playwright failed to launch because the Chromium browser binary was not installed in this environment, so E2E tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39db001ba08325b91a14d282565fc4)