### PR TITLE
Downgrade Spring Boot from 4.1.0 to 3.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.1.0</version>
+        <version>3.4.5</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
## Summary
This pull request downgrades the Spring Boot parent version from 4.1.0 to 3.4.5 in the project's Maven configuration.

## Key Changes
- Updated `spring-boot-starter-parent` version from 4.1.0 to 3.4.5 in pom.xml

## Notes
This is a significant version downgrade that moves from Spring Boot 4.x to 3.x. This change may require verification that all dependencies and code are compatible with Spring Boot 3.4.5, as there could be breaking changes between major versions.

https://claude.ai/code/session_016mMa8hyZNsi4AGeyc5f7J7