### PR TITLE
Downgrade Spring Boot from 4.1.0 to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>3.4.0</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary
This pull request downgrades the Spring Boot parent version from 4.1.0 to 3.4.0 in the project's Maven configuration.

## Key Changes
- Updated `spring-boot-starter-parent` version from 4.1.0 to 3.4.0 in pom.xml

## Notes
This is a significant version downgrade that moves from Spring Boot 4.x to 3.x. This change may impact:
- Java version compatibility requirements
- Dependency versions and transitive dependencies
- API compatibility with Spring Boot 4.x features

Please ensure all tests pass and verify that the application is compatible with Spring Boot 3.4.0.

https://claude.ai/code/session_01FXn3fobiKizCgVCa7UkHjH