### PR TITLE
fix(deps): revert springdoc and JUnit to Spring Boot 3.x compatible v…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <junit-jupiter.version>6.1.0</junit-jupiter.version>
+        <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <frontend.dir>${project.basedir}/frontend</frontend.dir>
         <frontend.build.dir>${frontend.dir}/dist</frontend.build.dir>
     </properties>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.3</version>
+            <version>2.7.0</version>
         </dependency>
 
         <!-- Spring Boot Test Starter -->


### PR DESCRIPTION
…ersions

springdoc-openapi 3.x targets Spring Boot 4.x and pulls Spring Boot 4.x autoconfigure classes onto the classpath, causing BeanDefinitionOverrideException when the parent is Spring Boot 3.4.0. Revert to springdoc 2.7.0 which is the Spring Boot 3.x compatible line.

JUnit Jupiter 6.1.0 is similarly incompatible with Spring Boot 3.4.0's test infrastructure; revert to 5.10.1.


Claude-Session: https://claude.ai/code/session_01FXn3fobiKizCgVCa7UkHjH