### PR TITLE
chore(deps): upgrade Spring Boot from 3.4.0 to 3.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.5</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Updates spring-boot-starter-parent to the latest patch release (3.4.5) while maintaining compatibility with existing dependencies. This is a stable patch upgrade within the 3.4.x line with no breaking changes.

Resolves compilation errors from the incompatible Spring Boot 4.1.0 upgrade attempt in Dependabot PR #575.


Claude-Session: https://claude.ai/code/session_016mMa8hyZNsi4AGeyc5f7J7