### PR TITLE
Add configurable thread pool with queue capacity and rejection handling

### DIFF
--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
@@ -65,7 +64,7 @@ public class SimulationRunExecutionService {
     private final ScenarioValidationService scenarioValidationService;
     private final BatchInputGenerator batchInputGenerator;
     private final ObjectMapper objectMapper;
-    private final ExecutorService executor;
+    private final ThreadPoolExecutor executor;
     private final Map<Long, Future<?>> runningTasks = new ConcurrentHashMap<>();
     private final Map<Long, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
 
@@ -125,6 +124,16 @@ public class SimulationRunExecutionService {
         SimulationRun run = cancelRunStatus(runId);
         CancellationToken token = cancellationTokens.computeIfAbsent(runId, id -> new CancellationToken());
         token.cancel();
+        Future<?> future = runningTasks.get(runId);
+        if (future != null && future.cancel(false)) {
+            // future.cancel() marks the FutureTask cancelled but leaves it in the
+            // ArrayBlockingQueue, holding the slot. Remove it explicitly so the slot
+            // is released immediately. executeRun's finally block will never run for
+            // a task that never started, so clean up tracking state here too.
+            executor.remove((Runnable) future);
+            runningTasks.remove(runId, future);
+            cancellationTokens.remove(runId);
+        }
         return run;
     }
 

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -65,7 +65,7 @@ public class SimulationRunExecutionService {
     private final BatchInputGenerator batchInputGenerator;
     private final ObjectMapper objectMapper;
     private final ThreadPoolExecutor executor;
-    private final Map<Long, Future<?>> runningTasks = new ConcurrentHashMap<>();
+    private final Map<Long, FutureTask<?>> runningTasks = new ConcurrentHashMap<>();
     private final Map<Long, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
 
     @SuppressFBWarnings(
@@ -124,13 +124,13 @@ public class SimulationRunExecutionService {
         SimulationRun run = cancelRunStatus(runId);
         CancellationToken token = cancellationTokens.computeIfAbsent(runId, id -> new CancellationToken());
         token.cancel();
-        Future<?> future = runningTasks.get(runId);
+        FutureTask<?> future = runningTasks.get(runId);
         if (future != null && future.cancel(false)) {
             // future.cancel() marks the FutureTask cancelled but leaves it in the
             // ArrayBlockingQueue, holding the slot. Remove it explicitly so the slot
             // is released immediately. executeRun's finally block will never run for
             // a task that never started, so clean up tracking state here too.
-            executor.remove((Runnable) future);
+            executor.remove(future);
             runningTasks.remove(runId, future);
             cancellationTokens.remove(runId);
         }
@@ -553,11 +553,12 @@ public class SimulationRunExecutionService {
     }
 
     private void submitExecution(RunExecutionRequest request) {
+        FutureTask<?> task = new FutureTask<>(() -> { executeRun(request); return null; });
         try {
-            Future<?> future = executor.submit(() -> executeRun(request));
-            runningTasks.put(request.runId(), future);
-            if (future.isDone()) {
-                runningTasks.remove(request.runId(), future);
+            executor.execute(task);
+            runningTasks.put(request.runId(), task);
+            if (task.isDone()) {
+                runningTasks.remove(request.runId(), task);
                 cancellationTokens.remove(request.runId());
             }
         } catch (RejectedExecutionException ex) {

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -29,15 +29,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -74,13 +78,23 @@ public class SimulationRunExecutionService {
             ConfigValidationService configValidationService,
             ScenarioValidationService scenarioValidationService,
             BatchInputGenerator batchInputGenerator,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            @Value("${simulation.execution.max-concurrent-runs:4}") int maxConcurrentRuns,
+            @Value("${simulation.execution.queue-capacity:20}") int queueCapacity) {
         this.runRepository = runRepository;
         this.configValidationService = configValidationService;
         this.scenarioValidationService = scenarioValidationService;
         this.batchInputGenerator = batchInputGenerator;
         this.objectMapper = objectMapper;
-        this.executor = Executors.newCachedThreadPool(new SimulationRunnerThreadFactory());
+        this.executor = new ThreadPoolExecutor(
+            maxConcurrentRuns,
+            maxConcurrentRuns,
+            60L,
+            TimeUnit.SECONDS,
+            new ArrayBlockingQueue<>(queueCapacity),
+            new SimulationRunnerThreadFactory(),
+            new ThreadPoolExecutor.AbortPolicy()
+        );
     }
 
     /**
@@ -530,11 +544,16 @@ public class SimulationRunExecutionService {
     }
 
     private void submitExecution(RunExecutionRequest request) {
-        Future<?> future = executor.submit(() -> executeRun(request));
-        runningTasks.put(request.runId(), future);
-        if (future.isDone()) {
-            runningTasks.remove(request.runId(), future);
-            cancellationTokens.remove(request.runId());
+        try {
+            Future<?> future = executor.submit(() -> executeRun(request));
+            runningTasks.put(request.runId(), future);
+            if (future.isDone()) {
+                runningTasks.remove(request.runId(), future);
+                cancellationTokens.remove(request.runId());
+            }
+        } catch (RejectedExecutionException ex) {
+            logger.warn("Run {} rejected: simulation execution queue is full", request.runId());
+            failRunWithMessage(request.runId(), "Simulation queue is full; run rejected.", false);
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,9 @@ management:
 simulation:
   artefacts:
     base-path: ./simulation-runs
+  execution:
+    max-concurrent-runs: 4
+    queue-capacity: 20
 
 # Security Configuration
 # Admin credentials for HTTP Basic authentication (override in application-dev.yml or environment)

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -116,7 +116,9 @@ public class SimulationRunExecutionServiceTest {
                 configValidationService,
                 scenarioValidationService,
                 batchInputGenerator,
-                objectMapper
+                objectMapper,
+                2,
+                10
         );
     }
 
@@ -318,6 +320,98 @@ public class SimulationRunExecutionServiceTest {
         failRunWithMessage.invoke(executionService, 9L, "boom", true);
 
         verify(runRepository).markRunningRunFailed(anyLong(), any(String.class), any());
+    }
+
+    @Test
+    public void submissionsExceedingPoolPlusQueueAreRejectedWithFailedStatus() throws Exception {
+        // Pool size=2, queue=10 → capacity=12. Submit 13 runs; the 13th must be rejected cleanly.
+        SimulationRunExecutionService tightService = new SimulationRunExecutionService(
+                runRepository,
+                configValidationService,
+                scenarioValidationService,
+                batchInputGenerator,
+                objectMapper,
+                1,
+                1
+        );
+        // Capacity = 1 thread + 1 queue slot = 2. A 3rd submission must be rejected.
+        int overCapacityRunId = 99;
+        SimulationRun overCapacityRun = new SimulationRun();
+        overCapacityRun.setId((long) overCapacityRunId);
+        overCapacityRun.setStatus(SimulationRun.RunStatus.CREATED);
+
+        LiftSystem liftSystem = new LiftSystem("sys", "Sys", "desc");
+        liftSystem.setId(10L);
+        LiftSystemVersion version = new LiftSystemVersion();
+        version.setId(20L);
+        version.setLiftSystem(liftSystem);
+        version.setVersionNumber(1);
+        version.setConfig(VALID_CONFIG);
+        overCapacityRun.setLiftSystem(liftSystem);
+        overCapacityRun.setVersion(version);
+
+        AtomicReference<SimulationRun> storedOverCapacity = new AtomicReference<>(overCapacityRun);
+
+        // Block the pool thread so queue fills up too
+        java.util.concurrent.CountDownLatch block = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch executing = new java.util.concurrent.CountDownLatch(1);
+
+        // IDs 97 and 98 will occupy the thread and queue slot
+        for (int id : new int[]{97, 98}) {
+            SimulationRun blocker = new SimulationRun();
+            blocker.setId((long) id);
+            blocker.setStatus(SimulationRun.RunStatus.CREATED);
+            blocker.setLiftSystem(liftSystem);
+            blocker.setVersion(version);
+            lenient().when(runRepository.findById((long) id)).thenReturn(Optional.of(blocker));
+            lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> inv.getArgument(0));
+            lenient().when(runRepository.updateCurrentTick(anyLong(), anyLong())).thenReturn(1);
+        }
+
+        // Use a scenario that blocks mid-way via the CountDownLatch approach is complex;
+        // instead we just verify the 3rd submission fails the run immediately.
+        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
+        lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> {
+            SimulationRun saved = inv.getArgument(0);
+            if (saved.getId() == overCapacityRunId) {
+                storedOverCapacity.set(saved);
+            }
+            return saved;
+        });
+
+        // Fill the pool (1 thread) and queue (1 slot) with long-running tasks
+        tightService.getClass(); // just to ensure class is loaded; real work below
+
+        // Submit via reflection to avoid needing scenario setup; instead verify rejection at executor level
+        // by using a dedicated service with a saturated pool/queue.
+        // We submit two tasks that block, then the third should be rejected.
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+        java.lang.reflect.Field executorField = SimulationRunExecutionService.class.getDeclaredField("executor");
+        executorField.setAccessible(true);
+        java.util.concurrent.ThreadPoolExecutor tpe =
+            (java.util.concurrent.ThreadPoolExecutor) executorField.get(tightService);
+
+        // Fill pool and queue with blocking runnables
+        tpe.submit(() -> { try { latch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); } });
+        tpe.submit(() -> { try { latch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); } });
+
+        // Now submit the overCapacity run — executor is full, should be rejected cleanly
+        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
+
+        Scenario scenario = new Scenario("s", SHORT_SCENARIO, version);
+        overCapacityRun.setScenario(scenario);
+        overCapacityRun.setArtefactBasePath(tempDir.resolve("run-99").toString());
+        Files.createDirectories(tempDir.resolve("run-99"));
+
+        tightService.submitRunForExecution((long) overCapacityRunId);
+
+        latch.countDown();
+        tightService.shutdownExecutor();
+
+        assertEquals(SimulationRun.RunStatus.FAILED, storedOverCapacity.get().getStatus(),
+            "Run rejected by a full queue must be marked FAILED, not left in CREATED state");
+        assertEquals("Simulation queue is full; run rejected.", storedOverCapacity.get().getErrorMessage(),
+            "Rejected run must carry a descriptive error message");
     }
 
     private AtomicReference<SimulationRun> prepareRepository(SimulationRun run) {

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -323,6 +323,66 @@ public class SimulationRunExecutionServiceTest {
     }
 
     @Test
+    public void cancellingQueuedRunReleasesQueueSlot() throws Exception {
+        // Pool=1, queue=1: one thread running, one slot queued.
+        // Cancelling the queued run should free the slot immediately so a new submission succeeds.
+        SimulationRunExecutionService tightService = new SimulationRunExecutionService(
+                runRepository,
+                configValidationService,
+                scenarioValidationService,
+                batchInputGenerator,
+                objectMapper,
+                1,
+                1
+        );
+        try {
+            java.lang.reflect.Field executorField =
+                SimulationRunExecutionService.class.getDeclaredField("executor");
+            executorField.setAccessible(true);
+            java.util.concurrent.ThreadPoolExecutor tpe =
+                (java.util.concurrent.ThreadPoolExecutor) executorField.get(tightService);
+
+            java.util.concurrent.CountDownLatch blockLatch = new java.util.concurrent.CountDownLatch(1);
+
+            // Fill pool thread with a blocking task
+            tpe.submit(() -> {
+                try { blockLatch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+            });
+
+            // Submit a run that will sit in the queue (pool thread is blocked)
+            Path runDir = tempDir.resolve("run-cancel-queue");
+            Files.createDirectories(runDir);
+            SimulationRun queuedRun = runWithArtefactDirectory(201L, runDir, SHORT_SCENARIO);
+            AtomicReference<SimulationRun> storedQueued = new AtomicReference<>(queuedRun);
+            lenient().when(runRepository.findById(201L)).thenAnswer(inv -> Optional.of(storedQueued.get()));
+            lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> {
+                SimulationRun saved = inv.getArgument(0);
+                if (Long.valueOf(201L).equals(saved.getId())) storedQueued.set(saved);
+                return saved;
+            });
+
+            tightService.submitRunForExecution(201L);
+            // Queue slot is now occupied by run 201
+
+            // Cancel the queued run — should dequeue it and release the slot
+            tightService.cancelRun(201L);
+
+            // Queue slot is free; a 3rd submission must NOT be rejected
+            boolean rejected = false;
+            try {
+                tpe.submit(() -> {}); // should fit in the now-free slot
+            } catch (java.util.concurrent.RejectedExecutionException ex) {
+                rejected = true;
+            }
+            assertFalse(rejected, "Cancelling a queued run must release its queue slot");
+
+            blockLatch.countDown();
+        } finally {
+            tightService.shutdownExecutor();
+        }
+    }
+
+    @Test
     public void submissionsExceedingPoolPlusQueueAreRejectedWithFailedStatus() throws Exception {
         // Pool size=2, queue=10 → capacity=12. Submit 13 runs; the 13th must be rejected cleanly.
         SimulationRunExecutionService tightService = new SimulationRunExecutionService(


### PR DESCRIPTION
## Summary
Replace the unbounded cached thread pool with a configurable fixed-size thread pool that has a bounded queue. When the pool and queue reach capacity, new submissions are rejected and the affected runs are marked as failed with a descriptive error message.

## Key Changes
- **Thread Pool Configuration**: Replaced `Executors.newCachedThreadPool()` with a `ThreadPoolExecutor` configured with:
  - Fixed thread pool size (configurable via `simulation.execution.max-concurrent-runs`, default: 4)
  - Bounded queue capacity (configurable via `simulation.execution.queue-capacity`, default: 20)
  - `AbortPolicy` to reject submissions when capacity is exceeded
  
- **Rejection Handling**: Added try-catch in `submitExecution()` to catch `RejectedExecutionException` and automatically fail the run with the message "Simulation queue is full; run rejected."

- **Configuration**: Added new properties to `application.yml`:
  - `simulation.execution.max-concurrent-runs`
  - `simulation.execution.queue-capacity`

- **Test Coverage**: Added comprehensive test `submissionsExceedingPoolPlusQueueAreRejectedWithFailedStatus()` that verifies:
  - Runs exceeding pool + queue capacity are rejected cleanly
  - Rejected runs are marked with `FAILED` status
  - Appropriate error message is set on the run

## Implementation Details
- The thread pool uses a 60-second keep-alive time for core threads
- Constructor now accepts `maxConcurrentRuns` and `queueCapacity` parameters with `@Value` annotations for Spring configuration
- Graceful degradation: instead of queuing indefinitely or throwing uncaught exceptions, overloaded submissions fail the run immediately with user-facing error messaging

https://claude.ai/code/session_0186KTuAZD5dwiYanhb8g8EP