### PR TITLE
fix: build simulation run detail DTO in service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 
+## [0.53.4] - 2026-06-26
+
+### Fixed
+- **Simulation run detail DTO transaction safety**: The by-id simulation-run endpoint now builds its response inside the service read transaction with the run relationships eagerly loaded, and the detail payload includes related lift-system, version, and scenario display fields to keep future DTO expansion safe from lazy-loading failures. Updated README and package metadata for the 0.53.4 patch release.
+
 ## [0.53.3] - 2026-06-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.53.3**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.4**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.53.3.jar
+java -jar target/lift-simulator-0.53.4.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.53.3.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.4.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,21 +133,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.53.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -219,7 +219,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.3.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.4.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -581,8 +581,11 @@ All simulation run endpoints require the configured API key header.
 ```json
 {
   "liftSystemId": 1,
+  "liftSystemName": "Downtown Tower",
+  "versionId": 2,
   "versionNumber": 2,
   "scenarioId": 3,
+  "scenarioName": "Morning Rush",
   "seed": 12345
 }
 ```
@@ -598,8 +601,11 @@ All simulation run endpoints require the configured API key header.
 {
   "id": 1,
   "liftSystemId": 1,
+  "liftSystemName": "Downtown Tower",
+  "versionId": 2,
   "versionNumber": 2,
   "scenarioId": 3,
+  "scenarioName": "Morning Rush",
   "status": "RUNNING",
   "createdAt": "2026-01-23T10:00:00Z",
   "startedAt": "2026-01-23T10:00:01Z",
@@ -634,8 +640,11 @@ Retrieves the current status and details of a simulation run, including progress
 {
   "id": 1,
   "liftSystemId": 1,
+  "liftSystemName": "Downtown Tower",
+  "versionId": 2,
   "versionNumber": 2,
   "scenarioId": 3,
+  "scenarioName": "Morning Rush",
   "status": "RUNNING",
   "createdAt": "2026-01-23T10:00:00Z",
   "startedAt": "2026-01-23T10:00:01Z",
@@ -673,8 +682,11 @@ Cancels a running simulation run and transitions it to a terminal `CANCELLED` st
 {
   "id": 1,
   "liftSystemId": 1,
+  "liftSystemName": "Downtown Tower",
+  "versionId": 2,
   "versionNumber": 2,
   "scenarioId": 3,
+  "scenarioName": "Morning Rush",
   "status": "CANCELLED",
   "createdAt": "2026-01-23T10:00:00Z",
   "startedAt": "2026-01-23T10:00:01Z",

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.53.3.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.4.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.53.3.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.53.3.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -408,7 +408,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.53.3.jar \
+   java -cp target/lift-simulator-0.53.4.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -453,7 +453,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -545,7 +545,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.53.3.jar \
+java -cp target/lift-simulator-0.53.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.53.3",
+  "version": "0.53.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.53.3",
+      "version": "0.53.4",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.53.3",
+  "version": "0.53.4",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.53.3</version>
+    <version>0.53.4</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
@@ -141,8 +141,7 @@ public class SimulationRunController {
      */
     @GetMapping("/{id}")
     public ResponseEntity<SimulationRunResponse> getSimulationRun(@PathVariable Long id) {
-        SimulationRun run = simulationRunService.getRunById(id);
-        SimulationRunResponse response = SimulationRunResponse.fromEntity(run);
+        SimulationRunResponse response = simulationRunService.getRunResponseById(id);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/liftsimulator/admin/dto/SimulationRunResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/SimulationRunResponse.java
@@ -11,8 +11,11 @@ import java.time.OffsetDateTime;
 public record SimulationRunResponse(
     Long id,
     Long liftSystemId,
+    String liftSystemName,
+    Long versionId,
     Integer versionNumber,
     Long scenarioId,
+    String scenarioName,
     RunStatus status,
     OffsetDateTime createdAt,
     OffsetDateTime startedAt,
@@ -33,8 +36,11 @@ public record SimulationRunResponse(
         return new SimulationRunResponse(
             run.getId(),
             run.getLiftSystem() != null ? run.getLiftSystem().getId() : null,
+            run.getLiftSystem() != null ? run.getLiftSystem().getDisplayName() : null,
+            run.getVersion() != null ? run.getVersion().getId() : null,
             run.getVersion() != null ? run.getVersion().getVersionNumber() : null,
             run.getScenario() != null ? run.getScenario().getId() : null,
+            run.getScenario() != null ? run.getScenario().getName() : null,
             run.getStatus(),
             run.getCreatedAt(),
             run.getStartedAt(),

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -2,6 +2,7 @@ package com.liftsimulator.admin.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
+import com.liftsimulator.admin.dto.SimulationRunResponse;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.Scenario;
@@ -353,6 +354,21 @@ public class SimulationRunService {
      * @throws ResourceNotFoundException if the run is not found
      */
     public SimulationRun getRunById(Long id) {
+        return findRunByIdWithDetails(id);
+    }
+
+    /**
+     * Get a run response by its ID while the persistence context is still open.
+     *
+     * @param id the run id
+     * @return the run response
+     * @throws ResourceNotFoundException if the run is not found
+     */
+    public SimulationRunResponse getRunResponseById(Long id) {
+        return SimulationRunResponse.fromEntity(findRunByIdWithDetails(id));
+    }
+
+    private SimulationRun findRunByIdWithDetails(Long id) {
         return runRepository.findByIdWithDetails(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "Simulation run not found with id: " + id));

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunControllerTest.java
@@ -6,9 +6,11 @@ import com.liftsimulator.admin.dto.CreateSimulationRunRequest;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
+import com.liftsimulator.admin.entity.Scenario;
 import com.liftsimulator.admin.entity.SimulationRun;
 import com.liftsimulator.admin.repository.LiftSystemRepository;
 import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import com.liftsimulator.admin.repository.ScenarioRepository;
 import com.liftsimulator.admin.repository.SimulationRunRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,12 +61,16 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
     @Autowired
     private SimulationRunRepository runRepository;
 
+    @Autowired
+    private ScenarioRepository scenarioRepository;
+
     private LiftSystem testSystem;
     private LiftSystemVersion testVersion;
 
     @BeforeEach
     public void setUp() throws IOException {
         runRepository.deleteAll();
+        scenarioRepository.deleteAll();
         versionRepository.deleteAll();
         liftSystemRepository.deleteAll();
 
@@ -148,7 +154,13 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
 
     @Test
     public void testGetSimulationRun_Success() throws Exception {
+        Scenario scenario = scenarioRepository.save(new Scenario(
+            "Morning Rush",
+            "{\"durationTicks\": 10, \"passengerFlows\": []}",
+            testVersion
+        ));
         SimulationRun run = new SimulationRun(testSystem, testVersion);
+        run.setScenario(scenario);
         run = runRepository.save(run);
 
         mockMvc.perform(get("/api/v1/simulation-runs/" + run.getId())
@@ -156,7 +168,11 @@ public class SimulationRunControllerTest extends LocalIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.id").value(run.getId()))
             .andExpect(jsonPath("$.liftSystemId").value(testSystem.getId()))
+            .andExpect(jsonPath("$.liftSystemName").value(testSystem.getDisplayName()))
+            .andExpect(jsonPath("$.versionId").value(testVersion.getId()))
             .andExpect(jsonPath("$.versionNumber").value(testVersion.getVersionNumber()))
+            .andExpect(jsonPath("$.scenarioId").value(scenario.getId()))
+            .andExpect(jsonPath("$.scenarioName").value(scenario.getName()))
             .andExpect(jsonPath("$.status").value("CREATED"));
     }
 


### PR DESCRIPTION
### Motivation
- Avoid LazyInitializationException when the controller mapped a `SimulationRun` entity into `SimulationRunResponse` after the service transaction/persistence context had closed. 
- Ensure the by-id simulation-run endpoint returns a stable detail payload even if DTO expansion needs related display fields in future. 
- Bump project version and documentation to reflect the patch release for the fix.

### Description
- Move DTO mapping for the by-id run endpoint into the read service transaction by adding `SimulationRunService.getRunResponseById(Long)` which uses the existing `findByIdWithDetails` eager lookup. 
- Extend `SimulationRunResponse` with `liftSystemName`, `versionId`, and `scenarioName` and populate them from the eagerly-loaded relationships. 
- Update `SimulationRunController#getSimulationRun` to call `simulationRunService.getRunResponseById(id)` instead of mapping the entity in the controller. 
- Add/adjust integration test coverage in `SimulationRunControllerTest` to save a `Scenario`, attach it to a `SimulationRun`, and assert the new display fields are returned; update `CHANGELOG.md`, `README.md`, `docs/*`, `pom.xml`, and frontend package metadata to bump the project to `0.53.4`.

### Testing
- Ran `git diff --check` and committed the change successfully. 
- Attempted to run `mvn -Dtest=SimulationRunControllerTest test`, but the run was blocked by dependency resolution errors (Maven Central returned HTTP 403 while resolving `spring-boot-starter-parent:3.4.0`). 
- Attempted offline test `mvn -o -Dtest=SimulationRunControllerTest test`, but it failed because the Spring Boot parent POM is not present in the local Maven cache, so the automated test run could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ddf63be5883258630f15201279d6e)