### PR TITLE
fix(ci): replace dependency-check with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      maven-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      frontend-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,7 @@ jobs:
       run: mvn -q clean compile
 
     - name: Verify tests and coverage gate
-      # The OWASP dependency CVE scan runs in the separate, non-blocking
-      # "security-scan" job so a slow/flaky NVD update can never hang or block
-      # the test build. Skip it here.
-      run: mvn -q verify -Ddependency-check.skip=true
+      run: mvn -q verify
       env:
         SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/lift_simulator_test?currentSchema=lift_simulator
         SPRING_DATASOURCE_USERNAME: lift_admin
@@ -291,60 +288,4 @@ jobs:
           frontend/test-results/
           frontend/playwright-report/
           backend-e2e.log
-        retention-days: 30
-
-  security-scan:
-    name: OWASP dependency CVE scan (advisory)
-    runs-on: ubuntu-latest
-    # Advisory: this scan depends on the external NVD service, whose first-time
-    # database sync is slow and occasionally unreliable. continue-on-error keeps a
-    # slow/failed scan from blocking the workflow (and therefore PRs); it still
-    # surfaces real CVEs as a non-blocking red check. Flip this off to make the
-    # scan blocking again once the NVD cache is warm and the keyed sync is fast.
-    continue-on-error: true
-    timeout-minutes: 50
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'maven'
-
-    - name: Cache OWASP Dependency-Check data
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2/repository/org/owasp/dependency-check-data
-        # Rotate the key every run so each run persists the NVD data it downloaded.
-        # A fixed key is immutable once written, which would freeze a partial NVD
-        # database in the cache and never let a completed copy be saved. The layered
-        # restore-keys load the most recent prior cache so downloads accumulate
-        # across runs until one completes the initial sync.
-        key: dependency-check-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: |
-          dependency-check-${{ runner.os }}-
-
-    - name: Run OWASP dependency-check
-      run: |
-        if [ -n "$NVD_API_KEY" ]; then
-          echo "NVD_API_KEY is set; using the fast keyed path (nvd.api.delay=2000)."
-          mvn -q compile org.owasp:dependency-check-maven:check -Dnvd.api.delay=2000
-        else
-          echo "::warning::NVD_API_KEY is not set; using the slow anonymous NVD throttle."
-          mvn -q compile org.owasp:dependency-check-maven:check
-        fi
-      env:
-        NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-
-    - name: Upload dependency-check report
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: dependency-check-report
-        path: target/dependency-check-report.*
-        if-no-files-found: ignore
         retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 
+## [0.53.2] - 2026-06-23
+
+### Changed
+- **Dependabot dependency monitoring**: Removed the OWASP Dependency-Check Maven plugin and its non-blocking CI scan because NVD database downloads can hang in CI. Added weekly Dependabot updates for Maven, frontend npm packages, and GitHub Actions, and refreshed README/package metadata for the 0.53.2 patch release.
+
+
 ## [0.53.1] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.53.1**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.2**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.53.1.jar
+java -jar target/lift-simulator-0.53.2.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.53.1.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.2.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,28 +133,28 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.53.1.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.53.1.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.53.1.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.53.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
 
 ## Testing
 
-Run the full verification suite (tests, JaCoCo coverage gate, and OWASP dependency CVE scan):
+Run the full verification suite (tests and JaCoCo coverage gate):
 ```bash
 mvn verify
 ```
@@ -182,7 +182,7 @@ mvn test -Dtest=ControllerScenarioTest
 mvn test -Dtest=ControllerScenarioTest#testDirectionalScan_CanonicalScenario_FromReadme
 ```
 
-The project enforces a minimum **50% line coverage baseline** through JaCoCo during `mvn verify` for production business logic, excluding Spring wiring, DTO/entity/repository boilerplate, package descriptors, and CLI/application entrypoints. CI runs the same Maven phase so pull requests fail if the scoped coverage baseline drops below the threshold or the OWASP dependency CVE scan finds vulnerabilities at **CVSS 7.0 or higher**. Dependency-Check reads an optional `NVD_API_KEY` environment variable (configured in CI from the `NVD_API_KEY` repository secret), uses conservative NVD retry/delay settings, and caches its local NVD database to avoid API rate-limit failures. Generate only the coverage report (available at `target/site/jacoco/index.html`) with:
+The project enforces a minimum **50% line coverage baseline** through JaCoCo during `mvn verify` for production business logic, excluding Spring wiring, DTO/entity/repository boilerplate, package descriptors, and CLI/application entrypoints. CI runs the same Maven phase so pull requests fail if the scoped coverage baseline drops below the threshold. Dependency monitoring is handled by GitHub Dependabot for Maven, frontend npm packages, and GitHub Actions; Dependabot opens weekly update pull requests instead of running an NVD-backed OWASP Dependency-Check scan during CI. Generate only the coverage report (available at `target/site/jacoco/index.html`) with:
 ```bash
 mvn jacoco:report
 ```
@@ -204,12 +204,12 @@ In CI, the backend test job runs with `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`, 
 ```bash
 mvn checkstyle:check        # code style
 mvn spotbugs:check          # static analysis
-mvn verify                  # tests, JaCoCo coverage gate, and OWASP CVSS >= 7.0 dependency CVE scan
+mvn verify                  # tests and JaCoCo coverage gate
 ```
 
 SpotBugs suppressions are limited to Spring-managed dependency injection in service constructors.
 
-The OWASP dependency CVE scan retrieves vulnerability data from the National Vulnerability Database (NVD) API. This product uses the NVD API but is not endorsed or certified by the NVD.
+Dependabot is configured in `.github/dependabot.yml` to check Maven dependencies, frontend npm dependencies, and GitHub Actions weekly.
 
 ## Configuration
 
@@ -219,7 +219,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.1.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.2.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 
@@ -424,5 +424,3 @@ See [docs/decisions](docs/decisions) for the full Architecture Decision Records 
 MIT License - see [LICENSE](LICENSE) file for details.
 
 ## Acknowledgements
-
-This product uses the NVD API but is not endorsed or certified by the NVD.

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.53.1.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.2.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.53.1.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.53.1.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -408,7 +408,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.53.1.jar \
+   java -cp target/lift-simulator-0.53.2.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -453,7 +453,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -545,7 +545,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.53.1.jar \
+java -cp target/lift-simulator-0.53.2.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.53.1",
+      "version": "0.53.2",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.53.1",
+  "version": "0.53.2",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.53.1</version>
+    <version>0.53.2</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -26,13 +26,6 @@
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <frontend.dir>${project.basedir}/frontend</frontend.dir>
         <frontend.build.dir>${frontend.dir}/dist</frontend.build.dir>
-        <!--
-            OWASP dependency-check NVD API throttle. Defaults to the plugin's no-key
-            value (10s) so anonymous runs (forked PRs, local builds without a key) stay
-            within NVD's anonymous rate limit. CI overrides this to a small value when an
-            NVD_API_KEY is present so the keyed scan completes quickly.
-        -->
-        <nvd.api.delay>10000</nvd.api.delay>
     </properties>
 
     <dependencies>
@@ -307,31 +300,6 @@
                                 </rule>
                             </rules>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.2</version>
-                <configuration>
-                    <failBuildOnCVSS>7.0</failBuildOnCVSS>
-                    <nvdApiKeyEnvironmentVariable>NVD_API_KEY</nvdApiKeyEnvironmentVariable>
-                    <!--
-                        Throttle between NVD API calls. Property-driven so the keyed CI path
-                        can use a small delay (fast scan) while the default stays at the
-                        plugin's no-key value (10s); see the nvd.api.delay property above.
-                    -->
-                    <nvdApiDelay>${nvd.api.delay}</nvdApiDelay>
-                    <nvdMaxRetryCount>20</nvdMaxRetryCount>
-                    <nvdValidForHours>24</nvdValidForHours>
-                    <dataDirectory>${user.home}/.m2/repository/org/owasp/dependency-check-data</dataDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### Motivation

- OWASP `dependency-check-maven` hangs in CI while downloading the NVD database and is unreliable for PRs, so dependency monitoring should be moved to GitHub Dependabot.

### Description

- Removed the OWASP Dependency-Check plugin and the `nvd.api.delay` property from `pom.xml` and eliminated its execution from the Maven build.
- Removed the advisory `security-scan` job from `.github/workflows/ci.yml` and restored the backend verify step to run `mvn -q verify` (no `-Ddependency-check.skip=true`).
- Added `.github/dependabot.yml` to enable weekly Dependabot updates for `maven`, frontend `npm`, and `github-actions` package-ecosystems.
- Bumped the project patch version to `0.53.2` and synchronized `README.md`, `frontend/package.json`, `frontend/package-lock.json`, and relevant docs and examples; added a `0.53.2` changelog entry describing the change.

### Testing

- ⚠️ Attempted `mvn -q verify` locally but it failed due to repository/environment network resolution of `org.springframework.boot:spring-boot-starter-parent` (HTTP 403), so full Maven verification could not be completed in this environment.
- ✅ Ran a version-consistency check via a Python snippet that validated `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json` all reference `0.53.2` successfully.
- ✅ Performed text/grep-based checks to confirm removal of `dependency-check` configuration and addition of `.github/dependabot.yml` and updated README/CHANGELOG entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39fddc4548832593fda3ac6e0837fa)