### PR TITLE
fix: normalize JSONB config persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.53.5] - 2026-06-26
 
 ### Fixed
-- **Consistent JSONB normalization**: Lift system version configuration writes now use the same Jackson re-serialization policy as scenarios before persisting to JSONB, while the JPA verification runner compares JSONB round trips semantically instead of requiring byte-for-byte string equality. Updated README and package metadata for the 0.53.5 patch release.
+- **Consistent JSONB normalization**: Lift system version configuration writes now use the same Jackson re-serialization policy as scenarios before persisting to JSONB with strict trailing-token rejection, while the JPA verification runner compares JSONB round trips semantically instead of requiring byte-for-byte string equality. Updated README and package metadata for the 0.53.5 patch release.
 
 ## [0.53.4] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 
+## [0.53.5] - 2026-06-26
+
+### Fixed
+- **Consistent JSONB normalization**: Lift system version configuration writes now use the same Jackson re-serialization policy as scenarios before persisting to JSONB, while the JPA verification runner compares JSONB round trips semantically instead of requiring byte-for-byte string equality. Updated README and package metadata for the 0.53.5 patch release.
+
 ## [0.53.4] - 2026-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.53.4**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.5**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.53.4.jar
+java -jar target/lift-simulator-0.53.5.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.53.4.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.5.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,21 +133,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.53.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -219,7 +219,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.4.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.5.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.53.4.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.5.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.53.4.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.53.4.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -408,7 +408,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.53.4.jar \
+   java -cp target/lift-simulator-0.53.5.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -453,7 +453,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -545,7 +545,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.53.4.jar \
+java -cp target/lift-simulator-0.53.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.53.4",
+  "version": "0.53.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.53.4",
+      "version": "0.53.5",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.53.4",
+  "version": "0.53.5",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.53.4</version>
+    <version>0.53.5</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/runner/JpaVerificationRunner.java
+++ b/src/main/java/com/liftsimulator/admin/runner/JpaVerificationRunner.java
@@ -1,5 +1,7 @@
 package com.liftsimulator.admin.runner;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
@@ -27,12 +29,15 @@ public class JpaVerificationRunner implements CommandLineRunner {
 
     private final LiftSystemRepository liftSystemRepository;
     private final LiftSystemVersionRepository versionRepository;
+    private final ObjectMapper objectMapper;
 
     public JpaVerificationRunner(
             LiftSystemRepository liftSystemRepository,
-            LiftSystemVersionRepository versionRepository) {
+            LiftSystemVersionRepository versionRepository,
+            ObjectMapper objectMapper) {
         this.liftSystemRepository = liftSystemRepository;
         this.versionRepository = versionRepository;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -139,10 +144,18 @@ public class JpaVerificationRunner implements CommandLineRunner {
         logger.info("✓ Saved complex JSONB config: id={}", saved.getId());
 
         Optional<LiftSystemVersion> retrieved = versionRepository.findById(saved.getId());
-        if (retrieved.isPresent() && retrieved.get().getConfig().equals(complexJson)) {
-            logger.info("✓ Retrieved JSONB config matches original");
+        if (retrieved.isPresent() && jsonSemanticallyEquals(complexJson, retrieved.get().getConfig())) {
+            logger.info("✓ Retrieved JSONB config semantically matches original");
         } else {
             throw new AssertionError("JSONB config mismatch after retrieval");
+        }
+    }
+
+    private boolean jsonSemanticallyEquals(String expectedJson, String actualJson) {
+        try {
+            return objectMapper.readTree(expectedJson).equals(objectMapper.readTree(actualJson));
+        } catch (JsonProcessingException e) {
+            throw new AssertionError("Failed to parse JSONB config during verification", e);
         }
     }
 

--- a/src/main/java/com/liftsimulator/admin/runner/JpaVerificationRunner.java
+++ b/src/main/java/com/liftsimulator/admin/runner/JpaVerificationRunner.java
@@ -7,6 +7,7 @@ import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
 import com.liftsimulator.admin.repository.LiftSystemRepository;
 import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
@@ -31,6 +32,11 @@ public class JpaVerificationRunner implements CommandLineRunner {
     private final LiftSystemVersionRepository versionRepository;
     private final ObjectMapper objectMapper;
 
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "Spring-managed beans injected via constructor; ObjectMapper lifecycle "
+                    + "and configuration are managed by the application context."
+    )
     public JpaVerificationRunner(
             LiftSystemRepository liftSystemRepository,
             LiftSystemVersionRepository versionRepository,

--- a/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
@@ -1,5 +1,8 @@
 package com.liftsimulator.admin.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.CreateVersionRequest;
 import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
@@ -23,14 +26,17 @@ public class LiftSystemVersionService {
     private final LiftSystemRepository liftSystemRepository;
     private final LiftSystemVersionRepository versionRepository;
     private final ConfigValidationService configValidationService;
+    private final ObjectMapper objectMapper;
 
     public LiftSystemVersionService(
             LiftSystemRepository liftSystemRepository,
             LiftSystemVersionRepository versionRepository,
-            ConfigValidationService configValidationService) {
+            ConfigValidationService configValidationService,
+            ObjectMapper objectMapper) {
         this.liftSystemRepository = liftSystemRepository;
         this.versionRepository = versionRepository;
         this.configValidationService = configValidationService;
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -72,7 +78,7 @@ public class LiftSystemVersionService {
         Integer nextVersionNumber = getNextVersionNumber(systemId);
 
         // Create new version
-        LiftSystemVersion version = new LiftSystemVersion(liftSystem, nextVersionNumber, config);
+        LiftSystemVersion version = new LiftSystemVersion(liftSystem, nextVersionNumber, normalizeConfigJson(config));
         LiftSystemVersion savedVersion = versionRepository.save(version);
 
         return VersionResponse.fromEntity(savedVersion);
@@ -102,10 +108,19 @@ public class LiftSystemVersionService {
             throw new ConfigValidationException("Configuration validation failed", validationResponse);
         }
 
-        version.setConfig(request.config());
+        version.setConfig(normalizeConfigJson(request.config()));
         LiftSystemVersion updatedVersion = versionRepository.save(version);
 
         return VersionResponse.fromEntity(updatedVersion);
+    }
+
+    private String normalizeConfigJson(String config) {
+        try {
+            JsonNode configJson = objectMapper.readTree(config);
+            return objectMapper.writeValueAsString(configJson);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Configuration JSON could not be normalized", e);
+        }
     }
 
     /**

--- a/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
@@ -12,6 +12,7 @@ import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.repository.LiftSystemRepository;
 import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +30,11 @@ public class LiftSystemVersionService {
     private final ConfigValidationService configValidationService;
     private final ObjectMapper objectMapper;
 
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "Spring-managed beans injected via constructor; ObjectMapper lifecycle "
+                    + "and configuration are managed by the application context."
+    )
     public LiftSystemVersionService(
             LiftSystemRepository liftSystemRepository,
             LiftSystemVersionRepository versionRepository,

--- a/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
@@ -1,6 +1,7 @@
 package com.liftsimulator.admin.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
@@ -116,7 +117,9 @@ public class LiftSystemVersionService {
 
     private String normalizeConfigJson(String config) {
         try {
-            JsonNode configJson = objectMapper.readTree(config);
+            JsonNode configJson = objectMapper.reader()
+                .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                .readTree(config);
             return objectMapper.writeValueAsString(configJson);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Configuration JSON could not be normalized", e);

--- a/src/test/java/com/liftsimulator/admin/service/LiftSystemVersionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/LiftSystemVersionServiceTest.java
@@ -124,6 +124,24 @@ public class LiftSystemVersionServiceTest {
     }
 
     @Test
+    public void testCreateVersion_RejectsTrailingJsonTokensDuringNormalization() {
+        String configWithTrailingTokens = "{\"minFloor\":0,\"maxFloor\":9} {\"ignored\":true}";
+        CreateVersionRequest request = new CreateVersionRequest(configWithTrailingTokens, null);
+
+        when(liftSystemRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(configValidationService.validate(configWithTrailingTokens)).thenReturn(validValidationResponse);
+        when(versionRepository.findMaxVersionNumberByLiftSystemId(1L)).thenReturn(null);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> versionService.createVersion(1L, request)
+        );
+
+        assertEquals("Configuration JSON could not be normalized", exception.getMessage());
+        verify(versionRepository, never()).save(any(LiftSystemVersion.class));
+    }
+
+    @Test
     public void testCreateVersion_WithCloning() {
         String originalConfig = "{\"minFloor\": 0, \"maxFloor\": 9}";
         LiftSystemVersion sourceVersion = new LiftSystemVersion();
@@ -222,6 +240,24 @@ public class LiftSystemVersionServiceTest {
         verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
         verify(configValidationService).validate(updatedConfig);
         verify(versionRepository).save(mockVersion);
+    }
+
+    @Test
+    public void testUpdateVersionConfig_RejectsTrailingJsonTokensDuringNormalization() {
+        String configWithTrailingTokens = "{\"minFloor\":0,\"maxFloor\":19} [1]";
+        UpdateVersionConfigRequest request = new UpdateVersionConfigRequest(configWithTrailingTokens);
+
+        when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1))
+            .thenReturn(Optional.of(mockVersion));
+        when(configValidationService.validate(configWithTrailingTokens)).thenReturn(validValidationResponse);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> versionService.updateVersionConfig(1L, 1, request)
+        );
+
+        assertEquals("Configuration JSON could not be normalized", exception.getMessage());
+        verify(versionRepository, never()).save(any(LiftSystemVersion.class));
     }
 
     @Test

--- a/src/test/java/com/liftsimulator/admin/service/LiftSystemVersionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/LiftSystemVersionServiceTest.java
@@ -1,5 +1,6 @@
 package com.liftsimulator.admin.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.CreateVersionRequest;
 import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
@@ -12,7 +13,6 @@ import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -46,7 +46,6 @@ public class LiftSystemVersionServiceTest {
     @Mock
     private ConfigValidationService configValidationService;
 
-    @InjectMocks
     private LiftSystemVersionService versionService;
 
     private LiftSystem mockLiftSystem;
@@ -78,6 +77,12 @@ public class LiftSystemVersionServiceTest {
             Collections.emptyList(),
             Collections.emptyList()
         );
+        versionService = new LiftSystemVersionService(
+            liftSystemRepository,
+            versionRepository,
+            configValidationService,
+            new ObjectMapper()
+        );
     }
 
     @Test
@@ -98,6 +103,24 @@ public class LiftSystemVersionServiceTest {
         verify(configValidationService).validate(config);
         verify(versionRepository).findMaxVersionNumberByLiftSystemId(1L);
         verify(versionRepository).save(any(LiftSystemVersion.class));
+    }
+
+    @Test
+    public void testCreateVersion_NormalizesProvidedConfigBeforeSaving() {
+        String config = "{\n  \"minFloor\" : 0,\n  \"maxFloor\" : 9,\n  \"lifts\" : 2\n}";
+        CreateVersionRequest request = new CreateVersionRequest(config, null);
+
+        when(liftSystemRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(mockLiftSystem));
+        when(configValidationService.validate(config)).thenReturn(validValidationResponse);
+        when(versionRepository.findMaxVersionNumberByLiftSystemId(1L)).thenReturn(null);
+        when(versionRepository.save(any(LiftSystemVersion.class)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        VersionResponse response = versionService.createVersion(1L, request);
+
+        assertNotNull(response);
+        assertEquals("{\"minFloor\":0,\"maxFloor\":9,\"lifts\":2}", response.config());
+        verify(configValidationService).validate(config);
     }
 
     @Test
@@ -195,6 +218,7 @@ public class LiftSystemVersionServiceTest {
         VersionResponse response = versionService.updateVersionConfig(1L, 1, request);
 
         assertNotNull(response);
+        assertEquals("{\"minFloor\":0,\"maxFloor\":19,\"lifts\":3}", mockVersion.getConfig());
         verify(versionRepository).findByLiftSystemIdAndVersionNumber(1L, 1);
         verify(configValidationService).validate(updatedConfig);
         verify(versionRepository).save(mockVersion);


### PR DESCRIPTION
### Motivation
- Stored lift-system version config was sometimes kept as the raw input string while scenarios were re-serialized via Jackson, causing inconsistent JSONB writes and an unsound byte-equality assertion in the JPA verification runner.
- The intent is to make version config persistence use the same re-serialization policy as scenarios and ensure verification compares JSON semantically rather than by byte equality.

### Description
- Normalized version config before persisting by adding `normalizeConfigJson(String)` and wiring an `ObjectMapper` into `LiftSystemVersionService`, and using the normalized output when creating and updating `LiftSystemVersion` entities.
- Replaced byte-for-byte JSON equality in `JpaVerificationRunner` with a semantic JSON comparison using `ObjectMapper.readTree(...).equals(...)` and added a helper `jsonSemanticallyEquals` method.
- Added unit coverage to `LiftSystemVersionServiceTest` (`testCreateVersion_NormalizesProvidedConfigBeforeSaving` and updated assertions in `testUpdateVersionConfig_Success`) to assert normalization behaviour.
- Bumped the project patch version to `0.53.5` and updated `CHANGELOG.md`, `README.md`, and frontend package metadata (`frontend/package.json` and `frontend/package-lock.json`) to reflect the patch release describing the JSONB fix.

### Testing
- Added unit tests in `LiftSystemVersionServiceTest` that verify normalization on create and update; these tests were added to the test suite (new test: `testCreateVersion_NormalizesProvidedConfigBeforeSaving`).
- Ran `mvn -Dtest=LiftSystemVersionServiceTest test`, which could not complete due to environment/network dependency resolution failure (Maven Central returned HTTP 403 resolving `org.springframework.boot:spring-boot-starter-parent:pom:3.4.0`).
- Ran repository checks (`git diff --check`) which passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de21f03f88325858b4ebbbd8c142f)