### PR TITLE
refactor(admin): single home for simulation-run lifecycle transitions; make post-commit artefact deletion honestly best-effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.57.4] - 2026-07-11
 
 ### Changed
-- **Simulation-run lifecycle centralization**: Added a dedicated `RunLifecycleManager` as the single owner for simulation-run configuration, status transitions, progress updates, and startup recovery. `SimulationRunService` and `SimulationRunExecutionService` now delegate lifecycle writes through it, reducing drift risk between admin and async execution paths. Completed-run deletion still removes database rows before artefacts, but post-commit artefact deletion is now documented and implemented as best-effort: failures are logged with the run id and artefact path without failing an already-committed delete request. Updated API/README documentation and package metadata for the 0.57.4 pre-MVP patch release.
+- **Simulation-run lifecycle centralization**: Added a dedicated `RunLifecycleManager` as the single owner for simulation-run configuration, status transitions, progress updates, and startup recovery. `SimulationRunService` and `SimulationRunExecutionService` now delegate lifecycle writes through it, reducing drift risk between admin and async execution paths. Completed-run deletion still removes database rows before artefacts, but post-commit artefact deletion is now documented and implemented as best-effort: checked and unchecked cleanup failures are logged with the run id and artefact path without failing an already-committed delete request. Updated API/README/developer documentation and Maven/npm metadata for the 0.57.4 pre-MVP patch release.
 
 ## [0.57.3] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.4] - 2026-07-11
+
+### Changed
+- **Simulation-run lifecycle centralization**: Added a dedicated `RunLifecycleManager` as the single owner for simulation-run configuration, status transitions, progress updates, and startup recovery. `SimulationRunService` and `SimulationRunExecutionService` now delegate lifecycle writes through it, reducing drift risk between admin and async execution paths. Completed-run deletion still removes database rows before artefacts, but post-commit artefact deletion is now documented and implemented as best-effort: failures are logged with the run id and artefact path without failing an already-committed delete request. Updated API/README documentation and package metadata for the 0.57.4 pre-MVP patch release.
+
 ## [0.57.3] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.3**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.4**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.3.jar
+java -jar target/lift-simulator-0.57.4.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.3.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.4.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.3.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.3.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.3.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.3.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -166,7 +166,7 @@ mvn test
 
 The suite spans several levels:
 
-- **Unit tests** — controllers, services, and domain logic: request lifecycle transitions (`LiftRequestTest`), artefact path/download/log/result handling (`ArtefactServiceTest`), simulation execution artefact and lifecycle orchestration (`SimulationRunExecutionServiceTest`), nearest-request and directional-scan routing, door handling and cancellation (`NaiveLiftControllerTest`, `DirectionalScanLiftControllerTest`), and the tick mechanism (`SimulationEngineTest`).
+- **Unit tests** — controllers, services, and domain logic: request lifecycle transitions (`LiftRequestTest`), artefact path/download/log/result handling (`ArtefactServiceTest`), simulation-run lifecycle transitions (`RunLifecycleManagerTest`), simulation execution artefact orchestration (`SimulationRunExecutionServiceTest`), nearest-request and directional-scan routing, door handling and cancellation (`NaiveLiftControllerTest`, `DirectionalScanLiftControllerTest`), and the tick mechanism (`SimulationEngineTest`).
 - **Integration tests** — full Spring context for REST APIs and repositories, including scenario CRUD, configuration-validation, runtime configuration, simulation-launch, and health controller APIs, multi-request scenarios, dynamic request addition during movement, cancellation, and out-of-service handling (`ScenarioControllerTest`, `ConfigValidationControllerTest`, `RuntimeConfigControllerTest`, `HealthControllerTest`, `DirectionalScanIntegrationTest`, `LiftRequestLifecycleTest`). Scenario fixtures live in `src/test/resources/scenarios`, controller API fixtures live under `src/test/java/com/liftsimulator/admin/controller/fixtures`, and batch-input golden files live under `src/test/resources/batch-input`.
 - **Scenario tests** — `ControllerScenarioTest` exercises realistic multi-request routing for both controller strategies via a deterministic `ScenarioHarness`, guarding against behavioural regressions.
 - **Playwright E2E tests** — browser smoke and feature tests under `frontend/e2e` run against the React dev server (port 3000) and a live backend (port 8080). See [ADR-0014](docs/decisions/0014-playwright-e2e-testing.md).
@@ -213,7 +213,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.3.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.4.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -720,6 +720,28 @@ Cancels a running simulation run and transitions it to a terminal `CANCELLED` st
 
 ---
 
+
+##### Delete Simulation Run
+
+**Endpoint:** `DELETE /api/v1/simulation-runs/{id}`
+
+Deletes a terminal simulation-run database record. Only runs in `SUCCEEDED`, `FAILED`, or `CANCELLED` state can be deleted; `CREATED` and `RUNNING` runs return `409 Conflict`.
+
+Artefact cleanup is intentionally best-effort and runs only after the delete transaction commits, so rollback or commit failures cannot remove files for a surviving run row. If post-commit artefact deletion fails, the API response still reflects the committed database delete and the server logs a warning with the run id and artefact path for operator cleanup.
+
+**Response:** `204 No Content`
+
+**Error Response (409 Conflict):**
+```json
+{
+  "status": 409,
+  "message": "Cannot delete a simulation run in RUNNING state. Only completed runs (SUCCEEDED, FAILED, CANCELLED) can be deleted.",
+  "timestamp": "2026-01-23T10:05:30Z"
+}
+```
+
+---
+
 ##### Get Simulation Results
 
 **Endpoint:** `GET /api/v1/simulation-runs/{id}/results`

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.3.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.4.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -46,7 +46,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.3.jar \
+java -cp target/lift-simulator-0.57.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -60,12 +60,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.3.jar \
+java -cp target/lift-simulator-0.57.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.3.jar \
+java -cp target/lift-simulator-0.57.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -109,7 +109,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.3.jar \
+java -cp target/lift-simulator-0.57.4.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -387,7 +387,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.3.jar \
+   java -cp target/lift-simulator-0.57.4.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -432,7 +432,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.3.jar \
+java -cp target/lift-simulator-0.57.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -524,7 +524,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.3.jar \
+java -cp target/lift-simulator-0.57.4.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -353,7 +353,7 @@ From the repository root:
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.3.jar
+java -jar target/lift-simulator-0.57.4.jar
 ```
 
 This command:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.3",
+  "version": "0.57.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.3",
+      "version": "0.57.4",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.3",
+  "version": "0.57.4",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.3</version>
+    <version>0.57.4</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/service/ArtefactDeletionException.java
+++ b/src/main/java/com/liftsimulator/admin/service/ArtefactDeletionException.java
@@ -1,9 +1,7 @@
 package com.liftsimulator.admin.service;
 
 /**
- * Exception thrown when stored artefacts for a simulation run cannot be deleted.
- * Signals a server-side failure (e.g. file system error) during run deletion so the
- * API can surface a clear error without leaving the run in an inconsistent state.
+ * Exception thrown when stored artefacts for cascade-deleted resources cannot be deleted.
  */
 public class ArtefactDeletionException extends RuntimeException {
 

--- a/src/main/java/com/liftsimulator/admin/service/RunLifecycleManager.java
+++ b/src/main/java/com/liftsimulator/admin/service/RunLifecycleManager.java
@@ -1,0 +1,144 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Single service responsible for simulation-run lifecycle transitions.
+ */
+@Service
+@Transactional(readOnly = true)
+public class RunLifecycleManager {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RunLifecycleManager.class);
+
+    private static final String STARTUP_RECOVERY_ERROR_MESSAGE =
+            "Run was still RUNNING when the application started; marking it FAILED because no in-memory "
+                    + "executor task can survive a JVM restart.";
+
+    private final SimulationRunRepository runRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public RunLifecycleManager(SimulationRunRepository runRepository) {
+        this.runRepository = runRepository;
+    }
+
+    public SimulationRun getByIdWithDetails(Long runId) {
+        return runRepository.findByIdWithDetails(runId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Simulation run not found with id: " + runId));
+    }
+
+    @Transactional
+    public SimulationRun configureRun(Long runId, Long totalTicks, Long seed, String artefactBasePath) {
+        SimulationRun run = getByIdWithDetails(runId);
+        if (totalTicks != null) {
+            run.setTotalTicks(totalTicks);
+        }
+        if (seed != null) {
+            run.setSeed(seed);
+        }
+        if (artefactBasePath != null) {
+            run.setArtefactBasePath(artefactBasePath);
+        }
+        return runRepository.save(run);
+    }
+
+    @Transactional
+    public SimulationRun startRun(Long runId) {
+        SimulationRun run = getByIdWithDetails(runId);
+        run.start();
+        return runRepository.save(run);
+    }
+
+    @Transactional
+    public SimulationRun succeedRun(Long runId) {
+        SimulationRun run = getByIdWithDetails(runId);
+        run.succeed();
+        return runRepository.save(run);
+    }
+
+    @Transactional
+    public SimulationRun failRun(Long runId, String message) {
+        SimulationRun run = getByIdWithDetails(runId);
+        run.fail(message);
+        return runRepository.save(run);
+    }
+
+    @Transactional
+    public SimulationRun cancelRun(Long runId) {
+        SimulationRun run = getByIdWithDetails(runId);
+        run.cancel();
+        return runRepository.save(run);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public SimulationRun updateProgress(Long runId, Long currentTick) {
+        int updated = runRepository.updateCurrentTick(runId, currentTick);
+        if (updated == 0) {
+            throw new ResourceNotFoundException("Simulation run not found with id: " + runId);
+        }
+        entityManager.clear();
+        return getByIdWithDetails(runId);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int markRunningRunFailedSafely(Long runId, String message, IllegalStateException transitionFailure) {
+        int updated = runRepository.markRunningRunFailed(runId, message, OffsetDateTime.now());
+        if (updated > 0) {
+            LOGGER.warn(
+                    "Recovered run {} by marking RUNNING run as FAILED after lifecycle transition failure",
+                    runId,
+                    transitionFailure
+            );
+            return updated;
+        }
+
+        try {
+            SimulationRun run = getByIdWithDetails(runId);
+            LOGGER.warn(
+                    "Run {} was not marked FAILED because its current status is {}; preserving existing lifecycle state",
+                    runId,
+                    run.getStatus(),
+                    transitionFailure
+            );
+        } catch (Exception lookupFailure) {
+            LOGGER.error("Failed to inspect run {} after failure transition error", runId, lookupFailure);
+        }
+        return updated;
+    }
+
+    @Transactional
+    public StartupRecoveryResult recoverOrphanedRunsOnStartup() {
+        OffsetDateTime recoveredAt = OffsetDateTime.now();
+        int failedRunningRuns = runRepository.failOrphanedRunningRuns(
+                STARTUP_RECOVERY_ERROR_MESSAGE,
+                recoveredAt
+        );
+        int cancelledCreatedRuns = runRepository.cancelOrphanedCreatedRuns(recoveredAt);
+
+        if (failedRunningRuns > 0 || cancelledCreatedRuns > 0) {
+            LOGGER.warn(
+                    "Recovered orphaned simulation runs on startup: {} RUNNING marked FAILED, "
+                            + "{} CREATED marked CANCELLED",
+                    failedRunningRuns,
+                    cancelledCreatedRuns
+            );
+        }
+
+        return new StartupRecoveryResult(failedRunningRuns, cancelledCreatedRuns);
+    }
+
+    public record StartupRecoveryResult(int failedRunningRuns, int cancelledCreatedRuns) {
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -6,7 +6,6 @@ import com.liftsimulator.admin.dto.PassengerFlowDTO;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
 import com.liftsimulator.admin.dto.ScenarioValidationResponse;
 import com.liftsimulator.admin.entity.SimulationRun;
-import com.liftsimulator.admin.repository.SimulationRunRepository;
 import com.liftsimulator.admin.service.metrics.RunMetrics;
 import com.liftsimulator.domain.Direction;
 import com.liftsimulator.domain.LiftRequest;
@@ -42,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.PreDestroy;
 
@@ -59,7 +57,7 @@ public class SimulationRunExecutionService {
     private static final String LOG_FILE_NAME = "run.log";
     private static final String RESULTS_FILE_NAME = "results.json";
 
-    private final SimulationRunRepository runRepository;
+    private final RunLifecycleManager lifecycleManager;
     private final ConfigValidationService configValidationService;
     private final ScenarioValidationService scenarioValidationService;
     private final BatchInputGenerator batchInputGenerator;
@@ -73,14 +71,14 @@ public class SimulationRunExecutionService {
         justification = "Injected dependencies and configuration managed by Spring."
     )
     public SimulationRunExecutionService(
-            SimulationRunRepository runRepository,
+            RunLifecycleManager lifecycleManager,
             ConfigValidationService configValidationService,
             ScenarioValidationService scenarioValidationService,
             BatchInputGenerator batchInputGenerator,
             ObjectMapper objectMapper,
             @Value("${simulation.execution.max-concurrent-runs:4}") int maxConcurrentRuns,
             @Value("${simulation.execution.queue-capacity:20}") int queueCapacity) {
-        this.runRepository = runRepository;
+        this.lifecycleManager = lifecycleManager;
         this.configValidationService = configValidationService;
         this.scenarioValidationService = scenarioValidationService;
         this.batchInputGenerator = batchInputGenerator;
@@ -102,7 +100,6 @@ public class SimulationRunExecutionService {
      *
      * @param runId the run id to execute
      */
-    @Transactional
     public void submitRunForExecution(Long runId) {
         SimulationRun run = getRunById(runId);
         String configJson = run.getVersion().getConfig();
@@ -119,9 +116,8 @@ public class SimulationRunExecutionService {
      * @param runId the run id
      * @return the updated run
      */
-    @Transactional
     public SimulationRun cancelRun(Long runId) {
-        SimulationRun run = cancelRunStatus(runId);
+        SimulationRun run = lifecycleManager.cancelRun(runId);
         CancellationToken token = cancellationTokens.computeIfAbsent(runId, id -> new CancellationToken());
         token.cancel();
         FutureTask<?> future = runningTasks.get(runId);
@@ -217,7 +213,7 @@ public class SimulationRunExecutionService {
 
             writeInputFiles(request, runDir, logWriter);
 
-            configureRun(
+            lifecycleManager.configureRun(
                 request.runId(),
                 scenario.durationTicks().longValue(),
                 scenario.seed() != null ? scenario.seed().longValue() : null,
@@ -233,10 +229,10 @@ public class SimulationRunExecutionService {
                 return;
             }
             if (currentRun.getStatus() != SimulationRun.RunStatus.RUNNING) {
-                startRun(request.runId());
+                lifecycleManager.startRun(request.runId());
             }
             started = true;
-            updateProgress(request.runId(), 0L);
+            lifecycleManager.updateProgress(request.runId(), 0L);
             log(logWriter, "Simulation started for run " + request.runId());
 
             RunMetrics metrics;
@@ -255,7 +251,7 @@ public class SimulationRunExecutionService {
             }
             log(logWriter, "Simulation succeeded for run " + request.runId());
             writeResults(request.runId(), runDir, config, scenario, metrics, "SUCCEEDED", null);
-            succeedRun(request.runId());
+            lifecycleManager.succeedRun(request.runId());
         } catch (IOException | RuntimeException ex) {
             String errorMessage = safeMessage(ex);
             logger.error("Simulation run {} failed", request.runId(), ex);
@@ -333,11 +329,11 @@ public class SimulationRunExecutionService {
 
             long progressTick = tick + 1L;
             if (tick % PROGRESS_UPDATE_INTERVAL == 0) {
-                updateProgress(runId, progressTick);
+                lifecycleManager.updateProgress(runId, progressTick);
             }
         }
 
-        updateProgress(runId, (long) scenario.durationTicks());
+        lifecycleManager.updateProgress(runId, (long) scenario.durationTicks());
         log(logWriter, "Simulation completed at tick " + engine.getCurrentTick());
         metrics.recordTerminalRequests(engine.getCurrentTick());
         return metrics;
@@ -357,54 +353,7 @@ public class SimulationRunExecutionService {
     }
 
     private SimulationRun getRunById(Long runId) {
-        return runRepository.findByIdWithDetails(runId)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "Simulation run not found with id: " + runId));
-    }
-
-    private SimulationRun configureRun(Long runId, Long totalTicks, Long seed, String artefactBasePath) {
-        SimulationRun run = getRunById(runId);
-        if (totalTicks != null) {
-            run.setTotalTicks(totalTicks);
-        }
-        if (seed != null) {
-            run.setSeed(seed);
-        }
-        if (artefactBasePath != null) {
-            run.setArtefactBasePath(artefactBasePath);
-        }
-        return runRepository.save(run);
-    }
-
-    private SimulationRun startRun(Long runId) {
-        SimulationRun run = getRunById(runId);
-        run.start();
-        return runRepository.save(run);
-    }
-
-    private SimulationRun succeedRun(Long runId) {
-        SimulationRun run = getRunById(runId);
-        run.succeed();
-        return runRepository.save(run);
-    }
-
-    private SimulationRun failRun(Long runId, String message) {
-        SimulationRun run = getRunById(runId);
-        run.fail(message);
-        return runRepository.save(run);
-    }
-
-    private SimulationRun cancelRunStatus(Long runId) {
-        SimulationRun run = getRunById(runId);
-        run.cancel();
-        return runRepository.save(run);
-    }
-
-    private void updateProgress(Long runId, Long currentTick) {
-        int updated = runRepository.updateCurrentTick(runId, currentTick);
-        if (updated == 0) {
-            throw new ResourceNotFoundException("Simulation run not found with id: " + runId);
-        }
+        return lifecycleManager.getByIdWithDetails(runId);
     }
 
     private void writeInputFiles(RunExecutionRequest request, Path runDir, BufferedWriter logWriter) throws IOException {
@@ -441,37 +390,13 @@ public class SimulationRunExecutionService {
     private void failRunWithMessage(Long runId, String message, boolean started) {
         try {
             if (!started) {
-                startRun(runId);
+                lifecycleManager.startRun(runId);
             }
-            failRun(runId, message);
+            lifecycleManager.failRun(runId, message);
         } catch (IllegalStateException ex) {
-            markRunningRunFailedSafely(runId, message, ex);
+            lifecycleManager.markRunningRunFailedSafely(runId, message, ex);
         } catch (Exception ex) {
             logger.error("Failed to mark run {} as failed", runId, ex);
-        }
-    }
-
-    private void markRunningRunFailedSafely(Long runId, String message, IllegalStateException transitionFailure) {
-        int updated = runRepository.markRunningRunFailed(runId, message, OffsetDateTime.now());
-        if (updated > 0) {
-            logger.warn(
-                    "Recovered run {} by marking RUNNING run as FAILED after lifecycle transition failure",
-                    runId,
-                    transitionFailure
-            );
-            return;
-        }
-
-        try {
-            SimulationRun run = getRunById(runId);
-            logger.warn(
-                    "Run {} was not marked FAILED because its current status is {}; preserving existing lifecycle state",
-                    runId,
-                    run.getStatus(),
-                    transitionFailure
-            );
-        } catch (Exception lookupFailure) {
-            logger.error("Failed to inspect run {} after failure transition error", runId, lookupFailure);
         }
     }
 
@@ -486,7 +411,7 @@ public class SimulationRunExecutionService {
             if (run.getStatus() == SimulationRun.RunStatus.CANCELLED) {
                 return;
             }
-            cancelRunStatus(runId);
+            lifecycleManager.cancelRun(runId);
         } catch (Exception ex) {
             logger.error("Failed to mark run {} as cancelled", runId, ex);
         }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -519,7 +519,7 @@ public class SimulationRunService {
     private void deleteArtefacts(SimulationRun run, Long id) {
         try {
             artefactService.deleteArtefacts(run);
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOGGER.warn(
                     "Best-effort artefact deletion failed for simulation run {} at {}",
                     id,

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunService.java
@@ -12,8 +12,6 @@ import com.liftsimulator.admin.repository.LiftSystemVersionRepository;
 import com.liftsimulator.admin.repository.ScenarioRepository;
 import com.liftsimulator.admin.repository.SimulationRunRepository;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +20,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -31,7 +28,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -48,10 +44,6 @@ public class SimulationRunService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SimulationRunService.class);
 
-    private static final String STARTUP_RECOVERY_ERROR_MESSAGE =
-            "Run was still RUNNING when the application started; marking it FAILED because no in-memory "
-                    + "executor task can survive a JVM restart.";
-
     private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
             "createdAt",
             "startedAt",
@@ -60,9 +52,6 @@ public class SimulationRunService {
             "id"
     );
 
-    @PersistenceContext
-    private EntityManager entityManager;
-
     private final SimulationRunRepository runRepository;
     private final LiftSystemRepository liftSystemRepository;
     private final LiftSystemVersionRepository versionRepository;
@@ -70,6 +59,7 @@ public class SimulationRunService {
     private final String artefactsBasePath;
     private final SimulationRunExecutionService executionService;
     private final ArtefactService artefactService;
+    private final RunLifecycleManager lifecycleManager;
     private final ObjectMapper objectMapper;
 
     @SuppressFBWarnings(
@@ -83,6 +73,7 @@ public class SimulationRunService {
             ScenarioRepository scenarioRepository,
             SimulationRunExecutionService executionService,
             ArtefactService artefactService,
+            RunLifecycleManager lifecycleManager,
             ObjectMapper objectMapper,
             @Value("${simulation.artefacts.base-path:./simulation-runs}") String artefactsBasePath) {
         this.runRepository = runRepository;
@@ -91,6 +82,7 @@ public class SimulationRunService {
         this.scenarioRepository = scenarioRepository;
         this.executionService = executionService;
         this.artefactService = artefactService;
+        this.lifecycleManager = lifecycleManager;
         this.objectMapper = objectMapper;
         this.artefactsBasePath = artefactsBasePath;
     }
@@ -178,12 +170,11 @@ public class SimulationRunService {
         run.setArtefactBasePath(artefactPath);
 
         // Save configuration
-        run = runRepository.save(run);
+        run = lifecycleManager.configureRun(run.getId(), totalTicks, runSeed, artefactPath);
 
         // Start the run before submitting for async execution
         // This ensures the API returns RUNNING status immediately
-        run.start();
-        run = runRepository.save(run);
+        run = lifecycleManager.startRun(run.getId());
 
         // Submit the run for execution only after the surrounding transaction commits.
         // Otherwise, the async executor can start immediately and attempt to read the
@@ -355,7 +346,7 @@ public class SimulationRunService {
      * @throws ResourceNotFoundException if the run is not found
      */
     public SimulationRun getRunById(Long id) {
-        return findRunByIdWithDetails(id);
+        return lifecycleManager.getByIdWithDetails(id);
     }
 
     /**
@@ -366,13 +357,7 @@ public class SimulationRunService {
      * @throws ResourceNotFoundException if the run is not found
      */
     public SimulationRunResponse getRunResponseById(Long id) {
-        return SimulationRunResponse.fromEntity(findRunByIdWithDetails(id));
-    }
-
-    private SimulationRun findRunByIdWithDetails(Long id) {
-        return runRepository.findByIdWithDetails(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "Simulation run not found with id: " + id));
+        return SimulationRunResponse.fromEntity(lifecycleManager.getByIdWithDetails(id));
     }
 
     /**
@@ -407,159 +392,87 @@ public class SimulationRunService {
 
     /**
      * Start a simulation run.
-     * Transitions from CREATED to RUNNING.
      *
      * @param id the run id
      * @return the updated run
-     * @throws ResourceNotFoundException if the run is not found
-     * @throws IllegalStateException if the run is not in CREATED state
      */
     @Transactional
     public SimulationRun startRun(Long id) {
-        SimulationRun run = getRunById(id);
-        run.start();
-        return runRepository.save(run);
+        return lifecycleManager.startRun(id);
     }
 
     /**
      * Mark a simulation run as succeeded.
-     * Transitions from RUNNING to SUCCEEDED.
      *
      * @param id the run id
      * @return the updated run
-     * @throws ResourceNotFoundException if the run is not found
-     * @throws IllegalStateException if the run is not in RUNNING state
      */
     @Transactional
     public SimulationRun succeedRun(Long id) {
-        SimulationRun run = getRunById(id);
-        run.succeed();
-        return runRepository.save(run);
+        return lifecycleManager.succeedRun(id);
     }
 
     /**
      * Mark a simulation run as failed.
-     * Transitions from RUNNING to FAILED.
      *
      * @param id the run id
      * @param errorMessage the error message describing the failure
      * @return the updated run
-     * @throws ResourceNotFoundException if the run is not found
-     * @throws IllegalStateException if the run is not in RUNNING state
      */
     @Transactional
     public SimulationRun failRun(Long id, String errorMessage) {
-        SimulationRun run = getRunById(id);
-        run.fail(errorMessage);
-        return runRepository.save(run);
+        return lifecycleManager.failRun(id, errorMessage);
     }
 
     /**
      * Cancel a simulation run.
-     * Can transition from CREATED or RUNNING to CANCELLED.
      *
      * @param id the run id
      * @return the updated run
-     * @throws ResourceNotFoundException if the run is not found
-     * @throws IllegalStateException if the run is not in CREATED or RUNNING state
      */
     @Transactional
     public SimulationRun cancelRun(Long id) {
-        SimulationRun run = getRunById(id);
-        run.cancel();
-        return runRepository.save(run);
+        return lifecycleManager.cancelRun(id);
     }
 
     /**
      * Update the progress of a running simulation.
-     * Uses REQUIRES_NEW propagation to ensure a fresh transaction is created,
-     * which is important when called from async threads. Uses a targeted UPDATE
-     * query to avoid overwriting concurrent status changes (e.g., cancel/fail/succeed).
      *
      * @param id the run id
      * @param currentTick the current tick number
      * @return the updated run
-     * @throws ResourceNotFoundException if the run is not found
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public SimulationRun updateProgress(Long id, Long currentTick) {
-        int updated = runRepository.updateCurrentTick(id, currentTick);
-        if (updated == 0) {
-            throw new ResourceNotFoundException("Simulation run not found with id: " + id);
-        }
-        // Clear the persistence context to ensure fresh read from database
-        entityManager.clear();
-        // Retrieve the updated entity from database
-        SimulationRun run = getRunById(id);
-        return run;
+        return lifecycleManager.updateProgress(id, currentTick);
     }
 
     /**
      * Set configuration for a run before starting.
-     * Only updates non-null values, preserving existing configuration.
      *
      * @param id the run id
      * @param totalTicks total number of ticks for the simulation (null to keep existing)
      * @param seed random seed for reproducibility (null to keep existing)
      * @param artefactBasePath base path for output artefacts (null to keep existing)
      * @return the updated run
-     * @throws ResourceNotFoundException if the run is not found
      */
     @Transactional
     public SimulationRun configureRun(Long id, Long totalTicks, Long seed, String artefactBasePath) {
-        SimulationRun run = getRunById(id);
-        if (totalTicks != null) {
-            run.setTotalTicks(totalTicks);
-        }
-        if (seed != null) {
-            run.setSeed(seed);
-        }
-        if (artefactBasePath != null) {
-            run.setArtefactBasePath(artefactBasePath);
-        }
-        return runRepository.save(run);
+        return lifecycleManager.configureRun(id, totalTicks, seed, artefactBasePath);
     }
 
     /**
      * Reconciles non-terminal runs that cannot have a live executor task after application startup.
-     * RUNNING runs are marked FAILED because their in-memory worker was lost with the previous JVM,
-     * while never-submitted CREATED runs are marked CANCELLED so they can be cleaned up.
      *
      * @return counts of recovered RUNNING and CREATED runs
      */
     @Transactional
-    public StartupRecoveryResult recoverOrphanedRunsOnStartup() {
-        OffsetDateTime recoveredAt = OffsetDateTime.now();
-        int failedRunningRuns = runRepository.failOrphanedRunningRuns(
-                STARTUP_RECOVERY_ERROR_MESSAGE,
-                recoveredAt
-        );
-        int cancelledCreatedRuns = runRepository.cancelOrphanedCreatedRuns(recoveredAt);
-
-        if (failedRunningRuns > 0 || cancelledCreatedRuns > 0) {
-            LOGGER.warn(
-                    "Recovered orphaned simulation runs on startup: {} RUNNING marked FAILED, "
-                            + "{} CREATED marked CANCELLED",
-                    failedRunningRuns,
-                    cancelledCreatedRuns
-            );
-        }
-
-        return new StartupRecoveryResult(failedRunningRuns, cancelledCreatedRuns);
-    }
-
-    /**
-     * Result counts for startup reconciliation of orphaned simulation runs.
-     *
-     * @param failedRunningRuns number of RUNNING rows marked FAILED
-     * @param cancelledCreatedRuns number of CREATED rows marked CANCELLED
-     */
-    public record StartupRecoveryResult(int failedRunningRuns, int cancelledCreatedRuns) {
+    public RunLifecycleManager.StartupRecoveryResult recoverOrphanedRunsOnStartup() {
+        return lifecycleManager.recoverOrphanedRunsOnStartup();
     }
 
     /**
      * Delete a completed simulation run, removing both its database record and any
-     * stored artefact files.
+     * stored artefact files on a best-effort basis.
      *
      * <p>Only runs in a terminal state (SUCCEEDED, FAILED, CANCELLED) may be deleted;
      * attempting to delete an in-progress run (CREATED or RUNNING) fails fast so that
@@ -567,16 +480,17 @@ public class SimulationRunService {
      *
      * <p>The database record is deleted first, and artefacts are removed only after
      * the surrounding transaction commits. This prevents a rollback or commit
-     * failure from leaving a surviving run row with permanently deleted files.</p>
+     * failure from leaving a surviving run row with permanently deleted files.
+     * Post-commit artefact deletion failures are logged and do not fail the
+     * already-committed delete request.</p>
      *
      * @param id the run id
      * @throws ResourceNotFoundException if the run is not found
      * @throws IllegalStateException if the run is not in a terminal state
-     * @throws ArtefactDeletionException if the stored artefacts cannot be removed
      */
     @Transactional
     public void deleteRun(Long id) {
-        SimulationRun run = getRunById(id);
+        SimulationRun run = lifecycleManager.getByIdWithDetails(id);
         RunStatus status = run.getStatus();
         if (status != RunStatus.SUCCEEDED && status != RunStatus.FAILED && status != RunStatus.CANCELLED) {
             throw new IllegalStateException(
@@ -606,8 +520,12 @@ public class SimulationRunService {
         try {
             artefactService.deleteArtefacts(run);
         } catch (IOException e) {
-            throw new ArtefactDeletionException(
-                    "Failed to delete artefacts for simulation run " + id + ": " + e.getMessage(), e);
+            LOGGER.warn(
+                    "Best-effort artefact deletion failed for simulation run {} at {}",
+                    id,
+                    run.getArtefactBasePath(),
+                    e
+            );
         }
     }
 }

--- a/src/test/java/com/liftsimulator/admin/service/RunLifecycleManagerTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/RunLifecycleManagerTest.java
@@ -1,0 +1,79 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.admin.entity.LiftSystem;
+import com.liftsimulator.admin.entity.LiftSystemVersion;
+import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.repository.SimulationRunRepository;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RunLifecycleManagerTest {
+
+    @Mock
+    private SimulationRunRepository runRepository;
+
+    @Mock
+    private EntityManager entityManager;
+
+    private RunLifecycleManager lifecycleManager;
+    private SimulationRun run;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        lifecycleManager = new RunLifecycleManager(runRepository);
+        java.lang.reflect.Field entityManagerField = RunLifecycleManager.class.getDeclaredField("entityManager");
+        entityManagerField.setAccessible(true);
+        entityManagerField.set(lifecycleManager, entityManager);
+
+        LiftSystem liftSystem = new LiftSystem("test-system", "Test System", "Test system");
+        liftSystem.setId(1L);
+        LiftSystemVersion version = new LiftSystemVersion();
+        version.setId(2L);
+        version.setLiftSystem(liftSystem);
+        run = new SimulationRun(liftSystem, version);
+        run.setId(3L);
+    }
+
+    @Test
+    void startRunOwnsCreatedToRunningTransition() {
+        when(runRepository.findByIdWithDetails(3L)).thenReturn(Optional.of(run));
+        when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        SimulationRun result = lifecycleManager.startRun(3L);
+
+        assertEquals(SimulationRun.RunStatus.RUNNING, result.getStatus());
+        verify(runRepository).save(run);
+    }
+
+    @Test
+    void updateProgressUsesTargetedUpdateAndReloads() {
+        run.start();
+        run.setCurrentTick(25L);
+        when(runRepository.updateCurrentTick(3L, 25L)).thenReturn(1);
+        when(runRepository.findByIdWithDetails(3L)).thenReturn(Optional.of(run));
+
+        SimulationRun result = lifecycleManager.updateProgress(3L, 25L);
+
+        assertEquals(25L, result.getCurrentTick());
+        verify(entityManager).clear();
+    }
+
+    @Test
+    void missingRunThrowsResourceNotFound() {
+        when(runRepository.findByIdWithDetails(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> lifecycleManager.getByIdWithDetails(99L));
+    }
+}

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -95,6 +95,9 @@ public class SimulationRunExecutionServiceTest {
     private SimulationRunRepository runRepository;
 
     @Mock
+    private RunLifecycleManager lifecycleManager;
+
+    @Mock
     private ConfigValidationService configValidationService;
 
     @Mock
@@ -112,7 +115,7 @@ public class SimulationRunExecutionServiceTest {
     @BeforeEach
     public void setUp() {
         executionService = new SimulationRunExecutionService(
-                runRepository,
+                lifecycleManager,
                 configValidationService,
                 scenarioValidationService,
                 batchInputGenerator,
@@ -125,20 +128,6 @@ public class SimulationRunExecutionServiceTest {
     @AfterEach
     public void tearDown() {
         executionService.shutdownExecutor();
-    }
-
-    @Test
-    public void testUpdateProgressUsesRepositoryDirectlyWithoutReloadingRun() throws Exception {
-        when(runRepository.updateCurrentTick(1L, 500L)).thenReturn(1);
-
-        Method updateProgress = SimulationRunExecutionService.class.getDeclaredMethod(
-                "updateProgress", Long.class, Long.class);
-        updateProgress.setAccessible(true);
-        updateProgress.invoke(executionService, 1L, 500L);
-
-        verify(runRepository).updateCurrentTick(1L, 500L);
-        verify(runRepository, never()).findById(1L);
-        verify(runRepository, never()).findByIdWithDetails(1L);
     }
 
     @Test
@@ -311,16 +300,16 @@ public class SimulationRunExecutionServiceTest {
         SimulationRun run = new SimulationRun();
         run.setId(9L);
         run.setStatus(SimulationRun.RunStatus.RUNNING);
-        when(runRepository.findByIdWithDetails(9L)).thenReturn(Optional.of(run));
-        when(runRepository.save(any(SimulationRun.class))).thenThrow(new IllegalStateException("stale state"));
-        when(runRepository.markRunningRunFailed(anyLong(), any(String.class), any())).thenReturn(1);
+        when(lifecycleManager.getByIdWithDetails(9L)).thenReturn(run);
+        when(lifecycleManager.failRun(9L, "boom")).thenThrow(new IllegalStateException("stale state"));
+
 
         Method failRunWithMessage = SimulationRunExecutionService.class.getDeclaredMethod(
                 "failRunWithMessage", Long.class, String.class, boolean.class);
         failRunWithMessage.setAccessible(true);
         failRunWithMessage.invoke(executionService, 9L, "boom", true);
 
-        verify(runRepository).markRunningRunFailed(anyLong(), any(String.class), any());
+        verify(lifecycleManager).markRunningRunFailedSafely(anyLong(), any(String.class), any());
     }
 
     @Test
@@ -328,7 +317,7 @@ public class SimulationRunExecutionServiceTest {
         // Pool=1, queue=1: one thread running, one slot queued.
         // Cancelling the queued run should free the slot immediately so a new submission succeeds.
         SimulationRunExecutionService tightService = new SimulationRunExecutionService(
-                runRepository,
+                lifecycleManager,
                 configValidationService,
                 scenarioValidationService,
                 batchInputGenerator,
@@ -355,8 +344,8 @@ public class SimulationRunExecutionServiceTest {
             Files.createDirectories(runDir);
             SimulationRun queuedRun = runWithArtefactDirectory(201L, runDir, SHORT_SCENARIO);
             AtomicReference<SimulationRun> storedQueued = new AtomicReference<>(queuedRun);
-            lenient().when(runRepository.findById(201L)).thenAnswer(inv -> Optional.of(storedQueued.get()));
-            lenient().when(runRepository.findByIdWithDetails(201L)).thenAnswer(inv -> Optional.of(storedQueued.get()));
+            lenient().when(runRepository.findById(201L)).thenAnswer(inv -> storedQueued.get());
+            lenient().when(lifecycleManager.getByIdWithDetails(201L)).thenAnswer(inv -> storedQueued.get());
             lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> {
                 SimulationRun saved = inv.getArgument(0);
                 if (Long.valueOf(201L).equals(saved.getId())) storedQueued.set(saved);
@@ -388,7 +377,7 @@ public class SimulationRunExecutionServiceTest {
     public void submissionsExceedingPoolPlusQueueAreRejectedWithFailedStatus() throws Exception {
         // Pool size=2, queue=10 → capacity=12. Submit 13 runs; the 13th must be rejected cleanly.
         SimulationRunExecutionService tightService = new SimulationRunExecutionService(
-                runRepository,
+                lifecycleManager,
                 configValidationService,
                 scenarioValidationService,
                 batchInputGenerator,
@@ -425,16 +414,16 @@ public class SimulationRunExecutionServiceTest {
             blocker.setStatus(SimulationRun.RunStatus.CREATED);
             blocker.setLiftSystem(liftSystem);
             blocker.setVersion(version);
-            lenient().when(runRepository.findById((long) id)).thenReturn(Optional.of(blocker));
-            lenient().when(runRepository.findByIdWithDetails((long) id)).thenReturn(Optional.of(blocker));
+            lenient().when(runRepository.findById((long) id)).thenReturn(blocker);
+            lenient().when(lifecycleManager.getByIdWithDetails((long) id)).thenReturn(blocker);
             lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> inv.getArgument(0));
-            lenient().when(runRepository.updateCurrentTick(anyLong(), anyLong())).thenReturn(1);
+
         }
 
         // Use a scenario that blocks mid-way via the CountDownLatch approach is complex;
         // instead we just verify the 3rd submission fails the run immediately.
-        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
-        lenient().when(runRepository.findByIdWithDetails((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
+        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(overCapacityRun);
+        lenient().when(lifecycleManager.getByIdWithDetails((long) overCapacityRunId)).thenReturn(overCapacityRun);
         lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> {
             SimulationRun saved = inv.getArgument(0);
             if (saved.getId() == overCapacityRunId) {
@@ -460,8 +449,8 @@ public class SimulationRunExecutionServiceTest {
         tpe.submit(() -> { try { latch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); } });
 
         // Now submit the overCapacity run — executor is full, should be rejected cleanly
-        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
-        lenient().when(runRepository.findByIdWithDetails((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
+        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(overCapacityRun);
+        lenient().when(lifecycleManager.getByIdWithDetails((long) overCapacityRunId)).thenReturn(overCapacityRun);
 
         Scenario scenario = new Scenario("s", SHORT_SCENARIO, version);
         overCapacityRun.setScenario(scenario);
@@ -627,16 +616,42 @@ public class SimulationRunExecutionServiceTest {
 
     private AtomicReference<SimulationRun> prepareRepository(SimulationRun run) {
         AtomicReference<SimulationRun> storedRun = new AtomicReference<>(run);
-        lenient().when(runRepository.findById(run.getId())).thenAnswer(invocation -> Optional.of(storedRun.get()));
-        lenient().when(runRepository.findByIdWithDetails(run.getId())).thenAnswer(invocation -> Optional.of(storedRun.get()));
+        lenient().when(runRepository.findById(run.getId())).thenAnswer(invocation -> storedRun.get());
+        lenient().when(lifecycleManager.getByIdWithDetails(run.getId())).thenAnswer(invocation -> storedRun.get());
         lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
             SimulationRun savedRun = invocation.getArgument(0);
             storedRun.set(savedRun);
             return savedRun;
         });
-        lenient().when(runRepository.updateCurrentTick(anyLong(), anyLong())).thenAnswer(invocation -> {
+        lenient().when(lifecycleManager.updateProgress(anyLong(), anyLong())).thenAnswer(invocation -> {
             storedRun.get().setCurrentTick(invocation.getArgument(1));
-            return 1;
+            return storedRun.get();
+        });
+        lenient().when(lifecycleManager.configureRun(anyLong(), any(), any(), any())).thenAnswer(invocation -> {
+            SimulationRun current = storedRun.get();
+            Long totalTicks = invocation.getArgument(1);
+            Long seed = invocation.getArgument(2);
+            String artefactBasePath = invocation.getArgument(3);
+            if (totalTicks != null) current.setTotalTicks(totalTicks);
+            if (seed != null) current.setSeed(seed);
+            if (artefactBasePath != null) current.setArtefactBasePath(artefactBasePath);
+            return current;
+        });
+        lenient().when(lifecycleManager.startRun(anyLong())).thenAnswer(invocation -> {
+            storedRun.get().start();
+            return storedRun.get();
+        });
+        lenient().when(lifecycleManager.succeedRun(anyLong())).thenAnswer(invocation -> {
+            storedRun.get().succeed();
+            return storedRun.get();
+        });
+        lenient().when(lifecycleManager.failRun(anyLong(), any())).thenAnswer(invocation -> {
+            storedRun.get().fail(invocation.getArgument(1));
+            return storedRun.get();
+        });
+        lenient().when(lifecycleManager.cancelRun(anyLong())).thenAnswer(invocation -> {
+            storedRun.get().cancel();
+            return storedRun.get();
         });
         return storedRun;
     }

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -414,7 +414,7 @@ public class SimulationRunExecutionServiceTest {
             blocker.setStatus(SimulationRun.RunStatus.CREATED);
             blocker.setLiftSystem(liftSystem);
             blocker.setVersion(version);
-            lenient().when(runRepository.findById((long) id)).thenReturn(blocker);
+            lenient().when(runRepository.findById((long) id)).thenReturn(Optional.of(blocker));
             lenient().when(lifecycleManager.getByIdWithDetails((long) id)).thenReturn(blocker);
             lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -422,7 +422,7 @@ public class SimulationRunExecutionServiceTest {
 
         // Use a scenario that blocks mid-way via the CountDownLatch approach is complex;
         // instead we just verify the 3rd submission fails the run immediately.
-        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(overCapacityRun);
+        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
         lenient().when(lifecycleManager.getByIdWithDetails((long) overCapacityRunId)).thenReturn(overCapacityRun);
         lenient().when(runRepository.save(any(SimulationRun.class))).thenAnswer(inv -> {
             SimulationRun saved = inv.getArgument(0);
@@ -449,7 +449,7 @@ public class SimulationRunExecutionServiceTest {
         tpe.submit(() -> { try { latch.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); } });
 
         // Now submit the overCapacity run — executor is full, should be rejected cleanly
-        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(overCapacityRun);
+        lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
         lenient().when(lifecycleManager.getByIdWithDetails((long) overCapacityRunId)).thenReturn(overCapacityRun);
 
         Scenario scenario = new Scenario("s", SHORT_SCENARIO, version);

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunExecutionServiceTest.java
@@ -300,9 +300,7 @@ public class SimulationRunExecutionServiceTest {
         SimulationRun run = new SimulationRun();
         run.setId(9L);
         run.setStatus(SimulationRun.RunStatus.RUNNING);
-        when(lifecycleManager.getByIdWithDetails(9L)).thenReturn(run);
         when(lifecycleManager.failRun(9L, "boom")).thenThrow(new IllegalStateException("stale state"));
-
 
         Method failRunWithMessage = SimulationRunExecutionService.class.getDeclaredMethod(
                 "failRunWithMessage", Long.class, String.class, boolean.class);
@@ -451,6 +449,16 @@ public class SimulationRunExecutionServiceTest {
         // Now submit the overCapacity run — executor is full, should be rejected cleanly
         lenient().when(runRepository.findById((long) overCapacityRunId)).thenReturn(Optional.of(overCapacityRun));
         lenient().when(lifecycleManager.getByIdWithDetails((long) overCapacityRunId)).thenReturn(overCapacityRun);
+        lenient().when(lifecycleManager.startRun((long) overCapacityRunId)).thenAnswer(inv -> {
+            overCapacityRun.start();
+            return overCapacityRun;
+        });
+        lenient().when(lifecycleManager.failRun((long) overCapacityRunId, "Simulation queue is full; run rejected."))
+                .thenAnswer(inv -> {
+                    overCapacityRun.fail(inv.getArgument(1));
+                    storedOverCapacity.set(overCapacityRun);
+                    return overCapacityRun;
+                });
 
         Scenario scenario = new Scenario("s", SHORT_SCENARIO, version);
         overCapacityRun.setScenario(scenario);

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -216,13 +216,16 @@ public class SimulationRunServiceTest {
     public void testCreateAndStartRun_ConfiguresRunStartsAndSubmitsExecution() throws Exception {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
         when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
+        java.util.concurrent.atomic.AtomicReference<SimulationRun> savedRunRef = new java.util.concurrent.atomic.AtomicReference<>();
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
             SimulationRun savedRun = invocation.getArgument(0);
             if (savedRun.getId() == null) {
                 savedRun.setId(42L);
             }
+            savedRunRef.set(savedRun);
             return savedRun;
         });
+        when(runRepository.findByIdWithDetails(42L)).thenAnswer(invocation -> Optional.of(savedRunRef.get()));
 
         SimulationRun result = runService.createAndStartRun(1L, 1, null, 12345L);
 
@@ -240,13 +243,16 @@ public class SimulationRunServiceTest {
     public void testCreateAndStartRun_SubmitsExecutionAfterTransactionCommit() throws Exception {
         when(liftSystemRepository.findById(1L)).thenReturn(Optional.of(mockLiftSystem));
         when(versionRepository.findByLiftSystemIdAndVersionNumber(1L, 1)).thenReturn(Optional.of(mockVersion));
+        java.util.concurrent.atomic.AtomicReference<SimulationRun> savedRunRef = new java.util.concurrent.atomic.AtomicReference<>();
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
             SimulationRun savedRun = invocation.getArgument(0);
             if (savedRun.getId() == null) {
                 savedRun.setId(42L);
             }
+            savedRunRef.set(savedRun);
             return savedRun;
         });
+        when(runRepository.findByIdWithDetails(42L)).thenAnswer(invocation -> Optional.of(savedRunRef.get()));
 
         TransactionSynchronizationManager.initSynchronization();
         try {
@@ -281,13 +287,16 @@ public class SimulationRunServiceTest {
             "{\"durationTicks\": 5000, \"passengerFlows\": []}",
             com.liftsimulator.admin.dto.ScenarioDefinitionDTO.class
         )).thenReturn(new com.liftsimulator.admin.dto.ScenarioDefinitionDTO(5000, List.of(), null));
+        java.util.concurrent.atomic.AtomicReference<SimulationRun> savedRunRef = new java.util.concurrent.atomic.AtomicReference<>();
         when(runRepository.save(any(SimulationRun.class))).thenAnswer(invocation -> {
             SimulationRun savedRun = invocation.getArgument(0);
             if (savedRun.getId() == null) {
                 savedRun.setId(42L);
             }
+            savedRunRef.set(savedRun);
             return savedRun;
         });
+        when(runRepository.findByIdWithDetails(42L)).thenAnswer(invocation -> Optional.of(savedRunRef.get()));
 
         SimulationRun result = runService.createAndStartRun(1L, 1, 5L, 12345L);
 

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -69,6 +69,7 @@ public class SimulationRunServiceTest {
     private EntityManager entityManager;
 
     private SimulationRunService runService;
+    private RunLifecycleManager lifecycleManager;
 
     private LiftSystem mockLiftSystem;
     private LiftSystemVersion mockVersion;
@@ -79,6 +80,11 @@ public class SimulationRunServiceTest {
 
     @BeforeEach
     public void setUp() throws Exception {
+        lifecycleManager = new RunLifecycleManager(runRepository);
+        java.lang.reflect.Field lifecycleEntityManagerField = RunLifecycleManager.class.getDeclaredField("entityManager");
+        lifecycleEntityManagerField.setAccessible(true);
+        lifecycleEntityManagerField.set(lifecycleManager, entityManager);
+
         runService = new SimulationRunService(
                 runRepository,
                 liftSystemRepository,
@@ -86,14 +92,10 @@ public class SimulationRunServiceTest {
                 scenarioRepository,
                 executionService,
                 artefactService,
+                lifecycleManager,
                 objectMapper,
                 tempDir.toString()
         );
-
-        // Inject EntityManager mock via reflection (it's normally injected by @PersistenceContext)
-        java.lang.reflect.Field entityManagerField = SimulationRunService.class.getDeclaredField("entityManager");
-        entityManagerField.setAccessible(true);
-        entityManagerField.set(runService, entityManager);
 
         mockLiftSystem = new LiftSystem();
         mockLiftSystem.setId(1L);
@@ -530,7 +532,7 @@ public class SimulationRunServiceTest {
         when(runRepository.failOrphanedRunningRuns(any(String.class), any(OffsetDateTime.class))).thenReturn(2);
         when(runRepository.cancelOrphanedCreatedRuns(any(OffsetDateTime.class))).thenReturn(1);
 
-        SimulationRunService.StartupRecoveryResult result = runService.recoverOrphanedRunsOnStartup();
+        RunLifecycleManager.StartupRecoveryResult result = runService.recoverOrphanedRunsOnStartup();
 
         assertEquals(2, result.failedRunningRuns());
         assertEquals(1, result.cancelledCreatedRuns());
@@ -615,8 +617,9 @@ public class SimulationRunServiceTest {
     }
 
     @Test
-    public void testDeleteRun_ArtefactDeletionFailureAfterCommitIsReported() throws Exception {
+    public void testDeleteRun_ArtefactDeletionFailureAfterCommitIsBestEffort() throws Exception {
         mockRun.setStatus(RunStatus.FAILED);
+        mockRun.setArtefactBasePath(tempDir.resolve("run-1").toString());
         when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
         doThrow(new java.io.IOException("disk error")).when(artefactService).deleteArtefacts(mockRun);
 
@@ -625,18 +628,14 @@ public class SimulationRunServiceTest {
             runService.deleteRun(1L);
             TransactionSynchronization synchronization = TransactionSynchronizationManager.getSynchronizations().get(0);
 
-            ArtefactDeletionException exception = assertThrows(
-                ArtefactDeletionException.class,
-                synchronization::afterCommit
-            );
+            synchronization.afterCommit();
 
-            assertTrue(exception.getMessage().contains("disk error"));
             verify(runRepository).deleteById(1L);
+            verify(artefactService).deleteArtefacts(mockRun);
         } finally {
             TransactionSynchronizationManager.clearSynchronization();
         }
     }
-
     @Test
     public void testConfigureRun_WithNullDurationTicks() {
         mockRun.setTotalTicks(null);

--- a/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
+++ b/src/test/java/com/liftsimulator/admin/service/SimulationRunServiceTest.java
@@ -636,6 +636,29 @@ public class SimulationRunServiceTest {
             TransactionSynchronizationManager.clearSynchronization();
         }
     }
+
+
+    @Test
+    public void testDeleteRun_UncheckedArtefactDeletionFailureAfterCommitIsBestEffort() throws Exception {
+        mockRun.setStatus(RunStatus.FAILED);
+        mockRun.setArtefactBasePath(tempDir.resolve("run-1").toString());
+        when(runRepository.findByIdWithDetails(1L)).thenReturn(Optional.of(mockRun));
+        doThrow(new ArtefactStateException("not a directory")).when(artefactService).deleteArtefacts(mockRun);
+
+        TransactionSynchronizationManager.initSynchronization();
+        try {
+            runService.deleteRun(1L);
+            TransactionSynchronization synchronization = TransactionSynchronizationManager.getSynchronizations().get(0);
+
+            synchronization.afterCommit();
+
+            verify(runRepository).deleteById(1L);
+            verify(artefactService).deleteArtefacts(mockRun);
+        } finally {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
     @Test
     public void testConfigureRun_WithNullDurationTicks() {
         mockRun.setTotalTicks(null);


### PR DESCRIPTION
### Motivation
- Reduce duplicated lifecycle transition logic and race-surface between async execution and admin APIs by providing a single authoritative owner for simulation-run lifecycle operations.
- Ensure run deletion does not fail an already-committed database operation when on-disk artefact removal fails by making post-commit artefact cleanup best-effort and observable to operators.
- Improve testability and reduce drift by consolidating lifecycle transitions, progress updates, and startup recovery into one service.

### Description
- Added a new `RunLifecycleManager` service that owns `getByIdWithDetails`, `configureRun`, `startRun`, `succeedRun`, `failRun`, `cancelRun`, `updateProgress`, `markRunningRunFailedSafely`, and startup recovery logic.
- Updated `SimulationRunService` and `SimulationRunExecutionService` to delegate lifecycle operations to `RunLifecycleManager` instead of duplicating repository-based lifecycle helpers, and adjusted related call sites (start/configure/progress/succeed/fail/cancel).
- Made `deleteRun` preserve the existing commit-first ordering but changed post-commit artefact removal to be best-effort: failures are logged with run id and artefact path instead of throwing from the `afterCommit` callback.
- Added `RunLifecycleManagerTest` and updated `SimulationRunExecutionServiceTest` / `SimulationRunServiceTest` to use the lifecycle manager in unit tests.
- Updated docs and metadata: `CHANGELOG.md` (added 0.57.4 entry), `docs/API.md` (document `DELETE /api/v1/simulation-runs/{id}` semantics), `README.md`, `pom.xml` and `frontend/package.json` (version bump to `0.57.4`).

### Testing
- Ran `git diff --check` to validate whitespace and trivial issues and fixed trailing whitespace problems, which passed.
- Attempted to run the unit test subset with `mvn -q -Dtest=RunLifecycleManagerTest,SimulationRunServiceTest,SimulationRunExecutionServiceTest test`, but execution was blocked by environment dependency resolution (Maven offline/CI environment could not fetch the Spring Boot parent POM `4.1.0`, HTTP 403); no failing tests in-source were observed during edits.
- Verified compilation attempts (`mvn -q -DskipTests compile` / `mvn -q -o -DskipTests compile`) were also blocked by the same offline dependency resolution issue in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a521edb4eac832584fc0945502e9242)