### PR TITLE
Migrate Jackson 2 to Jackson 3 for Spring Boot 4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-07-07
+
+### Changed
+- **Jackson 3 migration (main sources)**: Migrated all main-source Jackson usages from the `com.fasterxml.jackson.databind`/`core` packages to Jackson 3's `tools.jackson.databind`/`core` packages (annotations remain under `com.fasterxml.jackson.annotation`), as required by the Spring Boot 4 default of Jackson 3. Reworked `JacksonConfiguration` from `Jackson2ObjectMapperBuilderCustomizer` to a `JsonMapper.Builder` bean seeded with a `JsonFactory` that enforces the existing stream-read constraints (max nesting depth 100, max string length 1 MiB) and re-asserts `FAIL_ON_UNKNOWN_PROPERTIES`, while re-applying every auto-configured `JsonMapperBuilderCustomizer` so Spring Boot defaults are preserved. Audited Jackson exception handling for Jackson 3's unchecked `JacksonException` (formerly checked `JsonProcessingException`) so JSON parse and unknown-property failures still surface as clean 400s and unreadable simulation results still surface as 500s. Removed now-redundant `JavaTimeModule` registrations and the `WRITE_DATES_AS_TIMESTAMPS` toggle (java.time support and ISO-8601 date output are Jackson 3 core defaults), and replaced `ObjectMapper.copy()` with `rebuild().build()`. The JSON contract — strict unknown-property rejection, JSONB round-trips, and the authentication/authorization error-body shape — is unchanged. Updated ADR-0013 and package metadata for the 0.55.0 pre-MVP minor release.
+
 ## [0.54.0] - 2026-07-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.54.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.55.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 

--- a/docs/decisions/0013-strict-schema-validation-unknown-fields.md
+++ b/docs/decisions/0013-strict-schema-validation-unknown-fields.md
@@ -4,6 +4,12 @@
 
 **Status**: Accepted
 
+> **Update (2026-07-07, Jackson 3 / Spring Boot 4):** The decision to reject
+> unknown properties is unchanged, but the implementation moved to Jackson 3.
+> The code samples below reflect the original Jackson 2 implementation; see
+> [Update — Jackson 3 migration](#update--jackson-3-migration-spring-boot-4) at
+> the end of this ADR for the current approach.
+
 ## Context
 
 The Lift Config Service accepts configuration JSON payloads at multiple entry points:
@@ -364,3 +370,61 @@ This ADR complies with:
 - [OWASP: Input Validation](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html)
 - [REST API Error Handling Best Practices](https://www.rfc-editor.org/rfc/rfc7807)
 - [Semantic Versioning 2.0.0](https://semver.org/)
+
+## Update — Jackson 3 migration (Spring Boot 4)
+
+**Date**: 2026-07-07 (v0.55.0)
+
+Spring Boot 4 defaults to **Jackson 3**, which relocates the runtime packages from
+`com.fasterxml.jackson.databind`/`core` to `tools.jackson.databind`/`core` (only
+`jackson-annotations` keeps the `com.fasterxml.jackson.annotation` package). The
+strict-schema decision above is unchanged; only its implementation moved.
+
+### What changed
+
+1. **Configuration customizer → builder bean.** Jackson 3 owns stream-read
+   constraints on the `tools.jackson.core.TokenStreamFactory`, which a
+   `JsonMapperBuilderCustomizer` cannot replace on an already-created builder.
+   `JacksonConfiguration` therefore overrides Spring Boot's
+   `@ConditionalOnMissingBean` `jsonMapperBuilder` with a `JsonMapper.Builder`
+   bean seeded from a constrained `JsonFactory`, re-applies every auto-configured
+   `JsonMapperBuilderCustomizer` (so module discovery, `spring.jackson.*`
+   properties, and ProblemDetail support are preserved), and asserts
+   `FAIL_ON_UNKNOWN_PROPERTIES` last so unknown fields are always rejected:
+
+   ```java
+   @Bean
+   public JsonMapper.Builder jsonMapperBuilder(List<JsonMapperBuilderCustomizer> customizers) {
+       StreamReadConstraints readConstraints = StreamReadConstraints.builder()
+           .maxNestingDepth(MAX_JSON_NESTING_DEPTH)
+           .maxStringLength(MAX_JSON_STRING_LENGTH)
+           .build();
+       JsonFactory jsonFactory = JsonFactory.builder()
+           .streamReadConstraints(readConstraints)
+           .build();
+       JsonMapper.Builder builder = JsonMapper.builder(jsonFactory);
+       customizers.forEach(customizer -> customizer.customize(builder));
+       builder.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+       return builder;
+   }
+   ```
+
+2. **Modules are built in.** Jackson 3 bundles java.time support in databind
+   core and serializes dates as ISO-8601 strings by default
+   (`WRITE_DATES_AS_TIMESTAMPS` moved to `DateTimeFeature` and is off), so the
+   explicit `JavaTimeModule` registration and `WRITE_DATES_AS_TIMESTAMPS` toggle
+   in the security error handlers were removed. A plain `new ObjectMapper()`
+   still renders `OffsetDateTime`/`Instant` as ISO-8601 strings.
+
+3. **Unchecked exceptions.** The checked `JsonProcessingException`/
+   `JsonMappingException` are gone; all Jackson failures now extend the unchecked
+   `tools.jackson.core.JacksonException`. Unknown-property detection still relies
+   on `UnrecognizedPropertyException` (now `tools.jackson.databind.exc`), and the
+   mapping-path helper reads `JacksonException.Reference.getPropertyName()`
+   (renamed from `getFieldName()`). Catch/throws clauses were audited so parse and
+   unknown-property failures still return 400 and unreadable results still return
+   500.
+
+The externally observable JSON contract — strict unknown-property rejection, the
+`{ valid, errors[], warnings[] }` validation body, JSONB round-trips, and the
+authentication/authorization error-body shape — is unchanged.

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.54.0</version>
+    <version>0.55.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/liftsimulator/admin/config/CustomAccessDeniedHandler.java
@@ -1,7 +1,5 @@
 package com.liftsimulator.admin.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
@@ -9,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -38,8 +37,8 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     private final ObjectMapper objectMapper;
 
     public CustomAccessDeniedHandler() {
+        // Jackson 3 bundles java.time support in databind core, so no module registration is needed.
         this.objectMapper = new ObjectMapper();
-        this.objectMapper.registerModule(new JavaTimeModule());
     }
 
     @Override

--- a/src/main/java/com/liftsimulator/admin/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/liftsimulator/admin/config/CustomAuthenticationEntryPoint.java
@@ -1,8 +1,5 @@
 package com.liftsimulator.admin.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
@@ -11,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -61,10 +59,10 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
      */
     public CustomAuthenticationEntryPoint(String realm) {
         this.realm = realm;
+        // Jackson 3 bundles java.time support in databind core and serializes dates as ISO-8601
+        // strings by default (WRITE_DATES_AS_TIMESTAMPS is off), so no module or feature tuning
+        // is needed to render the timestamp as an ISO-8601 string.
         this.objectMapper = new ObjectMapper();
-        this.objectMapper.registerModule(new JavaTimeModule());
-        // Serialize dates as ISO-8601 strings, not timestamps
-        this.objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 
     @Override

--- a/src/main/java/com/liftsimulator/admin/config/JacksonConfiguration.java
+++ b/src/main/java/com/liftsimulator/admin/config/JacksonConfiguration.java
@@ -1,15 +1,17 @@
 package com.liftsimulator.admin.config;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.StreamReadConstraints;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import java.util.List;
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Jackson configuration for JSON serialization/deserialization.
- * Configures ObjectMapper to enforce strict schema validation.
+ * Configures the auto-configured {@link JsonMapper} to enforce strict schema validation.
  */
 @Configuration
 public class JacksonConfiguration {
@@ -18,18 +20,23 @@ public class JacksonConfiguration {
     private static final int MAX_JSON_STRING_LENGTH = 1_048_576;
 
     /**
-     * Customizes the auto-configured ObjectMapper with strict validation settings.
-     * Enables FAIL_ON_UNKNOWN_PROPERTIES to reject JSON with unexpected fields,
-     * helping catch typos and schema violations in configuration payloads.
+     * Supplies the {@link JsonMapper.Builder} that Spring Boot builds its auto-configured
+     * {@code JsonMapper} from, seeded with a {@link JsonFactory} that enforces our stricter
+     * {@link StreamReadConstraints} (maximum nesting depth and string length).
      *
-     * <p>Uses Jackson2ObjectMapperBuilderCustomizer to customize Spring Boot's
-     * auto-configured ObjectMapper rather than replacing it, preserving all
-     * Spring Boot defaults while adding our strict validation.
+     * <p>Jackson 3 owns stream-read constraints on the {@link tools.jackson.core.TokenStreamFactory},
+     * which a {@link JsonMapperBuilderCustomizer} cannot replace on an already-created builder.
+     * Overriding Boot's {@code @ConditionalOnMissingBean} builder is therefore the supported way to
+     * apply them. Every auto-configured {@link JsonMapperBuilderCustomizer} (module discovery,
+     * {@code spring.jackson.*} properties, ProblemDetail support) is re-applied so no Boot default
+     * is lost, and {@link DeserializationFeature#FAIL_ON_UNKNOWN_PROPERTIES} is asserted last so JSON
+     * with unexpected fields is rejected regardless of Jackson 3's flipped defaults.
      *
-     * @return ObjectMapper customizer
+     * @param customizers the auto-configured Jackson builder customizers to apply
+     * @return the strict JSON mapper builder
      */
     @Bean
-    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+    public JsonMapper.Builder jsonMapperBuilder(List<JsonMapperBuilderCustomizer> customizers) {
         StreamReadConstraints readConstraints = StreamReadConstraints.builder()
             .maxNestingDepth(MAX_JSON_NESTING_DEPTH)
             .maxStringLength(MAX_JSON_STRING_LENGTH)
@@ -38,8 +45,9 @@ public class JacksonConfiguration {
             .streamReadConstraints(readConstraints)
             .build();
 
-        return builder -> builder
-            .factory(jsonFactory)
-            .featuresToEnable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        JsonMapper.Builder builder = JsonMapper.builder(jsonFactory);
+        customizers.forEach(customizer -> customizer.customize(builder));
+        builder.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        return builder;
     }
 }

--- a/src/main/java/com/liftsimulator/admin/config/JsonStringConverter.java
+++ b/src/main/java/com/liftsimulator/admin/config/JsonStringConverter.java
@@ -1,9 +1,9 @@
 package com.liftsimulator.admin.config;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * JPA AttributeConverter for JSON string columns.
@@ -45,7 +45,7 @@ public class JsonStringConverter implements AttributeConverter<String, String> {
         // Validate JSON format before persisting
         try {
             OBJECT_MAPPER.readTree(attribute);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Invalid JSON format: " + e.getMessage(), e);
         }
 

--- a/src/main/java/com/liftsimulator/admin/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/liftsimulator/admin/controller/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.liftsimulator.admin.controller;
 
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.ErrorResponse;
 import com.liftsimulator.admin.dto.ScenarioValidationResponse;
@@ -26,6 +25,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;

--- a/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
+++ b/src/main/java/com/liftsimulator/admin/controller/SimulationRunController.java
@@ -1,6 +1,5 @@
 package com.liftsimulator.admin.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.liftsimulator.admin.dto.ArtefactInfo;
 import com.liftsimulator.admin.dto.CreateSimulationRunRequest;
 import com.liftsimulator.admin.dto.SimulationResultResponse;
@@ -40,6 +39,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -208,8 +209,10 @@ public class SimulationRunController {
                 try {
                     JsonNode results = artefactService.readResults(run);
                     yield ResponseEntity.ok(SimulationResultResponse.success(id, results));
-                } catch (IOException e) {
-                    // Results file not found or not readable - genuine server error
+                } catch (IOException | JacksonException e) {
+                    // Results file not found, not readable, or malformed JSON - genuine server error.
+                    // Jackson 3 parse failures are unchecked JacksonException, so catch them alongside
+                    // IOException to preserve the 500-with-body contract for unreadable results.
                     yield ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(SimulationResultResponse.succeededWithoutResults(
                                     id,

--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioRequest.java
@@ -1,6 +1,6 @@
 package com.liftsimulator.admin.dto;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioResponse.java
@@ -1,6 +1,6 @@
 package com.liftsimulator.admin.dto;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import java.time.OffsetDateTime;
 

--- a/src/main/java/com/liftsimulator/admin/dto/ScenarioValidateRequest.java
+++ b/src/main/java/com/liftsimulator/admin/dto/ScenarioValidateRequest.java
@@ -1,6 +1,6 @@
 package com.liftsimulator.admin.dto;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotNull;
 
 /**

--- a/src/main/java/com/liftsimulator/admin/dto/SimulationResultResponse.java
+++ b/src/main/java/com/liftsimulator/admin/dto/SimulationResultResponse.java
@@ -1,6 +1,6 @@
 package com.liftsimulator.admin.dto;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import com.liftsimulator.admin.entity.SimulationRun.RunStatus;
 
 /**

--- a/src/main/java/com/liftsimulator/admin/runner/JpaVerificationRunner.java
+++ b/src/main/java/com/liftsimulator/admin/runner/JpaVerificationRunner.java
@@ -1,7 +1,5 @@
 package com.liftsimulator.admin.runner;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.entity.LiftSystem;
 import com.liftsimulator.admin.entity.LiftSystemVersion;
 import com.liftsimulator.admin.entity.LiftSystemVersion.VersionStatus;
@@ -17,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Command-line runner to verify basic JPA entity and repository operations.
@@ -160,7 +160,7 @@ public class JpaVerificationRunner implements CommandLineRunner {
     private boolean jsonSemanticallyEquals(String expectedJson, String actualJson) {
         try {
             return objectMapper.readTree(expectedJson).equals(objectMapper.readTree(actualJson));
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new AssertionError("Failed to parse JSONB config during verification", e);
         }
     }

--- a/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactService.java
@@ -1,7 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ArtefactInfo;
 import com.liftsimulator.admin.entity.SimulationRun;
 import org.slf4j.Logger;
@@ -22,6 +20,8 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.stream.Stream;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Service for managing simulation run artefacts with security controls.
@@ -40,7 +40,8 @@ public class ArtefactService {
     private final ObjectMapper objectMapper;
 
     public ArtefactService(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper.copy();
+        // Jackson 3 replaces ObjectMapper.copy() with rebuild().build() to obtain an isolated copy.
+        this.objectMapper = objectMapper.rebuild().build();
     }
 
     public record ArtefactDownload(

--- a/src/main/java/com/liftsimulator/admin/service/BatchInputGenerator.java
+++ b/src/main/java/com/liftsimulator/admin/service/BatchInputGenerator.java
@@ -1,6 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.PassengerFlowDTO;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
@@ -14,6 +13,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Generates batch simulator input files in the legacy .scenario format.
@@ -30,7 +31,8 @@ public class BatchInputGenerator {
     private final ObjectMapper objectMapper;
 
     public BatchInputGenerator(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper.copy();
+        // Jackson 3 replaces ObjectMapper.copy() with rebuild().build() to obtain an isolated copy.
+        this.objectMapper = objectMapper.rebuild().build();
     }
 
     /**
@@ -76,7 +78,9 @@ public class BatchInputGenerator {
     private LiftConfigDTO parseLiftConfig(String liftConfigJson) throws IOException {
         try {
             return objectMapper.readValue(liftConfigJson, LiftConfigDTO.class);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
+            // Jackson 3 read failures are unchecked; keep surfacing them as IOException so the
+            // batch-generation call chain (throws IOException) stays a clean file-level error.
             throw new IOException("Failed to parse lift configuration JSON: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ConfigValidationService.java
@@ -1,11 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.ValidationIssue;
@@ -17,6 +11,11 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 /**
  * Service for validating lift system configuration JSON.
@@ -100,7 +99,7 @@ public class ConfigValidationService {
                 ValidationIssue.Severity.ERROR
             ));
             return new ConfigValidationResponse(false, errors, warnings);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             errors.add(new ValidationIssue(
                 "config",
                 "Invalid JSON format: " + e.getOriginalMessage(),
@@ -129,18 +128,18 @@ public class ConfigValidationService {
     }
 
     /**
-     * Extracts the field name from Jackson's JsonMappingException path.
+     * Extracts the field name from Jackson's databind exception path.
      *
-     * @param path The path from the JsonMappingException
+     * @param path The path from the {@link JacksonException}
      * @return The field name, or "config" if path is empty
      */
-    private String getFieldNameFromPath(List<JsonMappingException.Reference> path) {
+    private String getFieldNameFromPath(List<JacksonException.Reference> path) {
         if (path == null || path.isEmpty()) {
             return "config";
         }
         // Get the last reference in the path (most specific field)
-        JsonMappingException.Reference lastRef = path.get(path.size() - 1);
-        String fieldName = lastRef.getFieldName();
+        JacksonException.Reference lastRef = path.get(path.size() - 1);
+        String fieldName = lastRef.getPropertyName();
         return fieldName != null ? fieldName : "config";
     }
 

--- a/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/LiftSystemVersionService.java
@@ -1,9 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.CreateVersionRequest;
 import com.liftsimulator.admin.dto.UpdateVersionConfigRequest;
@@ -17,6 +13,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Service for managing lift system versions.
@@ -127,7 +127,7 @@ public class LiftSystemVersionService {
                 .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
                 .readTree(config);
             return objectMapper.writeValueAsString(configJson);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Configuration JSON could not be normalized", e);
         }
     }

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioService.java
@@ -1,8 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.ScenarioRequest;
 import com.liftsimulator.admin.dto.ScenarioResponse;
@@ -23,6 +20,9 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Service for managing stored scenarios.
@@ -279,7 +279,7 @@ public class ScenarioService {
     private JsonNode parseStoredScenarioJson(Scenario scenario) {
         try {
             return objectMapper.readTree(scenario.getScenarioJson());
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("Stored scenario JSON could not be parsed", e);
         }
     }
@@ -330,7 +330,7 @@ public class ScenarioService {
     private String serializeScenarioJson(JsonNode scenarioJson) {
         try {
             return objectMapper.writeValueAsString(scenarioJson);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalArgumentException("Scenario JSON could not be serialized");
         }
     }
@@ -374,7 +374,7 @@ public class ScenarioService {
                 scenario.getCreatedAt(),
                 scenario.getUpdatedAt()
             );
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException("Stored scenario JSON could not be parsed", e);
         }
     }

--- a/src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java
+++ b/src/main/java/com/liftsimulator/admin/service/ScenarioValidationService.java
@@ -1,12 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.PassengerFlowDTO;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
@@ -19,10 +12,15 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 /**
  * Service for validating UI scenario JSON payloads.
@@ -72,7 +70,7 @@ public class ScenarioValidationService {
         LiftConfigDTO config;
         try {
             config = objectMapper.readValue(version.getConfig(), LiftConfigDTO.class);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw new IllegalStateException(
                 "Failed to parse lift system version config: " + e.getMessage(), e
             );
@@ -91,7 +89,7 @@ public class ScenarioValidationService {
         try {
             scenario = objectMapper.readerFor(ScenarioDefinitionDTO.class)
                 .readValue(scenarioJson);
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             // This shouldn't happen since we already validated successfully above
             throw new IllegalStateException("Failed to parse scenario JSON: " + e.getMessage(), e);
         }
@@ -151,17 +149,10 @@ public class ScenarioValidationService {
             }
             errors.add(new ValidationIssue(fieldName, errorMessage, ValidationIssue.Severity.ERROR));
             return new ScenarioValidationResponse(false, errors, warnings);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             errors.add(new ValidationIssue(
                 "scenario",
                 "Invalid JSON format: " + e.getOriginalMessage(),
-                ValidationIssue.Severity.ERROR
-            ));
-            return new ScenarioValidationResponse(false, errors, warnings);
-        } catch (IOException e) {
-            errors.add(new ValidationIssue(
-                "scenario",
-                "Unable to read scenario payload: " + e.getMessage(),
                 ValidationIssue.Severity.ERROR
             ));
             return new ScenarioValidationResponse(false, errors, warnings);
@@ -182,12 +173,12 @@ public class ScenarioValidationService {
         return new ScenarioValidationResponse(valid, errors, warnings);
     }
 
-    private String getFieldNameFromPath(List<JsonMappingException.Reference> path) {
+    private String getFieldNameFromPath(List<JacksonException.Reference> path) {
         if (path == null || path.isEmpty()) {
             return "scenario";
         }
-        JsonMappingException.Reference lastRef = path.get(path.size() - 1);
-        String fieldName = lastRef.getFieldName();
+        JacksonException.Reference lastRef = path.get(path.size() - 1);
+        String fieldName = lastRef.getPropertyName();
         return fieldName != null ? fieldName : "scenario";
     }
 

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -1,8 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.liftsimulator.admin.dto.ConfigValidationResponse;
 import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.PassengerFlowDTO;
@@ -38,6 +35,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -1,6 +1,5 @@
 package com.liftsimulator.admin.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
 import com.liftsimulator.admin.dto.SimulationRunResponse;
 import com.liftsimulator.admin.entity.LiftSystem;
@@ -37,6 +36,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Service for managing simulation runs.
@@ -216,7 +217,7 @@ public class SimulationRunService {
             if (scenarioDefinition.durationTicks() != null) {
                 return scenarioDefinition.durationTicks().longValue();
             }
-        } catch (IOException ex) {
+        } catch (JacksonException ex) {
             LOGGER.warn("Failed to extract durationTicks from scenario {}: {}", scenario.getId(), ex.getMessage());
         }
         return null;

--- a/src/main/java/com/liftsimulator/admin/service/metrics/RunMetrics.java
+++ b/src/main/java/com/liftsimulator/admin/service/metrics/RunMetrics.java
@@ -1,8 +1,5 @@
 package com.liftsimulator.admin.service.metrics;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.PassengerFlowDTO;
 import com.liftsimulator.domain.LiftRequest;
@@ -14,6 +11,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public final class RunMetrics {
     private final Map<Long, RequestLifecycle> lifecycles = new LinkedHashMap<>();


### PR DESCRIPTION
## Summary
Migrates the codebase from Jackson 2 (`com.fasterxml.jackson.*`) to Jackson 3 (`tools.jackson.*`) to support Spring Boot 4's default Jackson version. The strict schema validation behavior (rejecting unknown properties) is preserved; only the implementation details change.

## Key Changes

### Configuration & Setup
- **JacksonConfiguration**: Reworked from `Jackson2ObjectMapperBuilderCustomizer` to a `JsonMapper.Builder` bean seeded with a `JsonFactory` that enforces stream-read constraints (max nesting depth 100, max string length 1 MiB). Re-applies all auto-configured `JsonMapperBuilderCustomizer` instances to preserve Spring Boot defaults, then asserts `FAIL_ON_UNKNOWN_PROPERTIES` last to ensure unknown fields are always rejected.
- **CustomAuthenticationEntryPoint & CustomAccessDeniedHandler**: Removed explicit `JavaTimeModule` registration and `WRITE_DATES_AS_TIMESTAMPS` configuration, as Jackson 3 bundles java.time support in databind core and defaults to ISO-8601 string serialization.

### Exception Handling
- Replaced checked exceptions (`JsonProcessingException`, `JsonMappingException`, `IOException`) with unchecked `tools.jackson.core.JacksonException` across all services:
  - `ScenarioValidationService`
  - `ConfigValidationService`
  - `ScenarioService`
  - `LiftSystemVersionService`
  - `BatchInputGenerator`
  - `ArtefactService`
  - `JsonStringConverter`
  - `JpaVerificationRunner`
  - `SimulationRunController`
- Updated exception path handling: `JsonMappingException.Reference.getFieldName()` → `JacksonException.Reference.getPropertyName()`

### ObjectMapper Usage
- Replaced `ObjectMapper.copy()` with `rebuild().build()` in `ArtefactService` and `BatchInputGenerator` to obtain isolated copies in Jackson 3.

### Import Updates
- Updated all Jackson imports from `com.fasterxml.jackson.*` to `tools.jackson.*` (except annotations, which remain under `com.fasterxml.jackson.annotation`)
- Affected files: 15+ service, controller, and configuration classes

### Documentation
- Added comprehensive ADR update section documenting the Jackson 3 migration rationale, implementation details, and preserved external contracts (JSON validation behavior, error response shapes, JSONB round-trips)
- Updated CHANGELOG and README with version 0.55.0

## Notable Implementation Details
- The `JsonMapper.Builder` bean override is the supported approach in Jackson 3 to apply stream-read constraints that cannot be set via `JsonMapperBuilderCustomizer` on an already-created builder.
- All external JSON contracts remain unchanged: strict unknown-property rejection, validation response format, error body shapes, and JSONB persistence semantics are preserved.
- Exception handling audited to maintain existing HTTP status codes: 400 for parse/unknown-property failures, 500 for unreadable results.

https://claude.ai/code/session_01AGRropSbeVp5ihCbdCgNDw