### PR TITLE
chore(deps): bump Spring Boot to 3.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ summary is kept under [Earlier history](#earlier-history).
 ## [Unreleased]
 
 
+## [0.53.9] - 2026-07-06
+
+### Changed
+- **Spring Boot 3.5 baseline refresh**: Upgraded the Maven Spring Boot parent from 3.4.5 to 3.5.15 and added the temporary Spring Boot properties migrator runtime dependency so renamed or removed configuration keys are reported during the 3.5.x transition. Updated README and package metadata for the 0.53.9 patch release.
+
 ## [0.53.8] - 2026-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.53.8**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.53.9**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.53.8.jar
+java -jar target/lift-simulator-0.53.9.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.53.8.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.53.9.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.53.8.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.53.8.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.53.9.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.53.9.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.53.8.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.53.8.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.53.9.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -214,7 +214,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.8.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.53.9.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 
@@ -335,7 +335,7 @@ Alternatively, set `LOGGING_FILE_PATH` as an environment variable.
 
 This project ships an `.editorconfig` for consistent formatting across editors and IDEs (IntelliJ IDEA has built-in support; VS Code, Eclipse, and Vim/Neovim use plugins). It enforces UTF-8 encoding, LF line endings, 4-space indentation for Java and XML, trailing-whitespace removal, and final-newline insertion.
 
-**Backend dependency baseline:** Spring Boot 3.4.13, Springdoc OpenAPI 2.7.0, PostgreSQL JDBC driver 42.7.11, and the Flyway PostgreSQL module (managed by Spring Boot dependency management).
+**Backend dependency baseline:** Spring Boot 3.5.15, Springdoc OpenAPI 2.7.0, PostgreSQL JDBC driver 42.7.11, and the Flyway PostgreSQL module (managed by Spring Boot dependency management). The temporary `spring-boot-properties-migrator` runtime dependency is enabled during the 3.5.x transition to report configuration keys that need migration before the Spring Boot 4 upgrade.
 
 **Commenting style:** use `//` for single-line comments and `/* */` for multi-line explanations, write non-obvious logic as complete sentences, and end comment sentences with periods.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.53.8.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.53.9.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.53.8.jar \
+java -cp target/lift-simulator-0.53.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.53.8.jar \
+java -cp target/lift-simulator-0.53.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.53.8.jar \
+java -cp target/lift-simulator-0.53.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.53.8.jar \
+java -cp target/lift-simulator-0.53.9.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -384,7 +384,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.53.8.jar \
+   java -cp target/lift-simulator-0.53.9.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -429,7 +429,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.53.8.jar \
+java -cp target/lift-simulator-0.53.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -521,7 +521,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.53.8.jar \
+java -cp target/lift-simulator-0.53.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.53.8",
+  "version": "0.53.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.53.8",
+      "version": "0.53.9",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.53.8",
+  "version": "0.53.9",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.5</version>
+        <version>3.5.15</version>
         <relativePath/>
     </parent>
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.53.8</version>
+    <version>0.53.9</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -97,6 +97,13 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.7.0</version>
+        </dependency>
+
+        <!-- Spring Boot Properties Migrator for temporary 3.5.x configuration migration diagnostics -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-properties-migrator</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Spring Boot Test Starter -->


### PR DESCRIPTION
### Motivation
- Prepare the repository for the Spring Boot 4 upgrade by moving the dependency baseline to the latest 3.5.x patch while surfacing configuration changes that need migration. 
- Keep project metadata consistent by bumping the project and frontend package versions using semantic versioning (from `0.53.8` → `0.53.9`).

### Description
- Updated the Maven parent Spring Boot version from `3.4.5` to `3.5.15` in `pom.xml` and added a runtime dependency on `org.springframework.boot:spring-boot-properties-migrator` to report renamed/removed configuration keys during the 3.5.x transition. 
- Bumped repository version and frontend package metadata from `0.53.8` to `0.53.9` in `pom.xml`, `README.md`, `CHANGELOG.md`, `frontend/package.json`, `frontend/package-lock.json`, and several docs (`docs/DEVELOPER-GUIDE.md`, `docs/Workflows-and-Troubleshooting.md`).
- Inserted a `0.53.9` changelog entry describing the baseline refresh and updated README guidance to note the temporary properties migrator and the new backend dependency baseline. 
- Small documentation updates to CLI/JAR examples and jar-version references so in-repo docs remain consistent with the bumped SemVer.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it completed with no reported problems. 
- Attempted `mvn -q -DskipTests compile` to verify compilation against the new Spring Boot parent, but the build was blocked in this environment when resolving `org.springframework.boot:spring-boot-starter-parent:3.5.15` due to Maven Central returning HTTP 403; the change is otherwise syntactically validated by local edits and repository consistency checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4be8907068832598b0bcc69f80f1da)