### PR TITLE
fix: warn on scenario deletion and cleanup artefacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 
+## [0.53.6] - 2026-06-27
+
+### Fixed
+- **Scenario deletion impact and artefact cleanup**: Scenario responses and a dedicated run-count endpoint now expose associated simulation-run counts, the Scenarios UI warns when deletion will remove run history and artefacts, and backend deletion captures cascade-removed runs before deleting the scenario so their artefact directories are cleaned after commit. Updated README and package metadata for the 0.53.6 patch release.
+
 ## [0.53.5] - 2026-06-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.53.6] - 2026-06-27
 
 ### Fixed
-- **Scenario deletion impact and artefact cleanup**: Scenario responses and a dedicated run-count endpoint now expose associated simulation-run counts, the Scenarios UI warns when deletion will remove run history and artefacts, and backend deletion captures cascade-removed runs before deleting the scenario so their artefact directories are cleaned after commit. Updated README and package metadata for the 0.53.6 patch release.
+- **Scenario deletion impact and artefact cleanup**: Scenario responses and a dedicated run-count endpoint now expose associated simulation-run counts, the Scenarios UI warns when deletion will remove run history and artefacts, and backend deletion write-locks the scenario before capturing cascade-removed runs so their artefact directories are reliably cleaned after commit. Updated README and package metadata for the 0.53.6 patch release.
 
 ## [0.53.5] - 2026-06-26
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.53.5**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.6**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -89,8 +89,8 @@ The **frontend admin UI** provides:
 - **Dashboard** — overview of lift systems with quick statistics
 - **Lift Systems Management** — full CRUD with list and detail views
 - **Version Management** — create, publish, and archive versioned configurations with optimistic locking, single-published-version enforcement, pagination, sorting, filtering, complete JSON examples, and schema guidance in the configuration editor
-- **Scenario Builder** — template-based or custom passenger-flow scenarios with server-side validation, validated copy-to-version reuse, and an advanced JSON editor
-- **Simulator Runs** — launch published versions with scenarios, poll status, recover orphaned active runs after restarts, list runs with capped pagination and documented sorting (`createdAt`, `startedAt`, `endedAt`, `status`, `id`; ignore-case modifiers rejected), bulk-cancel active runs, bulk-delete completed runs with post-commit artefact cleanup, and review pickup-latency KPI results with artefact downloads and CLI reproduction hints. Generated `input.scenario` artefacts skip same-floor passenger flows so CLI reproduction matches the in-process executor. Run creation uses the same lift-system-scoped `versionNumber` identifier as the version-management API, avoiding surrogate version row IDs in client requests.
+- **Scenario Builder** — template-based or custom passenger-flow scenarios with server-side validation, validated copy-to-version reuse, run-history deletion impact warnings, and an advanced JSON editor
+- **Simulator Runs** — launch published versions with scenarios, poll status, recover orphaned active runs after restarts, list runs with capped pagination and documented sorting (`createdAt`, `startedAt`, `endedAt`, `status`, `id`; ignore-case modifiers rejected), bulk-cancel active runs, bulk-delete completed runs with post-commit artefact cleanup, clean scenario-cascade artefacts after confirmed scenario deletion, and review pickup-latency KPI results with artefact downloads and CLI reproduction hints. Generated `input.scenario` artefacts skip same-floor passenger flows so CLI reproduction matches the in-process executor. Run creation uses the same lift-system-scoped `versionNumber` identifier as the version-management API, avoiding surrogate version row IDs in client requests.
 - **Configuration Editor & Validator** — edit and validate configuration JSON before publishing
 - **Health Check** — monitor backend service status
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.53.5.jar
+java -jar target/lift-simulator-0.53.6.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.53.5.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.6.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,21 +133,21 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.6.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.6.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
 Run a lightweight simulation from a published configuration JSON:
 ```bash
-java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
+java -cp target/lift-simulator-0.53.6.jar com.liftsimulator.runtime.LocalSimulationMain --config=path/to/config.json
 ```
 Optional flags: `--ticks=<count>` (default 25) and `-h, --help`.
 
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.53.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -219,7 +219,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.5.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.6.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -253,6 +253,7 @@ Scenario payloads define passenger flow for UI-driven simulation runs. The scena
         ],
         "seed": 42
       },
+      "simulationRunCount": 0,
       "createdAt": "2026-01-11T10:00:00Z",
       "updatedAt": "2026-01-11T10:00:00Z"
     }
@@ -267,7 +268,17 @@ Scenario payloads define passenger flow for UI-driven simulation runs. The scena
 
 - **Get Scenario**: `GET /api/v1/scenarios/{id}`
   - Returns a stored scenario by ID
-  - Response (200 OK): Scenario details
+  - Response (200 OK): Scenario details, including `simulationRunCount` for deletion-impact warnings
+
+- **Get Scenario Run Count**: `GET /api/v1/scenarios/{id}/run-count`
+  - Returns the number of simulation runs that reference the scenario
+  - Response (200 OK): Numeric count used by clients before confirming destructive scenario deletion
+
+- **Delete Scenario**: `DELETE /api/v1/scenarios/{id}`
+  - Deletes the scenario and intentionally cascades its associated simulation-run history
+  - Associated run artefact directories are removed after the delete transaction commits so cascade-deleted runs do not leave orphaned files
+  - Clients should warn users with the run count before calling this endpoint
+  - Response (204 No Content): Scenario deleted
 
 #### Scenario Validation
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.53.5.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.6.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a simulation using a JSON configuration file:
 
 ```bash
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=path/to/config.json \
   --ticks=100
@@ -119,7 +119,7 @@ java -cp target/lift-simulator-0.53.5.jar \
 
 **Example:**
 ```bash
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.runtime.LocalSimulationMain \
   --config=building-a.json \
   --ticks=1000
@@ -130,7 +130,7 @@ java -cp target/lift-simulator-0.53.5.jar \
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -408,7 +408,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.53.5.jar \
+   java -cp target/lift-simulator-0.53.6.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -453,7 +453,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -545,7 +545,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.53.5.jar \
+java -cp target/lift-simulator-0.53.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.53.5",
+  "version": "0.53.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.53.5",
+      "version": "0.53.6",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.53.5",
+  "version": "0.53.6",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/api/scenariosApi.js
+++ b/frontend/src/api/scenariosApi.js
@@ -7,6 +7,7 @@ export const scenariosApi = {
   createScenario: (data) => apiClient.post('/scenarios', data),
   updateScenario: (id, data) => apiClient.put(`/scenarios/${id}`, data),
   deleteScenario: (id) => apiClient.delete(`/scenarios/${id}`),
+  getScenarioRunCount: (id) => apiClient.get(`/scenarios/${id}/run-count`),
   copyScenario: (id, data) => apiClient.post(`/scenarios/${id}/copy`, data),
 
   // Validation

--- a/frontend/src/pages/Scenarios.jsx
+++ b/frontend/src/pages/Scenarios.jsx
@@ -29,6 +29,7 @@ function Scenarios() {
   const [alertMessage, setAlertMessage] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteConfirm, setDeleteConfirm] = useState(null);
+  const [loadingDeleteImpact, setLoadingDeleteImpact] = useState(null);
   const [copyScenario, setCopyScenario] = useState(null);
   const [systems, setSystems] = useState([]);
   const [targetSystemId, setTargetSystemId] = useState('');
@@ -141,6 +142,23 @@ function Scenarios() {
       handleApiError(err, setAlertMessage, 'Failed to copy scenario');
     } finally {
       setCopying(false);
+    }
+  };
+
+  /**
+   * Opens scenario deletion confirmation with run-history impact details.
+   *
+   * @param {Object} scenario - Scenario selected for deletion
+   */
+  const handleOpenDeleteConfirm = async (scenario) => {
+    setLoadingDeleteImpact(scenario.id);
+    try {
+      const response = await scenariosApi.getScenarioRunCount(scenario.id);
+      setDeleteConfirm({ ...scenario, simulationRunCount: Number(response.data) || 0 });
+    } catch (err) {
+      handleApiError(err, setAlertMessage, 'Failed to load scenario deletion impact');
+    } finally {
+      setLoadingDeleteImpact(null);
     }
   };
 
@@ -266,9 +284,10 @@ function Scenarios() {
                   </button>
                   <button
                     className="btn-danger"
-                    onClick={() => setDeleteConfirm(scenario)}
+                    onClick={() => handleOpenDeleteConfirm(scenario)}
+                    disabled={loadingDeleteImpact === scenario.id}
                   >
-                    Delete
+                    {loadingDeleteImpact === scenario.id ? 'Checking...' : 'Delete'}
                   </button>
                 </div>
               </div>
@@ -322,7 +341,9 @@ function Scenarios() {
         isOpen={!!deleteConfirm}
         onClose={() => setDeleteConfirm(null)}
         title="Delete Scenario"
-        message={`Are you sure you want to delete "${deleteConfirm?.name}"? This action cannot be undone.`}
+        message={deleteConfirm?.simulationRunCount > 0
+          ? `Deleting "${deleteConfirm?.name}" will permanently delete ${deleteConfirm.simulationRunCount} simulation run(s), their history, and their artefacts. This action cannot be undone.`
+          : `Are you sure you want to delete "${deleteConfirm?.name}"? This action cannot be undone.`}
         confirmText="Delete"
         confirmStyle="danger"
         onConfirm={() => handleDeleteScenario(deleteConfirm.id)}

--- a/frontend/src/pages/__tests__/Scenarios.delete.test.jsx
+++ b/frontend/src/pages/__tests__/Scenarios.delete.test.jsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Scenarios from '../Scenarios';
+import { scenariosApi } from '../../api/scenariosApi';
+
+vi.mock('../../api/scenariosApi', () => ({
+  scenariosApi: {
+    getAllScenarios: vi.fn(),
+    getScenarioRunCount: vi.fn(),
+    deleteScenario: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/liftSystemsApi', () => ({
+  liftSystemsApi: {
+    getAllSystems: vi.fn(),
+    getVersions: vi.fn(),
+  },
+}));
+
+const scenario = {
+  id: 42,
+  name: 'Morning rush',
+  scenarioJson: { durationTicks: 120, passengerFlows: [] },
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={['/scenarios']}>
+    <Scenarios />
+  </MemoryRouter>
+);
+
+describe('Scenarios deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('warns about associated run history and artefacts before deleting', async () => {
+    scenariosApi.getAllScenarios
+      .mockResolvedValueOnce({ data: [scenario] })
+      .mockResolvedValueOnce({ data: [] });
+    scenariosApi.getScenarioRunCount.mockResolvedValue({ data: 3 });
+    scenariosApi.deleteScenario.mockResolvedValue({ status: 204 });
+
+    renderPage();
+
+    await screen.findByText('Morning rush');
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(scenariosApi.getScenarioRunCount).toHaveBeenCalledWith(42));
+    expect(screen.getByText(/permanently delete 3 simulation run\(s\), their history, and their artefacts/i))
+      .toBeInTheDocument();
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Scenario' });
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(scenariosApi.deleteScenario).toHaveBeenCalledWith(42));
+    expect(scenariosApi.getAllScenarios).toHaveBeenCalledTimes(2);
+  });
+});

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.53.5</version>
+    <version>0.53.6</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/controller/ScenarioController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/ScenarioController.java
@@ -125,6 +125,17 @@ public class ScenarioController {
     }
 
     /**
+     * Counts simulation runs associated with a scenario.
+     *
+     * @param id scenario id
+     * @return number of runs referencing the scenario
+     */
+    @GetMapping("/{id}/run-count")
+    public ResponseEntity<Long> countScenarioRuns(@PathVariable Long id) {
+        return ResponseEntity.ok(scenarioService.countSimulationRuns(id));
+    }
+
+    /**
      * Deletes a scenario by id.
      *
      * @param id scenario id

--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioResponse.java
@@ -13,6 +13,7 @@ public record ScenarioResponse(
     JsonNode scenarioJson,
     Long liftSystemVersionId,
     LiftSystemVersionInfo versionInfo,
+    long simulationRunCount,
     OffsetDateTime createdAt,
     OffsetDateTime updatedAt
 ) {

--- a/src/main/java/com/liftsimulator/admin/repository/ScenarioRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/ScenarioRepository.java
@@ -1,16 +1,30 @@
 package com.liftsimulator.admin.repository;
 
 import com.liftsimulator.admin.entity.Scenario;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 /**
  * Repository for Scenario entities.
  */
 @Repository
 public interface ScenarioRepository extends JpaRepository<Scenario, Long> {
+
+    /**
+     * Find a scenario by id while holding a database write lock for serialized deletion.
+     *
+     * @param id the scenario id
+     * @return an Optional containing the locked Scenario if found
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM Scenario s WHERE s.id = :id")
+    Optional<Scenario> findByIdForUpdate(@Param("id") Long id);
 
     /**
      * Counts scenarios associated with any version of the specified lift system.

--- a/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
+++ b/src/main/java/com/liftsimulator/admin/repository/SimulationRunRepository.java
@@ -219,6 +219,22 @@ public interface SimulationRunRepository extends JpaRepository<SimulationRun, Lo
     long countActiveRunsByLiftSystemId(@Param("liftSystemId") Long liftSystemId);
 
     /**
+     * Find all runs for a specific scenario.
+     *
+     * @param scenarioId the scenario id
+     * @return list of runs for the scenario
+     */
+    List<SimulationRun> findByScenarioId(Long scenarioId);
+
+    /**
+     * Count runs for a specific scenario.
+     *
+     * @param scenarioId the scenario id
+     * @return total number of runs for the scenario
+     */
+    long countByScenarioId(Long scenarioId);
+
+    /**
      * Count runs for a specific lift system.
      *
      * @param liftSystemId the lift system id

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
@@ -200,11 +200,16 @@ public class ScenarioService {
     /**
      * Deletes a scenario by id.
      *
+     * <p>The scenario row is write-locked before capturing associated runs so
+     * concurrent run creation cannot insert a new child row after the capture
+     * query but before the delete commits. This keeps post-commit artefact cleanup
+     * aligned with the database cascade.</p>
+     *
      * @param id scenario id
      */
     @Transactional
     public void deleteScenario(Long id) {
-        Scenario scenario = scenarioRepository.findById(id)
+        Scenario scenario = scenarioRepository.findByIdForUpdate(id)
             .orElseThrow(() -> new ResourceNotFoundException(
                 "Scenario not found with id: " + id
             ));

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
@@ -10,12 +10,17 @@ import com.liftsimulator.admin.dto.ScenarioValidationResponse;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.Scenario;
+import com.liftsimulator.admin.entity.SimulationRun;
 import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
 import com.liftsimulator.admin.repository.ScenarioRepository;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +38,8 @@ public class ScenarioService {
     private final ScenarioRepository scenarioRepository;
     private final LiftSystemVersionRepository versionRepository;
     private final ScenarioValidationService scenarioValidationService;
+    private final SimulationRunRepository runRepository;
+    private final ArtefactService artefactService;
     private final ObjectMapper objectMapper;
 
     @SuppressFBWarnings(
@@ -44,10 +51,14 @@ public class ScenarioService {
             ScenarioRepository scenarioRepository,
             LiftSystemVersionRepository versionRepository,
             ScenarioValidationService scenarioValidationService,
+            SimulationRunRepository runRepository,
+            ArtefactService artefactService,
             ObjectMapper objectMapper) {
         this.scenarioRepository = scenarioRepository;
         this.versionRepository = versionRepository;
         this.scenarioValidationService = scenarioValidationService;
+        this.runRepository = runRepository;
+        this.artefactService = artefactService;
         this.objectMapper = objectMapper;
     }
 
@@ -198,7 +209,55 @@ public class ScenarioService {
                 "Scenario not found with id: " + id
             ));
 
+        List<SimulationRun> runs = runRepository.findByScenarioId(id);
         scenarioRepository.delete(scenario);
+        deleteRunArtefactsAfterCommit(runs);
+    }
+
+    /**
+     * Counts simulation runs associated with a scenario.
+     *
+     * @param id scenario id
+     * @return number of runs that will be removed by scenario deletion
+     */
+    public long countSimulationRuns(Long id) {
+        if (!scenarioRepository.existsById(id)) {
+            throw new ResourceNotFoundException(
+                "Scenario not found with id: " + id
+            );
+        }
+        return runRepository.countByScenarioId(id);
+    }
+
+    private void deleteRunArtefactsAfterCommit(List<SimulationRun> runs) {
+        if (runs.isEmpty()) {
+            return;
+        }
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            deleteRunArtefacts(runs);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                deleteRunArtefacts(runs);
+            }
+        });
+    }
+
+    private void deleteRunArtefacts(List<SimulationRun> runs) {
+        for (SimulationRun run : runs) {
+            try {
+                artefactService.deleteArtefacts(run);
+            } catch (IOException e) {
+                throw new ArtefactDeletionException(
+                    "Failed to delete artefacts for simulation run " + run.getId()
+                        + ": " + e.getMessage(),
+                    e
+                );
+            }
+        }
     }
 
     private void validateScenarioJson(JsonNode scenarioJson, Long liftSystemVersionId) {
@@ -303,6 +362,7 @@ public class ScenarioService {
                 scenarioJson,
                 versionId,
                 versionInfo,
+                runRepository.countByScenarioId(scenario.getId()),
                 scenario.getCreatedAt(),
                 scenario.getUpdatedAt()
             );

--- a/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
@@ -9,8 +9,10 @@ import com.liftsimulator.admin.dto.ValidationIssue;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.Scenario;
+import com.liftsimulator.admin.entity.SimulationRun;
 import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
 import com.liftsimulator.admin.repository.ScenarioRepository;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,6 +64,12 @@ public class ScenarioServiceTest {
     @Mock
     private ScenarioValidationService scenarioValidationService;
 
+    @Mock
+    private SimulationRunRepository runRepository;
+
+    @Mock
+    private ArtefactService artefactService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     private ScenarioService scenarioService;
     private LiftSystemVersion version;
@@ -72,6 +80,8 @@ public class ScenarioServiceTest {
                 scenarioRepository,
                 versionRepository,
                 scenarioValidationService,
+                runRepository,
+                artefactService,
                 objectMapper
         );
         version = version(20L);
@@ -101,6 +111,7 @@ public class ScenarioServiceTest {
         assertEquals(10L, response.versionInfo().liftSystemId());
         assertEquals("test-system", response.versionInfo().systemKey());
         assertEquals(1, response.versionInfo().versionNumber());
+        assertEquals(0L, response.simulationRunCount());
         assertEquals(0, response.versionInfo().minFloor());
         assertEquals(9, response.versionInfo().maxFloor());
 
@@ -343,6 +354,48 @@ public class ScenarioServiceTest {
         );
 
         assertTrue(exception.getMessage().contains("Stored scenario JSON could not be parsed"));
+    }
+
+    @Test
+    public void getScenarioIncludesSimulationRunCount() throws Exception {
+        Scenario scenario = new Scenario("Morning rush", validScenario(), version);
+        scenario.setId(30L);
+        when(scenarioRepository.findById(30L)).thenReturn(Optional.of(scenario));
+        when(runRepository.countByScenarioId(30L)).thenReturn(3L);
+
+        ScenarioResponse response = scenarioService.getScenario(30L);
+
+        assertEquals(3L, response.simulationRunCount());
+    }
+
+    @Test
+    public void deleteScenarioDeletesScenarioAfterCapturingCascadeRunArtefacts() throws Exception {
+        Scenario scenario = new Scenario("Morning rush", validScenario(), version);
+        scenario.setId(30L);
+        SimulationRun run = new SimulationRun(version.getLiftSystem(), version);
+        run.setId(88L);
+        run.setScenario(scenario);
+        run.setArtefactBasePath("/tmp/run-88");
+        when(scenarioRepository.findById(30L)).thenReturn(Optional.of(scenario));
+        when(runRepository.findByScenarioId(30L)).thenReturn(List.of(run));
+
+        scenarioService.deleteScenario(30L);
+
+        verify(runRepository).findByScenarioId(30L);
+        verify(scenarioRepository).delete(scenario);
+        verify(artefactService).deleteArtefacts(run);
+    }
+
+    @Test
+    public void countSimulationRunsThrowsWhenScenarioIsMissing() {
+        when(scenarioRepository.existsById(99L)).thenReturn(false);
+
+        ResourceNotFoundException exception = assertThrows(
+                ResourceNotFoundException.class,
+                () -> scenarioService.countSimulationRuns(99L)
+        );
+
+        assertEquals("Scenario not found with id: 99", exception.getMessage());
     }
 
     private JsonNode json(String payload) throws Exception {

--- a/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ScenarioServiceTest.java
@@ -376,11 +376,12 @@ public class ScenarioServiceTest {
         run.setId(88L);
         run.setScenario(scenario);
         run.setArtefactBasePath("/tmp/run-88");
-        when(scenarioRepository.findById(30L)).thenReturn(Optional.of(scenario));
+        when(scenarioRepository.findByIdForUpdate(30L)).thenReturn(Optional.of(scenario));
         when(runRepository.findByScenarioId(30L)).thenReturn(List.of(run));
 
         scenarioService.deleteScenario(30L);
 
+        verify(scenarioRepository).findByIdForUpdate(30L);
         verify(runRepository).findByScenarioId(30L);
         verify(scenarioRepository).delete(scenario);
         verify(artefactService).deleteArtefacts(run);


### PR DESCRIPTION
### Motivation
- Prevent silent loss of simulation-run history and on-disk artefacts when a scenario delete cascades runs, and surface that impact to users before they confirm destructive actions.
- Ensure artefact directories for cascade-removed runs are removed only after the delete transaction commits to avoid orphaned files or accidental permanent deletion on rollback.
- Make the deletion workflow discoverable to clients and automate cleanup so operators can safely remove scenarios without leaving leftover files.

### Description
- Added `simulationRunCount` to `ScenarioResponse`, `SimulationRunRepository` helpers `findByScenarioId`/`countByScenarioId`, and a new controller endpoint `GET /api/v1/scenarios/{id}/run-count` for deletion-impact queries.
- Updated `ScenarioService.deleteScenario` to capture runs that reference the scenario before deleting the scenario row and to delete captured runs' artefact directories after transaction commit using `TransactionSynchronizationManager` and `ArtefactService.deleteArtefacts`.
- Frontend: added `scenariosApi.getScenarioRunCount`, updated the Scenarios UI to check run-count before opening the confirmation modal, disable the Delete button while checking, and show a stronger warning when associated runs/artefacts will be removed.
- Tests and docs: added unit tests covering the new service behavior and UI flow (`ScenarioServiceTest` updates and `Scenarios.delete.test.jsx`), updated `CHANGELOG.md`, `README.md`, and `docs/API.md`, and bumped project/frontend version to `0.53.6`.

### Testing
- Ran frontend unit tests with `npm run test:unit` and all tests passed (11 files, 93 tests) including the new Scenarios deletion test. (passed)
- Ran frontend linter `npm run lint` with no errors. (passed)
- Attempted Java unit run for `ScenarioServiceTest` with Maven; JVM compilation/run was blocked by environment inability to resolve the Spring Boot parent POM from Maven Central (HTTP 403) and offline attempts failed because the parent POM was not cached locally, so backend integration/unit JVM tests could not be executed in this environment. (blocked)
- Tried a Playwright screenshot of the deletion warning but Playwright browser installation was not available in the environment, so end-to-end browser checks were skipped. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3ab6a88c8325a83338ce1ef5ac3a)