### PR TITLE
Bump version to 0.56.0

### DIFF
--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.54.0.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.56.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.54.0.jar \
+java -cp target/lift-simulator-0.56.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.54.0.jar \
+java -cp target/lift-simulator-0.56.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.54.0.jar \
+java -cp target/lift-simulator-0.56.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.54.0.jar \
+java -cp target/lift-simulator-0.56.0.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -384,7 +384,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.54.0.jar \
+   java -cp target/lift-simulator-0.56.0.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -429,7 +429,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.54.0.jar \
+java -cp target/lift-simulator-0.56.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -521,7 +521,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.54.0.jar \
+java -cp target/lift-simulator-0.56.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.54.0",
+  "version": "0.56.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.54.0",
+      "version": "0.56.0",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.54.0",
+  "version": "0.56.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"


### PR DESCRIPTION
## Summary
This PR updates the lift-simulator project version from 0.54.0 to 0.56.0 across all documentation and configuration files.

## Key Changes
- Updated version references in `Workflows-and-Troubleshooting.md` documentation (6 occurrences in code examples)
- Updated version reference in `DEVELOPER-GUIDE.md` documentation (1 occurrence)
- Updated `frontend/package.json` version field to 0.56.0

## Notes
All changes are version number updates in documentation and configuration files to reflect the new release version. No functional code changes are included in this PR.

https://claude.ai/code/session_01SUjkU8YSbxh8Hb3i5RwaJT