### PR TITLE
Upgrade to Spring Boot 4.1.0 and Java 21 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'maven'
 
@@ -184,10 +184,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: 'maven'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.0] - 2026-07-10
+
+### Changed
+- **Spring Boot 4.1.0 upgrade (completes the 3.4.5 → 4.1.0 sequence)**: Bumped the Maven parent from 4.0.7 to 4.1.0, moving the backend baseline to Spring Framework 7.0, Spring Security 7.1, Hibernate ORM 7.4, Jackson 3.1, and Flyway 12.4. Removed the now-redundant explicit Testcontainers BOM import (Spring Boot 4.1 dependency management supplies Testcontainers 2.0.5) and confirmed no 4.0-deprecated bridges remain (no `spring-boot-starter-web` alias, no Jackson 2 defaults toggle, no properties migrator). Replaced the Framework 7-deprecated `HttpStatus.PAYLOAD_TOO_LARGE` constant with `CONTENT_TOO_LARGE` (still HTTP 413; the JSON error body is unchanged) and the Jackson 3.1-deprecated `JsonNode.asText()` test usages with `asString()` for a deprecation-clean compile. Moved CI from JDK 17 to JDK 21 LTS while keeping the compiled bytecode at Java 17 (`maven.compiler.release=17`), so Java 17 runtimes remain supported. Verified Flyway 12.4 migrations against PostgreSQL via Testcontainers, behavioural smoke tests on a running instance (HTTP Basic + ADMIN/VIEWER RBAC, API-key auth, actuator behind ADMIN, Swagger UI, SPA forwarding, rate limiting, request-size caps, CORS preflight, and Framework 7 strict trailing-slash path matching), and an end-to-end simulation run (system → version → scenario → run → results/log artefacts). Refreshed README/architecture/testing docs with the new dependency baseline table for the 0.57.0 pre-MVP minor release.
+
 ## [0.56.0] - 2026-07-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.56.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -22,7 +22,7 @@ For a visual overview of the major components (React admin UI, Spring Boot backe
 
 **Prerequisites**
 
-- **Java 17+** — [Oracle](https://www.oracle.com/java/technologies/downloads/) or OpenJDK
+- **Java 17+** (Java 21 LTS recommended; CI builds and tests on 21) — [Oracle](https://www.oracle.com/java/technologies/downloads/) or OpenJDK
 - **Node.js 20.19+ or 22.12+** and npm — [nodejs.org](https://nodejs.org/)
 - **PostgreSQL 12+** — [postgresql.org](https://www.postgresql.org/download/)
 - **Maven 3.6+** — bundled with most Java IDEs, or [download separately](https://maven.apache.org/download.cgi)
@@ -335,7 +335,22 @@ Alternatively, set `LOGGING_FILE_PATH` as an environment variable.
 
 This project ships an `.editorconfig` for consistent formatting across editors and IDEs (IntelliJ IDEA has built-in support; VS Code, Eclipse, and Vim/Neovim use plugins). It enforces UTF-8 encoding, LF line endings, 4-space indentation for Java and XML, trailing-whitespace removal, and final-newline insertion.
 
-**Backend dependency baseline:** Spring Boot 4.0.7, Springdoc OpenAPI 3.0.3, PostgreSQL JDBC driver 42.7.11, and the Flyway PostgreSQL module (managed by Spring Boot dependency management). Spring Boot 4 dependency management also supplies JUnit 6 and Testcontainers 2 for the backend test suite, with modular MVC and Data JPA test starters covering controller and repository slice tests. Test sources use Jackson 3 `tools.jackson` core/databind APIs and Spring-configured mappers for JSON contract assertions.
+**Backend dependency baseline** — versions are supplied by the Spring Boot 4.1.0 parent's dependency management unless marked explicit:
+
+| Component | Version |
+|-----------|---------|
+| Spring Boot | 4.1.0 |
+| Spring Framework | 7.0 |
+| Spring Security | 7.1 |
+| Hibernate ORM | 7.4 |
+| Jackson | 3.1 (`tools.jackson` packages) |
+| Flyway | 12.4 (with PostgreSQL module) |
+| JUnit | 6.0 |
+| Testcontainers | 2.0 |
+| Springdoc OpenAPI | 3.0.3 (explicit) |
+| PostgreSQL JDBC driver | 42.7.11 (explicit) |
+
+The backend test suite uses the modular MVC and Data JPA test starters for controller and repository slice tests. Test sources use Jackson 3 `tools.jackson` core/databind APIs and Spring-configured mappers for JSON contract assertions.
 
 **Commenting style:** use `//` for single-line comments and `/* */` for multi-line explanations, write non-obvious logic as complete sentences, and end comment sentences with periods.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.56.0.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.0.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/TESTING-SETUP.md
+++ b/docs/TESTING-SETUP.md
@@ -16,7 +16,7 @@ The project uses:
 
 ### Prerequisites
 
-1. **Java 17** - Development environment
+1. **Java 17+** (CI uses Java 21 LTS) - Development environment
 2. **PostgreSQL 15+** - Test database server
 3. **Maven 3.6+** - Build tool
 

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.56.0.jar \
+java -cp target/lift-simulator-0.57.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.56.0.jar \
+java -cp target/lift-simulator-0.57.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.56.0.jar \
+java -cp target/lift-simulator-0.57.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.56.0.jar \
+java -cp target/lift-simulator-0.57.0.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -384,7 +384,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.56.0.jar \
+   java -cp target/lift-simulator-0.57.0.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -429,7 +429,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.56.0.jar \
+java -cp target/lift-simulator-0.57.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -521,7 +521,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.56.0.jar \
+java -cp target/lift-simulator-0.57.0.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,11 @@ graph TD
 
 ### Spring Boot backend (Lift Config Service)
 
+Built on Spring Boot 4.1 (Spring Framework 7, Spring Security 7.1, Hibernate
+ORM 7, Jackson 3, Flyway 12); the full dependency baseline table lives in the
+README's Development Setup section. Runs on Java 17+ (CI builds and tests on
+Java 21 LTS).
+
 - **Security & edge filters** (`admin.config`, `admin.security`) — HTTP Basic
   authentication for admin APIs, API-key authentication for runtime/simulation
   APIs, role-based access control (ADMIN / VIEWER), token-bucket rate limiting

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -8,6 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+# Node/npm distribution installed locally by the Maven frontend profile
+/node/
 dist
 dist-ssr
 *.local

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.56.0",
+      "version": "0.57.0",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.56.0",
+  "version": "0.57.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.7</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.56.0</version>
+    <version>0.57.0</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -25,21 +25,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <frontend.dir>${project.basedir}/frontend</frontend.dir>
         <frontend.build.dir>${frontend.dir}/dist</frontend.build.dir>
-        <testcontainers.version>2.0.5</testcontainers.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <!-- Testcontainers BOM: manages versions for all org.testcontainers modules -->
-            <dependency>
-                <groupId>org.testcontainers</groupId>
-                <artifactId>testcontainers-bom</artifactId>
-                <version>${testcontainers.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Spring Boot Web Starter -->

--- a/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
+++ b/src/main/java/com/liftsimulator/admin/config/RequestSizeLimitFilter.java
@@ -85,7 +85,7 @@ public class RequestSizeLimitFilter extends OncePerRequestFilter {
     private void writePayloadTooLarge(
             HttpServletResponse response,
             long maxBodyBytes) throws IOException {
-        response.setStatus(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        response.setStatus(HttpStatus.CONTENT_TOO_LARGE.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getWriter().write(String.format(
             "{\"status\":413,\"error\":\"Payload Too Large\","

--- a/src/test/java/com/liftsimulator/admin/config/RequestSizeLimitFilterTest.java
+++ b/src/test/java/com/liftsimulator/admin/config/RequestSizeLimitFilterTest.java
@@ -44,7 +44,7 @@ class RequestSizeLimitFilterTest {
 
         filter.doFilter(request, response, filterChain);
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.CONTENT_TOO_LARGE.value());
         assertThat(response.getContentAsString()).contains("Request body exceeds");
         verify(filterChain, never()).doFilter(request, response);
     }
@@ -57,7 +57,7 @@ class RequestSizeLimitFilterTest {
 
         filter.doFilter(request, response, filterChain);
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.CONTENT_TOO_LARGE.value());
         assertThat(response.getContentAsString()).contains("Request body exceeds");
         verify(filterChain, never()).doFilter(any(), eq(response));
     }

--- a/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
+++ b/src/test/java/com/liftsimulator/admin/controller/SimulationRunLifecycleIntegrationTest.java
@@ -158,7 +158,7 @@ public class SimulationRunLifecycleIntegrationTest extends LocalIntegrationTest 
                     .andExpect(status().isOk())
                     .andReturn();
             JsonNode pollJson = objectMapper.readTree(pollResult.getResponse().getContentAsString());
-            if ("SUCCEEDED".equals(pollJson.get("status").asText())) {
+            if ("SUCCEEDED".equals(pollJson.get("status").asString())) {
                 return true;
             }
             Thread.sleep(100);

--- a/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/ArtefactServiceTest.java
@@ -125,7 +125,7 @@ class ArtefactServiceTest {
 
         JsonNode results = artefactService.readResults(runForTempDir());
 
-        assertEquals("SUCCEEDED", results.at("/runSummary/status").asText());
+        assertEquals("SUCCEEDED", results.at("/runSummary/status").asString());
     }
 
     @Test

--- a/src/test/java/com/liftsimulator/admin/service/RunMetricsTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/RunMetricsTest.java
@@ -199,7 +199,7 @@ class RunMetricsTest {
         assertNotNull(lifts);
         assertEquals(1, lifts.size());
         ObjectNode lift = (ObjectNode) lifts.get(0);
-        assertEquals("lift-1", lift.get("liftId").asText());
+        assertEquals("lift-1", lift.get("liftId").asString());
         assertEquals(1, lift.get("minFloor").asInt());
         assertEquals(5, lift.get("maxFloor").asInt());
         assertEquals(1L, lift.get("movingTicks").asLong());

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -161,7 +161,7 @@ public class SimulationRunExecutionServiceTest {
         assertTrue(Files.readString(runDir.resolve("run.log")).contains("Simulation succeeded for run 1"));
 
         JsonNode results = objectMapper.readTree(runDir.resolve("results.json").toFile());
-        assertEquals("SUCCEEDED", results.at("/runSummary/status").asText());
+        assertEquals("SUCCEEDED", results.at("/runSummary/status").asString());
         assertEquals(1L, results.at("/runSummary/runId").asLong());
         assertTrue(results.has("kpis"));
         assertInternalStateCleared(1L);
@@ -183,8 +183,8 @@ public class SimulationRunExecutionServiceTest {
         assertTrue(Files.readString(runDir.resolve("run.log")).contains("Missing scenario payload for run 2"));
 
         JsonNode results = objectMapper.readTree(runDir.resolve("results.json").toFile());
-        assertEquals("FAILED", results.at("/runSummary/status").asText());
-        assertEquals("Missing scenario payload for run.", results.at("/runSummary/message").asText());
+        assertEquals("FAILED", results.at("/runSummary/status").asString());
+        assertEquals("Missing scenario payload for run.", results.at("/runSummary/message").asString());
         assertInternalStateCleared(2L);
     }
 
@@ -204,8 +204,8 @@ public class SimulationRunExecutionServiceTest {
         assertTrue(Files.readString(runDir.resolve("run.log")).contains("Scenario validation failed"));
 
         JsonNode results = objectMapper.readTree(runDir.resolve("results.json").toFile());
-        assertEquals("FAILED", results.at("/runSummary/status").asText());
-        assertEquals("Invalid scenario payload.", results.at("/runSummary/message").asText());
+        assertEquals("FAILED", results.at("/runSummary/status").asString());
+        assertEquals("Invalid scenario payload.", results.at("/runSummary/message").asString());
         assertInternalStateCleared(3L);
     }
 


### PR DESCRIPTION
## Summary

This PR upgrades the project to Spring Boot 4.1.0 (from 4.0.7), moving the backend baseline to Spring Framework 7.0, Spring Security 7.1, Hibernate ORM 7.4, Jackson 3.1, and Flyway 12.4. CI is updated to build and test on Java 21 LTS while maintaining Java 17 runtime compatibility. Deprecated APIs are replaced with their Framework 7 and Jackson 3.1 equivalents.

## Key Changes

- **Spring Boot parent**: 4.0.7 → 4.1.0 in `pom.xml`
- **Removed explicit Testcontainers BOM**: Spring Boot 4.1 dependency management now supplies Testcontainers 2.0.5, eliminating the need for manual version management
- **Deprecated API replacements**:
  - `HttpStatus.PAYLOAD_TOO_LARGE` → `HttpStatus.CONTENT_TOO_LARGE` (HTTP 413 unchanged) in `RequestSizeLimitFilter` and related tests
  - `JsonNode.asText()` → `JsonNode.asString()` across test files for Jackson 3.1 compatibility
- **CI/build updates**:
  - GitHub Actions: JDK 17 → JDK 21 LTS for builds and tests
  - `maven.compiler.release=17` retained to ensure Java 17 runtime support
- **Documentation**:
  - README: Added dependency baseline table with Spring Boot 4.1.0 component versions
  - Architecture docs: Updated with Spring Boot 4.1 and Java 21 LTS details
  - Testing docs: Clarified Java 17+ requirement with Java 21 LTS CI note
  - Version bumps in code examples and package.json (0.56.0 → 0.57.0)
- **Frontend**: Added `/node/` to `.gitignore` for locally installed Node distributions via Maven profile

## Implementation Details

- All deprecated Framework 7 and Jackson 3.1 APIs have been replaced; no deprecation warnings remain
- Flyway 12.4 migrations verified against PostgreSQL via Testcontainers
- Behavioral smoke tests confirm HTTP Basic auth, RBAC, API-key auth, actuator, Swagger UI, SPA forwarding, rate limiting, request-size caps, CORS, and strict trailing-slash path matching all function correctly
- End-to-end simulation run tested (system → version → scenario → run → results/log artefacts)

https://claude.ai/code/session_01VSHaHNVnTmYTzWQGJfy8nB