### PR TITLE
fix(spotbugs): remove unnecessary EI_EXPOSE_REP2 suppression from Con…

### DIFF
--- a/src/main/java/com/liftsimulator/admin/controller/ConfigValidationController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/ConfigValidationController.java
@@ -3,7 +3,6 @@ package com.liftsimulator.admin.controller;
 import com.liftsimulator.admin.dto.ConfigValidationRequest;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.service.ConfigValidationService;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,11 +19,6 @@ public class ConfigValidationController {
 
     private final ConfigValidationService configValidationService;
 
-    @SuppressFBWarnings(
-            value = "EI_EXPOSE_REP2",
-            justification = "Spring-managed service injected via constructor. "
-                    + "Lifecycle and immutability managed by Spring container."
-    )
     public ConfigValidationController(ConfigValidationService configValidationService) {
         this.configValidationService = configValidationService;
     }


### PR DESCRIPTION
…figValidationController

SpotBugs 4.10.2 introduced US_USELESS_SUPPRESSION_ON_METHOD which flags suppressions that do not correspond to an actual detected bug. The suppression on the constructor was not needed since ConfigValidationService is a Spring-managed interface, not a mutable type that triggers EI_EXPOSE_REP2.


Claude-Session: https://claude.ai/code/session_01FXn3fobiKizCgVCa7UkHjH