### PR TITLE
fix: harden simulation run execution IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 
+## [0.53.3] - 2026-06-23
+
+### Fixed
+- **Simulation run execution IO correctness**: Avoided reopening `run.log` while handling in-process cancellation, skipped same-floor passenger flows when generating downloadable `input.scenario` artefacts so CLI reproduction matches execution, and removed the discarded progress reload after direct tick updates. Updated README and package metadata for the 0.53.3 patch release.
+
 ## [0.53.2] - 2026-06-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.53.2**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.3**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -90,7 +90,7 @@ The **frontend admin UI** provides:
 - **Lift Systems Management** — full CRUD with list and detail views
 - **Version Management** — create, publish, and archive versioned configurations with optimistic locking, single-published-version enforcement, pagination, sorting, filtering, complete JSON examples, and schema guidance in the configuration editor
 - **Scenario Builder** — template-based or custom passenger-flow scenarios with server-side validation, validated copy-to-version reuse, and an advanced JSON editor
-- **Simulator Runs** — launch published versions with scenarios, poll status, recover orphaned active runs after restarts, list runs with capped pagination and documented sorting (`createdAt`, `startedAt`, `endedAt`, `status`, `id`; ignore-case modifiers rejected), bulk-cancel active runs, bulk-delete completed runs with post-commit artefact cleanup, and review pickup-latency KPI results with artefact downloads and CLI reproduction hints. Run creation uses the same lift-system-scoped `versionNumber` identifier as the version-management API, avoiding surrogate version row IDs in client requests.
+- **Simulator Runs** — launch published versions with scenarios, poll status, recover orphaned active runs after restarts, list runs with capped pagination and documented sorting (`createdAt`, `startedAt`, `endedAt`, `status`, `id`; ignore-case modifiers rejected), bulk-cancel active runs, bulk-delete completed runs with post-commit artefact cleanup, and review pickup-latency KPI results with artefact downloads and CLI reproduction hints. Generated `input.scenario` artefacts skip same-floor passenger flows so CLI reproduction matches the in-process executor. Run creation uses the same lift-system-scoped `versionNumber` identifier as the version-management API, avoiding surrogate version row IDs in client requests.
 - **Configuration Editor & Validator** — edit and validate configuration JSON before publishing
 - **Health Check** — monitor backend service status
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.53.2.jar
+java -jar target/lift-simulator-0.53.3.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.53.2.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.3.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,21 +133,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.53.2.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -219,7 +219,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.2.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.3.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.53.2.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.3.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.53.2.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.53.2.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -408,7 +408,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.53.2.jar \
+   java -cp target/lift-simulator-0.53.3.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -453,7 +453,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -545,7 +545,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.53.2.jar \
+java -cp target/lift-simulator-0.53.3.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.53.2",
+  "version": "0.53.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.53.2",
+      "version": "0.53.3",
       "dependencies": {
         "axios": "^1.17.0",
         "react": "^19.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.53.2",
+  "version": "0.53.3",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.53.2</version>
+    <version>0.53.3</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/service/BatchInputGenerator.java
+++ b/src/main/java/com/liftsimulator/admin/service/BatchInputGenerator.java
@@ -167,6 +167,9 @@ public class BatchInputGenerator {
 
         for (PassengerFlowDTO flow : passengerFlows) {
             String direction = determineDirection(flow.originFloor(), flow.destinationFloor());
+            if (direction == null) {
+                continue;
+            }
 
             for (int i = 0; i < flow.passengers(); i++) {
                 String alias = String.format(Locale.ROOT, "p%d", passengerCounter++);
@@ -183,7 +186,13 @@ public class BatchInputGenerator {
     }
 
     private String determineDirection(int originFloor, int destinationFloor) {
-        return destinationFloor > originFloor ? "UP" : "DOWN";
+        if (destinationFloor > originFloor) {
+            return "UP";
+        }
+        if (destinationFloor < originFloor) {
+            return "DOWN";
+        }
+        return null;
     }
 
     private void writeScenarioFile(Path outputPath, String content) throws IOException {

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -457,15 +457,6 @@ public class SimulationRunExecutionService {
         cancelRunSafely(runId, message);
     }
 
-    private void cancelRunSafely(Long runId, Path logPath, String message) {
-        try (BufferedWriter logWriter = Files.newBufferedWriter(logPath, StandardCharsets.UTF_8, java.nio.file.StandardOpenOption.APPEND)) {
-            log(logWriter, message);
-        } catch (IOException ex) {
-            logger.warn("Failed to append cancellation message to run log for run {}", runId, ex);
-        }
-        cancelRunSafely(runId, message);
-    }
-
     private void cancelRunSafely(Long runId, String message) {
         try {
             SimulationRun run = getRunById(runId);

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -216,7 +216,14 @@ public class SimulationRunExecutionService {
             updateProgress(request.runId(), 0L);
             log(logWriter, "Simulation started for run " + request.runId());
 
-            RunMetrics metrics = runSimulation(request.runId(), config, scenario, logWriter, cancelToken);
+            RunMetrics metrics;
+            try {
+                metrics = runSimulation(request.runId(), config, scenario, logWriter, cancelToken);
+            } catch (RunCancelledException ex) {
+                cancelRunSafely(request.runId(), logWriter, ex.getMessage());
+                writeResults(request.runId(), runDir, ex.getConfig(), ex.getScenario(), ex.getMetrics(), "CANCELLED", ex.getMessage());
+                return;
+            }
 
             if (cancelToken.isCancelled() || getRunById(request.runId()).getStatus() == SimulationRun.RunStatus.CANCELLED) {
                 log(logWriter, "Run cancelled for run " + request.runId());
@@ -226,13 +233,6 @@ public class SimulationRunExecutionService {
             log(logWriter, "Simulation succeeded for run " + request.runId());
             writeResults(request.runId(), runDir, config, scenario, metrics, "SUCCEEDED", null);
             succeedRun(request.runId());
-        } catch (RunCancelledException ex) {
-            try {
-                cancelRunSafely(request.runId(), logPath, ex.getMessage());
-                writeResults(request.runId(), runDir, ex.getConfig(), ex.getScenario(), ex.getMetrics(), "CANCELLED", ex.getMessage());
-            } catch (IOException ioEx) {
-                logger.warn("Failed to write cancellation results file for run {}", request.runId(), ioEx);
-            }
         } catch (IOException | RuntimeException ex) {
             String errorMessage = safeMessage(ex);
             logger.error("Simulation run {} failed", request.runId(), ex);
@@ -377,12 +377,11 @@ public class SimulationRunExecutionService {
         return runRepository.save(run);
     }
 
-    private SimulationRun updateProgress(Long runId, Long currentTick) {
+    private void updateProgress(Long runId, Long currentTick) {
         int updated = runRepository.updateCurrentTick(runId, currentTick);
         if (updated == 0) {
             throw new ResourceNotFoundException("Simulation run not found with id: " + runId);
         }
-        return getRunById(runId);
     }
 
     private void writeInputFiles(RunExecutionRequest request, Path runDir, BufferedWriter logWriter) throws IOException {

--- a/src/test/java/com/liftsimulator/admin/service/BatchInputGeneratorTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/BatchInputGeneratorTest.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -85,6 +86,29 @@ public class BatchInputGeneratorTest {
 
         // Check for hall call event (1 passenger at tick 10, origin 7, going DOWN to 2)
         assertTrue(result.contains("10, hall_call, p3, 7, DOWN"));
+    }
+
+    @Test
+    public void testGenerateScenarioContent_SkipsSameFloorFlows() throws IOException {
+        LiftConfigDTO liftConfig = new LiftConfigDTO(
+                0, 10, 1, 1, 1, 1, 0, 0, 5,
+                ControllerStrategy.NEAREST_REQUEST_ROUTING,
+                IdleParkingMode.PARK_TO_HOME_FLOOR
+        );
+
+        PassengerFlowDTO sameFloorFlow = new PassengerFlowDTO(0, 3, 3, 2);
+        PassengerFlowDTO movingFlow = new PassengerFlowDTO(1, 2, 5, 1);
+        ScenarioDefinitionDTO scenario = new ScenarioDefinitionDTO(
+                20,
+                List.of(sameFloorFlow, movingFlow),
+                null
+        );
+
+        String result = generator.generateScenarioContent(liftConfig, scenario, "Same Floor Test");
+
+        assertFalse(result.contains("0, hall_call"));
+        assertFalse(result.contains(", 3, DOWN"));
+        assertTrue(result.contains("1, hall_call, p1, 2, UP"));
     }
 
     @Test

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -127,22 +126,16 @@ public class SimulationRunExecutionServiceTest {
     }
 
     @Test
-    public void testUpdateProgressUsesRepositoryDirectly() throws Exception {
-        SimulationRun run = new SimulationRun();
-        run.setId(1L);
-        run.setCurrentTick(500L);
+    public void testUpdateProgressUsesRepositoryDirectlyWithoutReloadingRun() throws Exception {
         when(runRepository.updateCurrentTick(1L, 500L)).thenReturn(1);
-        when(runRepository.findById(1L)).thenReturn(Optional.of(run));
 
         Method updateProgress = SimulationRunExecutionService.class.getDeclaredMethod(
                 "updateProgress", Long.class, Long.class);
         updateProgress.setAccessible(true);
-        SimulationRun result = (SimulationRun) updateProgress.invoke(executionService, 1L, 500L);
+        updateProgress.invoke(executionService, 1L, 500L);
 
-        assertNotNull(result);
-        assertEquals(500L, result.getCurrentTick());
         verify(runRepository).updateCurrentTick(1L, 500L);
-        verify(runRepository).findById(1L);
+        verify(runRepository, never()).findById(1L);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Fix IO and behaviour defects observed during simulation execution: reopening `run.log` twice on cancellation, generating bogus same-floor `hall_call` events in downloadable `input.scenario`, and re-reading the run after direct progress updates.

### Description

- Use the active `BufferedWriter` (`logWriter`) when handling in-process cancellation instead of reopening an append writer, and handle `RunCancelledException` inside the main execution flow so cancellation writes use the same writer and scope. 
- Stop reloading the `SimulationRun` after updating progress; `updateProgress` now performs a direct repository `updateCurrentTick` and no longer returns/reads the run entity. 
- Make the batch input generator skip same-floor passenger flows by returning `null` for same-floor direction in `determineDirection` and skipping those flows when generating `hall_call` events so CLI `input.scenario` output matches in-process executor behaviour. 
- Add/adjust unit tests to cover the fixes: `BatchInputGeneratorTest#testGenerateScenarioContent_SkipsSameFloorFlows` and `SimulationRunExecutionServiceTest#testUpdateProgressUsesRepositoryDirectlyWithoutReloadingRun`. 
- Bump repository/version metadata to `0.53.3`, update `CHANGELOG.md`, `README.md`, and related docs to document the behaviour change and release note.

### Testing

- Attempted to run unit tests via `mvn -q -Dtest=SimulationRunExecutionServiceTest,BatchInputGeneratorTest test`, but the run was blocked by a Maven Central resolution error (HTTP 403 for `org.springframework.boot:spring-boot-starter-parent:pom:3.4.13`).
- Added and updated unit tests in `src/test/java/com/liftsimulator/admin/service/BatchInputGeneratorTest.java` and `src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java` to validate same-floor skipping and avoiding run reload on progress update; these tests were committed but full execution was blocked by the dependency resolution issue. 
- Ran repository checks: `git diff --check` (no whitespace errors) and local `git` commit verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a0b7c439c832585f04c300d410e92)