### PR TITLE
build: unify version synchronization

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,54 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Only act when pom.xml is staged — version bump detection
+# Only act when pom.xml is staged — version bump detection.
 if ! git diff --cached --name-only | grep -q '^pom\.xml$'; then
   exit 0
 fi
 
-# Resolve python binary (python3 on Linux/Mac, may be python on Windows)
-if command -v python3 >/dev/null 2>&1; then
-  PYTHON=python3
-elif command -v python >/dev/null 2>&1; then
-  PYTHON=python
-else
-  echo "[pre-commit] ERROR: python3/python not found — cannot sync version." >&2
-  exit 1
-fi
+echo "[pre-commit] pom.xml version change detected — syncing version references..."
+./scripts/sync-versions.sh
 
-# Extract project version from staged pom.xml (avoids reading parent <version>)
-VERSION=$(git show :pom.xml | $PYTHON -c "
-import sys, xml.etree.ElementTree as ET
-tree = ET.parse(sys.stdin)
-root = tree.getroot()
-ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
-print(root.find('m:version', ns).text)
-")
-
-echo "[pre-commit] Version bump detected: ${VERSION} — syncing version references..."
-
-# Sync README.md and docs/*.md (fast — no compilation)
-mvn generate-resources -q
-
-# Sync frontend/package.json (and package-lock.json if npm is available)
-if command -v npm >/dev/null 2>&1; then
-  npm --prefix frontend version "${VERSION}" --no-git-tag-version --allow-same-version --silent
-else
-  $PYTHON - "${VERSION}" <<'PYEOF'
-import json, sys
-path = 'frontend/package.json'
-with open(path) as f:
-    data = json.load(f)
-data['version'] = sys.argv[1]
-with open(path, 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-PYEOF
-fi
-
-# Re-stage all version-synced files
-git add README.md docs/
-git add frontend/package.json
+# Re-stage all version-synced files.
+git add README.md frontend/README.md docs/*.md scripts/sync-versions.sh frontend/package.json
 if [ -f frontend/package-lock.json ]; then
   git add frontend/package-lock.json
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,7 +7,7 @@ if ! git diff --cached --name-only | grep -q '^pom\.xml$'; then
 fi
 
 echo "[pre-commit] pom.xml version change detected — syncing version references..."
-./scripts/sync-versions.sh
+./scripts/sync-versions.sh --staged-pom
 
 # Re-stage all version-synced files.
 git add README.md frontend/README.md docs/*.md scripts/sync-versions.sh frontend/package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,39 +54,7 @@ jobs:
         PGPASSWORD: liftpassword
 
     - name: Verify version consistency
-      run: |
-        POM_VERSION=$(python3 -c "
-        import xml.etree.ElementTree as ET
-        tree = ET.parse('pom.xml')
-        root = tree.getroot()
-        ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
-        print(root.find('m:version', ns).text)
-        ")
-        echo "POM version: $POM_VERSION"
-        FAILED=0
-
-        if ! grep -qF "Current version: **${POM_VERSION}**" README.md; then
-          echo "ERROR: README.md version does not match pom.xml ($POM_VERSION)"
-          FAILED=1
-        fi
-
-        for f in docs/*.md; do
-          if grep -qE 'lift-simulator-[0-9]+\.[0-9]+\.[0-9]+\.jar' "$f"; then
-            if ! grep -qF "lift-simulator-${POM_VERSION}.jar" "$f"; then
-              echo "ERROR: $f contains a stale JAR version (expected $POM_VERSION)"
-              FAILED=1
-            fi
-          fi
-        done
-
-        PKG_VERSION=$(python3 -c "import json; print(json.load(open('frontend/package.json'))['version'])")
-        if [ "$PKG_VERSION" != "$POM_VERSION" ]; then
-          echo "ERROR: frontend/package.json version ($PKG_VERSION) != pom.xml ($POM_VERSION)"
-          FAILED=1
-        fi
-
-        [ $FAILED -eq 0 ] && echo "All version references are consistent."
-        exit $FAILED
+      run: ./scripts/sync-versions.sh --check
 
     - name: Build project
       run: mvn -q clean compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.57.1] - 2026-07-10
 
 ### Fixed
-- **Version synchronization tooling**: Added `scripts/sync-versions.sh` as the single hook/CI implementation for syncing the Maven version into README current-version text, README/docs/frontend JAR filename examples, and frontend package metadata. The pre-commit hook now delegates to the script, CI verifies with the script's `--check` mode, stale README JAR references were refreshed, and Maven no longer mutates tracked README/docs files during `generate-resources`. Updated package metadata for the 0.57.1 pre-MVP patch release.
+- **Version synchronization tooling**: Added `scripts/sync-versions.sh` as the single hook/CI implementation for syncing the Maven version into README current-version text, README/docs/frontend JAR filename examples, and frontend package metadata. The pre-commit hook now delegates to the script using the staged `pom.xml` blob, CI verifies with the script's `--check` mode, stale README JAR references were refreshed, and Maven no longer mutates tracked README/docs files during `generate-resources`. Updated package metadata for the 0.57.1 pre-MVP patch release.
 
 ## [0.57.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.1] - 2026-07-10
+
+### Fixed
+- **Version synchronization tooling**: Added `scripts/sync-versions.sh` as the single hook/CI implementation for syncing the Maven version into README current-version text, README/docs/frontend JAR filename examples, and frontend package metadata. The pre-commit hook now delegates to the script, CI verifies with the script's `--check` mode, stale README JAR references were refreshed, and Maven no longer mutates tracked README/docs files during `generate-resources`. Updated package metadata for the 0.57.1 pre-MVP patch release.
+
 ## [0.57.0] - 2026-07-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.0**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.1**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.54.0.jar
+java -jar target/lift-simulator-0.57.1.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.54.0.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.1.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.54.0.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.54.0.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.1.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.1.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.54.0.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.54.0.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.1.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -214,7 +214,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.54.0.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.1.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -466,6 +466,6 @@ Activate it once after cloning:
 git config core.hooksPath .githooks
 ```
 
-**What the hook does:** when it detects a version change in staged `pom.xml`, it runs `./scripts/sync-versions.sh` to read the Maven project version, update the `README.md` current-version line, rewrite every `lift-simulator-X.Y.Z.jar` reference in `README.md`, `frontend/README.md`, and `docs/*.md`, update `frontend/package.json`/`frontend/package-lock.json` with `npm version` (or the Python fallback), and re-stage the affected files before the commit is recorded. Maven compile/resource phases no longer rewrite tracked documentation files.
+**What the hook does:** when it detects a version change in staged `pom.xml`, it runs `./scripts/sync-versions.sh --staged-pom` to read the Maven project version from the staged `pom.xml` blob, update the `README.md` current-version line, rewrite every `lift-simulator-X.Y.Z.jar` reference in `README.md`, `frontend/README.md`, and `docs/*.md`, update `frontend/package.json`/`frontend/package-lock.json` with `npm version` (or the Python fallback), and re-stage the affected files before the commit is recorded. Maven compile/resource phases no longer rewrite tracked documentation files.
 
 **CI safety net:** the CI pipeline runs `./scripts/sync-versions.sh --check`, which performs the same coverage without writing files and fails the build if any README, docs, or frontend package version is out of sync with `pom.xml`, catching the rare case where the hook was bypassed with `--no-verify`.

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.0.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.1.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:
@@ -458,7 +458,7 @@ When both admin values are present, the Axios client sends an HTTP Basic `Author
 
 ## Git Hooks
 
-A pre-commit hook lives in `.githooks/pre-commit`. It fires automatically whenever `pom.xml` is staged and keeps version references in `README.md`, `docs/*.md`, and `frontend/package.json` in sync — so you never need to update them by hand.
+A pre-commit hook lives in `.githooks/pre-commit`. It fires automatically whenever `pom.xml` is staged and delegates to `scripts/sync-versions.sh`, the single implementation for repository version synchronization.
 
 Activate it once after cloning:
 
@@ -466,6 +466,6 @@ Activate it once after cloning:
 git config core.hooksPath .githooks
 ```
 
-**What the hook does:** when it detects a version change in the staged `pom.xml`, it runs `mvn generate-resources` to update `README.md` and `docs/*.md`, updates `frontend/package.json` (via `npm version` if available, otherwise Python), and re-stages all affected files before the commit is recorded.
+**What the hook does:** when it detects a version change in staged `pom.xml`, it runs `./scripts/sync-versions.sh` to read the Maven project version, update the `README.md` current-version line, rewrite every `lift-simulator-X.Y.Z.jar` reference in `README.md`, `frontend/README.md`, and `docs/*.md`, update `frontend/package.json`/`frontend/package-lock.json` with `npm version` (or the Python fallback), and re-stage the affected files before the commit is recorded. Maven compile/resource phases no longer rewrite tracked documentation files.
 
-**CI safety net:** the CI pipeline includes a version-consistency check that fails the build if any of these files are out of sync with `pom.xml`, catching the rare case where the hook was bypassed with `--no-verify`.
+**CI safety net:** the CI pipeline runs `./scripts/sync-versions.sh --check`, which performs the same coverage without writing files and fails the build if any README, docs, or frontend package version is out of sync with `pom.xml`, catching the rare case where the hook was bypassed with `--no-verify`.

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -43,7 +43,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.0.jar \
+java -cp target/lift-simulator-0.57.1.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -57,12 +57,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.0.jar \
+java -cp target/lift-simulator-0.57.1.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.0.jar \
+java -cp target/lift-simulator-0.57.1.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -106,7 +106,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.0.jar \
+java -cp target/lift-simulator-0.57.1.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -384,7 +384,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.0.jar \
+   java -cp target/lift-simulator-0.57.1.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -429,7 +429,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.0.jar \
+java -cp target/lift-simulator-0.57.1.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -521,7 +521,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.0.jar \
+java -cp target/lift-simulator-0.57.1.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -353,7 +353,7 @@ From the repository root:
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.41.5.jar
+java -jar target/lift-simulator-0.57.1.jar
 ```
 
 This command:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.0",
+      "version": "0.57.1",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.0",
+  "version": "0.57.1",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.0</version>
+    <version>0.57.1</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -168,41 +168,6 @@
                         <configuration>
                             <target>
                                 <delete dir="${project.build.outputDirectory}/db/migration" quiet="true"/>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>sync-readme-version</id>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <target>
-                                <replaceregexp
-                                    file="${project.basedir}/README.md"
-                                    match="Current version: \*\*[0-9]+\.[0-9]+\.[0-9]+\*\*"
-                                    replace="Current version: **${project.version}**"
-                                    byline="true"/>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>sync-docs-jar-version</id>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <target>
-                                <replaceregexp
-                                    match="lift-simulator-[0-9]+\.[0-9]+\.[0-9]+\.jar"
-                                    replace="lift-simulator-${project.version}.jar"
-                                    byline="true">
-                                    <fileset dir="${project.basedir}/docs">
-                                        <include name="*.md"/>
-                                    </fileset>
-                                </replaceregexp>
                             </target>
                         </configuration>
                         <goals>

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -2,12 +2,22 @@
 set -euo pipefail
 
 MODE="sync"
-if [ "${1:-}" = "--check" ]; then
-  MODE="check"
-elif [ $# -gt 0 ]; then
-  echo "Usage: $0 [--check]" >&2
-  exit 2
-fi
+POM_SOURCE="worktree"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check)
+      MODE="check"
+      ;;
+    --staged-pom)
+      POM_SOURCE="staged"
+      ;;
+    *)
+      echo "Usage: $0 [--check] [--staged-pom]" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
@@ -20,9 +30,15 @@ else
   exit 1
 fi
 
-VERSION=$("$PYTHON" - <<'PY'
-import xml.etree.ElementTree as ET
-root = ET.parse('pom.xml').getroot()
+if [ "$POM_SOURCE" = "staged" ]; then
+  POM_XML=$(git show :pom.xml)
+else
+  POM_XML=$(cat pom.xml)
+fi
+
+VERSION=$(POM_XML="$POM_XML" "$PYTHON" - <<'PY'
+import os, xml.etree.ElementTree as ET
+root = ET.fromstring(os.environ['POM_XML'])
 ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
 version = root.find('m:version', ns)
 if version is None or not version.text:

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="sync"
+if [ "${1:-}" = "--check" ]; then
+  MODE="check"
+elif [ $# -gt 0 ]; then
+  echo "Usage: $0 [--check]" >&2
+  exit 2
+fi
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+  PYTHON=python
+else
+  echo "ERROR: python3/python not found." >&2
+  exit 1
+fi
+
+VERSION=$("$PYTHON" - <<'PY'
+import xml.etree.ElementTree as ET
+root = ET.parse('pom.xml').getroot()
+ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+version = root.find('m:version', ns)
+if version is None or not version.text:
+    raise SystemExit('pom.xml project version not found')
+print(version.text)
+PY
+)
+
+FILES=(README.md frontend/README.md)
+while IFS= read -r -d '' f; do
+  FILES+=("$f")
+done < <(find docs -maxdepth 1 -type f -name '*.md' -print0 | sort -z)
+
+if [ "$MODE" = "check" ]; then
+  "$PYTHON" - "$VERSION" "${FILES[@]}" <<'PY'
+import json, re, sys
+from pathlib import Path
+version = sys.argv[1]
+files = [Path(p) for p in sys.argv[2:]]
+failed = False
+
+def fail(msg):
+    global failed
+    print(f"ERROR: {msg}", file=sys.stderr)
+    failed = True
+
+readme = Path('README.md').read_text()
+if f"Current version: **{version}**" not in readme:
+    fail(f"README.md Current version line does not match pom.xml ({version})")
+
+jar_re = re.compile(r'lift-simulator-(\d+\.\d+\.\d+)\.jar')
+for path in files:
+    text = path.read_text()
+    for match in jar_re.finditer(text):
+        if match.group(1) != version:
+            fail(f"{path} contains stale JAR version {match.group(1)} (expected {version})")
+
+pkg_version = json.loads(Path('frontend/package.json').read_text()).get('version')
+if pkg_version != version:
+    fail(f"frontend/package.json version ({pkg_version}) != pom.xml ({version})")
+
+lock = Path('frontend/package-lock.json')
+if lock.exists():
+    data = json.loads(lock.read_text())
+    if data.get('version') != version:
+        fail(f"frontend/package-lock.json root version ({data.get('version')}) != pom.xml ({version})")
+    pkg_root = data.get('packages', {}).get('', {})
+    if pkg_root.get('version') != version:
+        fail(f"frontend/package-lock.json package root version ({pkg_root.get('version')}) != pom.xml ({version})")
+
+if failed:
+    sys.exit(1)
+print(f"All version references are consistent with pom.xml ({version}).")
+PY
+  exit $?
+fi
+
+"$PYTHON" - "$VERSION" "${FILES[@]}" <<'PY'
+import re, sys
+from pathlib import Path
+version = sys.argv[1]
+for name in sys.argv[2:]:
+    path = Path(name)
+    text = path.read_text()
+    original = text
+    if name == 'README.md':
+        text = re.sub(r'Current version: \*\*\d+\.\d+\.\d+\*\*', f'Current version: **{version}**', text)
+    text = re.sub(r'lift-simulator-\d+\.\d+\.\d+\.jar', f'lift-simulator-{version}.jar', text)
+    if text != original:
+        path.write_text(text)
+PY
+
+if command -v npm >/dev/null 2>&1; then
+  npm --prefix frontend version "$VERSION" --no-git-tag-version --allow-same-version --silent >/dev/null
+else
+  "$PYTHON" - "$VERSION" <<'PY'
+import json, sys
+from pathlib import Path
+version = sys.argv[1]
+for filename in ['frontend/package.json', 'frontend/package-lock.json']:
+    path = Path(filename)
+    if not path.exists():
+        continue
+    data = json.loads(path.read_text())
+    data['version'] = version
+    if filename.endswith('package-lock.json') and 'packages' in data and '' in data['packages']:
+        data['packages']['']['version'] = version
+    path.write_text(json.dumps(data, indent=2) + '\n')
+PY
+fi
+
+echo "Version references synced to ${VERSION}."


### PR DESCRIPTION
### Motivation
- Consolidate multiple ad-hoc version sync mechanisms into a single, auditable script to avoid stale examples in docs and front-end metadata. 
- Prevent Maven build phases from mutating tracked README/docs files and close a CI blind spot that previously missed stale JAR-version examples. 
- Bump the project patch version to keep examples and package metadata consistent with the Maven `pom.xml` version.

### Description
- Added `scripts/sync-versions.sh`, a single implementation that reads the Maven project version and either updates (`sync`) or verifies (`--check`) version references in `README.md`, `frontend/README.md`, `docs/*.md`, `frontend/package.json`, and `frontend/package-lock.json`.
- Replaced pre-commit logic with a delegate that runs `./scripts/sync-versions.sh` and re-stages the affected files (`.githooks/pre-commit`).
- Replaced inline CI verification with a call to `./scripts/sync-versions.sh --check` in `.github/workflows/ci.yml` to ensure the same checks run in CI without mutating files.
- Removed the `maven-antrun-plugin` executions that rewrote tracked README/docs during the `generate-resources` phase while keeping the `clean-stale-migrations` execution.
- Bumped Maven project version from `0.57.0` to `0.57.1` and updated corresponding examples and frontend package metadata (`frontend/package.json`, `frontend/package-lock.json`, `README.md`, `docs/*`, and `CHANGELOG.md`).

### Testing
- Ran `./scripts/sync-versions.sh --check` and it succeeded, reporting all references consistent with `pom.xml`.
- Performed a negative test by temporarily changing a README JAR reference and observed `./scripts/sync-versions.sh --check` fail with an appropriate error, confirming detection of stale references.
- Ran `git diff --check` with no whitespace/index issues.
- Attempted `mvn -q compile` and `mvn -q verify`, but these were blocked by the environment/network resolving the Spring Boot parent POM (Maven Central returned HTTP 403), so full Maven build/test verification could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a511d0f6f6083259aa0851e909d2d6e)