### PR TITLE
Fix equals/hashCode to use id instead of mutable fields

### DIFF
--- a/src/main/java/com/liftsimulator/admin/entity/LiftSystem.java
+++ b/src/main/java/com/liftsimulator/admin/entity/LiftSystem.java
@@ -153,12 +153,12 @@ public class LiftSystem {
             return false;
         }
         LiftSystem that = (LiftSystem) o;
-        return Objects.equals(id, that.id);
+        return id != null && id.equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return getClass().hashCode();
     }
 
     @Override

--- a/src/main/java/com/liftsimulator/admin/entity/LiftSystem.java
+++ b/src/main/java/com/liftsimulator/admin/entity/LiftSystem.java
@@ -153,12 +153,12 @@ public class LiftSystem {
             return false;
         }
         LiftSystem that = (LiftSystem) o;
-        return Objects.equals(systemKey, that.systemKey);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(systemKey);
+        return Objects.hash(id);
     }
 
     @Override

--- a/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
+++ b/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
@@ -213,13 +213,12 @@ public class LiftSystemVersion {
             return false;
         }
         LiftSystemVersion that = (LiftSystemVersion) o;
-        return Objects.equals(liftSystem, that.liftSystem)
-                && Objects.equals(versionNumber, that.versionNumber);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(liftSystem, versionNumber);
+        return Objects.hash(id);
     }
 
     @Override

--- a/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
+++ b/src/main/java/com/liftsimulator/admin/entity/LiftSystemVersion.java
@@ -213,12 +213,12 @@ public class LiftSystemVersion {
             return false;
         }
         LiftSystemVersion that = (LiftSystemVersion) o;
-        return Objects.equals(id, that.id);
+        return id != null && id.equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return getClass().hashCode();
     }
 
     @Override

--- a/src/test/java/com/liftsimulator/admin/repository/LiftSystemVersionRepositoryTest.java
+++ b/src/test/java/com/liftsimulator/admin/repository/LiftSystemVersionRepositoryTest.java
@@ -294,6 +294,32 @@ public class LiftSystemVersionRepositoryTest {
     }
 
     @Test
+    public void testTransientLiftSystemsAreDistinctInSet() {
+        LiftSystem a = new LiftSystem("key-a", "System A", "desc");
+        LiftSystem b = new LiftSystem("key-b", "System B", "desc");
+
+        Set<LiftSystem> set = new HashSet<>();
+        set.add(a);
+        set.add(b);
+
+        assertEquals(2, set.size(), "Two distinct transient LiftSystems must not collapse to one in a HashSet");
+        assertFalse(a.equals(b), "Transient LiftSystems with null ids must not be equal");
+    }
+
+    @Test
+    public void testTransientLiftSystemVersionsAreDistinctInSet() {
+        LiftSystemVersion a = new LiftSystemVersion(testSystem, 1, "{}");
+        LiftSystemVersion b = new LiftSystemVersion(testSystem, 2, "{}");
+
+        Set<LiftSystemVersion> set = new HashSet<>();
+        set.add(a);
+        set.add(b);
+
+        assertEquals(2, set.size(), "Two distinct transient LiftSystemVersions must not collapse to one in a HashSet");
+        assertFalse(a.equals(b), "Transient LiftSystemVersions with null ids must not be equal");
+    }
+
+    @Test
     public void testCascadeDeleteVersionsWithParentSystem() {
         LiftSystemVersion v1 = new LiftSystemVersion(testSystem, 1, "{}");
         LiftSystemVersion v2 = new LiftSystemVersion(testSystem, 2, "{}");

--- a/src/test/java/com/liftsimulator/admin/repository/LiftSystemVersionRepositoryTest.java
+++ b/src/test/java/com/liftsimulator/admin/repository/LiftSystemVersionRepositoryTest.java
@@ -11,8 +11,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -245,6 +247,50 @@ public class LiftSystemVersionRepositoryTest {
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             org.junit.jupiter.api.Assertions.fail("Failed to parse JSON: " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testLiftSystemSetMembershipStableAfterSystemKeyMutation() {
+        LiftSystem system = new LiftSystem("original-key", "System", "desc");
+        entityManager.persist(system);
+        entityManager.flush();
+
+        Set<LiftSystem> set = new HashSet<>();
+        set.add(system);
+        assertTrue(set.contains(system));
+
+        system.setSystemKey("mutated-key");
+
+        assertTrue(set.contains(system), "Set membership must be stable after mutating systemKey");
+    }
+
+    @Test
+    public void testLiftSystemVersionSetMembershipStableAfterVersionNumberMutation() {
+        LiftSystemVersion version = new LiftSystemVersion(testSystem, 1, "{}");
+        entityManager.persist(version);
+        entityManager.flush();
+
+        Set<LiftSystemVersion> set = new HashSet<>();
+        set.add(version);
+        assertTrue(set.contains(version));
+
+        version.setVersionNumber(99);
+
+        assertTrue(set.contains(version), "Set membership must be stable after mutating versionNumber");
+    }
+
+    @Test
+    public void testRemoveVersionFromCollectionAfterMutation() {
+        LiftSystemVersion v1 = new LiftSystemVersion(testSystem, 1, "{}");
+        entityManager.persist(v1);
+        entityManager.flush();
+
+        testSystem.addVersion(v1);
+
+        v1.setVersionNumber(42);
+
+        assertTrue(testSystem.getVersions().remove(v1),
+                "removeVersion must succeed after mutating versionNumber");
     }
 
     @Test


### PR DESCRIPTION
## Summary
Changed the `equals()` and `hashCode()` implementations in `LiftSystem` and `LiftSystemVersion` entities to use the immutable `id` field instead of mutable business key fields (`systemKey` and `versionNumber`). This ensures stable object identity and set membership regardless of field mutations.

## Key Changes
- **LiftSystem**: Changed `equals()` and `hashCode()` to use `id` instead of `systemKey`
- **LiftSystemVersion**: Changed `equals()` and `hashCode()` to use `id` instead of the composite key of `liftSystem` and `versionNumber`
- **Tests**: Added three new test cases to verify the fix:
  - `testLiftSystemSetMembershipStableAfterSystemKeyMutation()` - Verifies that a LiftSystem remains findable in a HashSet after mutating its systemKey
  - `testLiftSystemVersionSetMembershipStableAfterVersionNumberMutation()` - Verifies that a LiftSystemVersion remains findable in a HashSet after mutating its versionNumber
  - `testRemoveVersionFromCollectionAfterMutation()` - Verifies that a LiftSystemVersion can be removed from a collection after mutation

## Implementation Details
Using the database-generated `id` field for equality and hashing is the correct approach for JPA entities because:
- The `id` is immutable once persisted
- It provides stable object identity across the entity's lifecycle
- It prevents issues with HashSet/HashMap lookups when business key fields are modified
- It aligns with JPA best practices for entity identity

https://claude.ai/code/session_01CGFDd7muPAnACUR2E8xQ3Y