### PR TITLE
Fix HTTP status codes for simulation results endpoint

### DIFF
--- a/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
@@ -185,8 +185,9 @@ public class SimulationRunController {
      * Endpoint: GET /api/simulation-runs/{id}/results
      *
      * Returns:
-     * - 200 with structured results JSON when SUCCEEDED
-     * - 200 with error message and logs link when FAILED
+     * - 200 with structured results JSON when SUCCEEDED with readable results
+     * - 500 when SUCCEEDED but results file is unreadable (server error)
+     * - 400 when FAILED (client error - simulation failed)
      * - 409 when RUNNING (simulation still in progress)
      * - 400 when CREATED or CANCELLED
      *
@@ -203,21 +204,22 @@ public class SimulationRunController {
                     JsonNode results = artefactService.readResults(run);
                     yield ResponseEntity.ok(SimulationResultResponse.success(id, results));
                 } catch (IOException e) {
-                    // Results file not found or not readable - preserve SUCCEEDED status
-                    // but indicate results are unavailable
-                    yield ResponseEntity.ok(SimulationResultResponse.succeededWithoutResults(
-                            id,
-                            "Results file not available: " + e.getMessage()
-                    ));
+                    // Results file not found or not readable - genuine server error
+                    yield ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .body(SimulationResultResponse.succeededWithoutResults(
+                                    id,
+                                    "Results file not available: " + e.getMessage()
+                            ));
                 }
             }
-            case FAILED -> ResponseEntity.ok(SimulationResultResponse.failure(id, run.getErrorMessage()));
+            case FAILED -> ResponseEntity.badRequest()
+                    .body(SimulationResultResponse.failure(id, run.getErrorMessage()));
             case RUNNING -> ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(SimulationResultResponse.running(id));
             case CREATED, CANCELLED -> ResponseEntity.badRequest()
                     .body(new SimulationResultResponse(
                             id,
-                            run.getStatus().name(),
+                            run.getStatus(),
                             null,
                             "Results not available for " + run.getStatus().name() + " runs",
                             null

--- a/src/main/java/com/liftsimulator/admin/dto/SimulationResultResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/SimulationResultResponse.java
@@ -1,13 +1,14 @@
 package com.liftsimulator.admin.dto;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.liftsimulator.admin.entity.SimulationRun.RunStatus;
 
 /**
  * Response DTO for simulation run results.
  */
 public record SimulationResultResponse(
     Long runId,
-    String status,
+    RunStatus status,
     JsonNode results,
     String errorMessage,
     String logsUrl
@@ -22,7 +23,7 @@ public record SimulationResultResponse(
     public static SimulationResultResponse success(Long runId, JsonNode results) {
         return new SimulationResultResponse(
             runId,
-            "SUCCEEDED",
+            RunStatus.SUCCEEDED,
             results,
             null,
             "/api/v1/simulation-runs/" + runId + "/logs"
@@ -39,7 +40,7 @@ public record SimulationResultResponse(
     public static SimulationResultResponse failure(Long runId, String errorMessage) {
         return new SimulationResultResponse(
             runId,
-            "FAILED",
+            RunStatus.FAILED,
             null,
             errorMessage,
             "/api/v1/simulation-runs/" + runId + "/logs"
@@ -55,7 +56,7 @@ public record SimulationResultResponse(
     public static SimulationResultResponse running(Long runId) {
         return new SimulationResultResponse(
             runId,
-            "RUNNING",
+            RunStatus.RUNNING,
             null,
             "Simulation is still running",
             null
@@ -73,7 +74,7 @@ public record SimulationResultResponse(
     public static SimulationResultResponse succeededWithoutResults(Long runId, String errorMessage) {
         return new SimulationResultResponse(
             runId,
-            "SUCCEEDED",
+            RunStatus.SUCCEEDED,
             null,
             errorMessage,
             "/api/v1/simulation-runs/" + runId + "/logs"

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -223,9 +223,9 @@ public class SimulationRunExecutionService {
                 writeResults(request.runId(), runDir, config, scenario, metrics, "CANCELLED", "Run cancelled.");
                 return;
             }
-            succeedRun(request.runId());
             log(logWriter, "Simulation succeeded for run " + request.runId());
             writeResults(request.runId(), runDir, config, scenario, metrics, "SUCCEEDED", null);
+            succeedRun(request.runId());
         } catch (RunCancelledException ex) {
             try {
                 cancelRunSafely(request.runId(), logPath, ex.getMessage());

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -191,7 +191,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
 
         mockMvc.perform(get("/api/v1/simulation-runs/" + run.getId() + "/results")
                 .header(API_KEY_HEADER, API_KEY_VALUE))
-            .andExpect(status().isOk())
+            .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.runId").value(run.getId()))
             .andExpect(jsonPath("$.status").value("FAILED"))
             .andExpect(jsonPath("$.errorMessage").value("Test error message"))

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -248,7 +248,7 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
 
         mockMvc.perform(get("/api/v1/simulation-runs/" + run.getId() + "/results")
                 .header(API_KEY_HEADER, API_KEY_VALUE))
-            .andExpect(status().isOk())
+            .andExpect(status().isInternalServerError())
             .andExpect(jsonPath("$.runId").value(run.getId()))
             .andExpect(jsonPath("$.status").value("SUCCEEDED"))
             .andExpect(jsonPath("$.results").doesNotExist())


### PR DESCRIPTION
## Summary
This PR corrects the HTTP status codes returned by the simulation results endpoint to properly reflect the nature of each response, improving API semantics and client error handling.

## Key Changes
- **FAILED simulations**: Changed from 200 OK to 400 Bad Request, as a failed simulation is a client-side issue (the simulation itself failed)
- **SUCCEEDED but unreadable results**: Changed from 200 OK to 500 Internal Server Error, as an unreadable results file is a genuine server error
- **Type safety improvement**: Changed `status` field in `SimulationResultResponse` from `String` to `RunStatus` enum for better type safety and consistency
- **Updated documentation**: Clarified the endpoint's response codes in JavaDoc comments
- **Updated test**: Modified test assertion to expect 400 Bad Request for failed simulations

## Implementation Details
- The status field in `SimulationResultResponse` is now strongly typed as `RunStatus` enum instead of a string literal
- All factory methods in `SimulationResultResponse` now use enum values instead of string constants
- HTTP status codes now follow REST conventions: 4xx for client errors (failed simulation, invalid state) and 5xx for server errors (unreadable results file)

https://claude.ai/code/session_01JQseYNGW5n6FhiDmrhxJZP