### PR TITLE
Add comprehensive KPI regression and integration tests

### DIFF
--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -140,6 +140,13 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
                 .andExpect(jsonPath("$.status").value("SUCCEEDED"))
                 .andExpect(jsonPath("$.results.runSummary.status").value("SUCCEEDED"))
                 .andExpect(jsonPath("$.results.kpis.pickupRequestsServed").value(1))
+                .andExpect(jsonPath("$.results.kpis.passengersServed").value(1))
+                .andExpect(jsonPath("$.results.kpis.avgPickupWaitTicks").isNotEmpty())
+                .andExpect(jsonPath("$.results.kpis.maxPickupWaitTicks").isNotEmpty())
+                .andExpect(jsonPath("$.results.kpis.idleTicks").isNotEmpty())
+                .andExpect(jsonPath("$.results.kpis.movingTicks").isNotEmpty())
+                .andExpect(jsonPath("$.results.kpis.doorTicks").isNotEmpty())
+                .andExpect(jsonPath("$.results.kpis.pickupLegUtilisation").isNotEmpty())
                 .andExpect(jsonPath("$.logsUrl").value("/api/v1/simulation-runs/" + runId + "/logs"));
     }
 

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -607,6 +607,21 @@ public class SimulationRunExecutionServiceTest {
             "All 3 passengers should be served");
         assertTrue(kpis.get("movingTicks").asLong() > 0,
             "Lift must move to service requests at different floors");
+
+        JsonNode perFloor = results.get("perFloor");
+        assertTrue(perFloor.isArray() && perFloor.size() > 0,
+            "Per-floor analytics must be recorded");
+
+        JsonNode floor0 = perFloor.path(0);
+        assertEquals(0, floor0.get("floor").asInt(), "First floor should be floor 0");
+        assertTrue(floor0.get("liftVisits").asLong() >= 1,
+            "Floor 0 should be visited (home floor and destination)");
+
+        JsonNode floor10 = perFloor.path(10);
+        assertEquals(10, floor10.get("floor").asInt(), "Floor 10 should exist in per-floor data");
+        assertTrue(floor10.get("liftVisits").asLong() >= 1,
+            "Floor 10 should be visited for the maxFloor request");
+
         assertInternalStateCleared(101L);
     }
 

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -479,6 +479,137 @@ public class SimulationRunExecutionServiceTest {
             "Rejected run must carry a descriptive error message");
     }
 
+    @Test
+    public void kpiRegressionTestWithFixedSeedAndMultiplePassengers() throws Exception {
+        Path runDir = tempDir.resolve("run-kpi-regression");
+        Files.createDirectories(runDir);
+
+        String kpiScenario = """
+            {
+                "durationTicks": 30,
+                "seed": 12345,
+                "passengerFlows": [
+                    {
+                        "startTick": 0,
+                        "originFloor": 0,
+                        "destinationFloor": 4,
+                        "passengers": 3
+                    },
+                    {
+                        "startTick": 10,
+                        "originFloor": 2,
+                        "destinationFloor": 1,
+                        "passengers": 2
+                    }
+                ]
+            }
+            """.trim();
+
+        SimulationRun run = runWithArtefactDirectory(100L, runDir, kpiScenario);
+        AtomicReference<SimulationRun> storedRun = prepareRepository(run);
+        when(configValidationService.validate(VALID_CONFIG)).thenReturn(validConfigResponse());
+        when(scenarioValidationService.validate(any(JsonNode.class))).thenReturn(validScenarioResponse());
+
+        executionService.submitRunForExecution(100L);
+
+        waitForExecutionToFinish(storedRun, SimulationRun.RunStatus.SUCCEEDED);
+        JsonNode results = objectMapper.readTree(runDir.resolve("results.json").toFile());
+        JsonNode kpis = results.get("kpis");
+
+        assertEquals(2, kpis.get("pickupRequestsServed").asInt(),
+            "Should have 2 pickup requests served (one per flow)");
+        assertEquals(5, kpis.get("passengersServed").asInt(),
+            "Should have 5 total passengers served (3 from flow 1 + 2 from flow 2)");
+        assertTrue(kpis.get("avgPickupWaitTicks").asDouble() > 0,
+            "Average wait ticks must be positive");
+        assertTrue(kpis.get("maxPickupWaitTicks").asLong() > 0,
+            "Max wait ticks must be positive");
+        assertTrue(kpis.get("idleTicks").asLong() >= 0,
+            "Idle ticks must be non-negative");
+        assertTrue(kpis.get("movingTicks").asLong() > 0,
+            "Moving ticks must be positive (lift must move to service requests)");
+        assertTrue(kpis.get("doorTicks").asLong() > 0,
+            "Door ticks must be positive (doors must open for pickups)");
+        double utilisation = kpis.get("pickupLegUtilisation").asDouble();
+        assertTrue(utilisation >= 0 && utilisation <= 1.0,
+            "Utilisation must be between 0 and 1, got " + utilisation);
+
+        JsonNode perLift = results.get("perLift").get(0);
+        assertEquals(30L, perLift.get("totalTicks").asLong(),
+            "Total ticks must equal scenario duration");
+        assertInternalStateCleared(100L);
+    }
+
+    @Test
+    public void directionalScanReversalFloorTest() throws Exception {
+        Path runDir = tempDir.resolve("run-ds-reversal");
+        Files.createDirectories(runDir);
+
+        String dsConfig = """
+            {
+                "minFloor": 0,
+                "maxFloor": 10,
+                "lifts": 1,
+                "travelTicksPerFloor": 1,
+                "doorTransitionTicks": 1,
+                "doorDwellTicks": 1,
+                "doorReopenWindowTicks": 1,
+                "homeFloor": 0,
+                "idleTimeoutTicks": 2,
+                "controllerStrategy": "DIRECTIONAL_SCAN",
+                "idleParkingMode": "PARK_TO_HOME_FLOOR"
+            }
+            """.trim();
+
+        String dsScenario = """
+            {
+                "durationTicks": 100,
+                "seed": 54321,
+                "passengerFlows": [
+                    {
+                        "startTick": 0,
+                        "originFloor": 0,
+                        "destinationFloor": 8,
+                        "passengers": 1
+                    },
+                    {
+                        "startTick": 5,
+                        "originFloor": 9,
+                        "destinationFloor": 0,
+                        "passengers": 1
+                    },
+                    {
+                        "startTick": 15,
+                        "originFloor": 10,
+                        "destinationFloor": 5,
+                        "passengers": 1
+                    }
+                ]
+            }
+            """.trim();
+
+        SimulationRun run = runWithArtefactDirectory(101L, runDir, dsScenario);
+        run.setLiftSystem(run.getLiftSystem());
+        run.getVersion().setConfig(dsConfig);
+        AtomicReference<SimulationRun> storedRun = prepareRepository(run);
+        when(configValidationService.validate(dsConfig)).thenReturn(validConfigResponse());
+        when(scenarioValidationService.validate(any(JsonNode.class))).thenReturn(validScenarioResponse());
+
+        executionService.submitRunForExecution(101L);
+
+        waitForExecutionToFinish(storedRun, SimulationRun.RunStatus.SUCCEEDED);
+        JsonNode results = objectMapper.readTree(runDir.resolve("results.json").toFile());
+        JsonNode kpis = results.get("kpis");
+
+        assertEquals(3, kpis.get("pickupRequestsServed").asInt(),
+            "All 3 requests should be served in directional scan");
+        assertEquals(3, kpis.get("passengersServed").asInt(),
+            "All 3 passengers should be served");
+        assertTrue(kpis.get("movingTicks").asLong() > 0,
+            "Lift must move to service requests at different floors");
+        assertInternalStateCleared(101L);
+    }
+
     private AtomicReference<SimulationRun> prepareRepository(SimulationRun run) {
         AtomicReference<SimulationRun> storedRun = new AtomicReference<>(run);
         lenient().when(runRepository.findById(run.getId())).thenAnswer(invocation -> Optional.of(storedRun.get()));


### PR DESCRIPTION
## Summary
This PR adds two new test cases to improve test coverage for KPI calculations and simulation execution, ensuring that key performance indicators are correctly computed and reported across different scenarios and controller strategies.

## Key Changes
- **KPI Regression Test**: Added `kpiRegressionTestWithFixedSeedAndMultiplePassengers()` to validate KPI calculations with a fixed seed and multiple passenger flows. This test verifies:
  - Correct counting of pickup requests served and total passengers served
  - Positive values for wait time metrics (average and maximum pickup wait ticks)
  - Proper tracking of lift operational metrics (idle, moving, and door ticks)
  - Valid utilisation percentage (0-1 range)
  - Per-lift analytics are correctly recorded

- **Directional Scan Strategy Test**: Added `directionalScanReversalFloorTest()` to validate the DIRECTIONAL_SCAN controller strategy with floor reversal scenarios. This test ensures:
  - All passenger requests are served across multiple floors
  - Lift movement is properly tracked
  - Per-floor analytics are recorded for all visited floors
  - Specific floor visits are tracked (home floor and maximum floor)

- **Integration Test Enhancement**: Updated `testRunLifecycle_StartPollResults()` to validate all KPI fields in the API response, including:
  - `passengersServed`
  - `avgPickupWaitTicks`
  - `maxPickupWaitTicks`
  - `idleTicks`
  - `movingTicks`
  - `doorTicks`
  - `pickupLegUtilisation`

## Notable Implementation Details
- Both new tests use fixed seeds (12345 and 54321) to ensure deterministic, reproducible results
- Tests verify internal state cleanup after execution via `assertInternalStateCleared()`
- Comprehensive assertions validate both aggregate KPIs and per-lift/per-floor analytics
- Tests cover edge cases like multiple passenger flows and floor range traversal

https://claude.ai/code/session_0129HNYwCbuGyjWHt9kJ743D