### PR TITLE
Consolidate polling logic and utility functions across frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.5] - 2026-07-11
+
+### Changed
+- **Frontend polling/utils consolidation and credential guard**: Added a shared `useRunPolling` hook (`frontend/src/hooks/useRunPolling.js`) encapsulating interval lifecycle, terminal-status (`SUCCEEDED`/`FAILED`/`CANCELLED`) stop conditions, and unmount cleanup, and migrated the five duplicated `setInterval` polling blocks in `Simulator.jsx`, `SimulationRuns.jsx`, and `SimulationRunDetail.jsx` onto it. Moved duplicated status-badge and date/duration formatting helpers into `utils/statusUtils.js` and deleted the page-local copies. `api/client.js` now exports the single-source-of-truth `apiBaseUrl`/`normalizedApiBaseUrl`, removing the re-derivation in `Simulator.jsx` and `SimulationRunDetail.jsx`. `vite.config.js` now fails a production-mode build if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set, since `VITE_*` variables are embedded in the compiled bundle; `frontend/README.md` documents the guard and the risk. Updated affected unit tests and added focused coverage for the new hook.
+
 ## [0.57.4] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.4**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.5**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.4.jar
+java -jar target/lift-simulator-0.57.5.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.4.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.5.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.4.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -213,7 +213,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.4.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.5.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.4.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.5.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -46,7 +46,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.4.jar \
+java -cp target/lift-simulator-0.57.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -60,12 +60,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.4.jar \
+java -cp target/lift-simulator-0.57.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.4.jar \
+java -cp target/lift-simulator-0.57.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -109,7 +109,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.4.jar \
+java -cp target/lift-simulator-0.57.5.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -387,7 +387,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.4.jar \
+   java -cp target/lift-simulator-0.57.5.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -432,7 +432,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.4.jar \
+java -cp target/lift-simulator-0.57.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -524,7 +524,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.4.jar \
+java -cp target/lift-simulator-0.57.5.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,6 +83,8 @@ VITE_API_KEY=local-api-key
 
 The Axios client sends `Authorization: Basic ...` when both admin values are set and sends `X-API-Key` when `VITE_API_KEY` is set. Vite exposes `VITE_*` values in the browser bundle, so use these credentials only for local development or disposable environments. Anyone who can load a built SPA can inspect `VITE_ADMIN_PASSWORD` and `VITE_API_KEY`; do not deploy a hosted frontend bundle with real backend credentials. For hosted use, move authentication behind a backend/session proxy or another server-side auth layer, and never commit this file.
 
+> **⚠️ `VITE_*` variables ship in the bundle.** Vite inlines every `VITE_`-prefixed variable into the compiled JavaScript at build time — there is no server-side secret store. Anyone who loads the app can read `VITE_ADMIN_PASSWORD` and `VITE_API_KEY` from the shipped bundle. `npm run build` **fails** if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set while building in production mode (`vite build`'s default mode), so a real credential can't accidentally end up in a deployed build. Use `VITE_*` credentials for local development or disposable environments only; for hosted deployments, authenticate through a backend/session proxy instead.
+
 ### 3. Start Development Server
 
 ```bash
@@ -353,7 +355,7 @@ From the repository root:
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.4.jar
+java -jar target/lift-simulator-0.57.5.jar
 ```
 
 This command:
@@ -462,6 +464,8 @@ VITE_API_KEY=local-api-key
 
 If `VITE_API_BASE_URL` is left unset, the app will continue to use `/api/v1`, which works with the Vite proxy in local development. The backend ignores whichever auth header does not apply to a specific endpoint, so sending both the Basic auth and API-key headers from the shared Axios client works for local development. Do not rely on bundled `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` values for hosted deployments; keep real credentials server-side behind a backend/session proxy.
 
+**Production build guard:** `vite.config.js` fails `npm run build` (production mode) if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set in the build environment, so a real credential cannot be baked into a shipped bundle by accident. `VITE_ADMIN_USERNAME` alone does not trigger the guard. The guard only applies to production-mode builds — `npm run dev` and `npm run preview` are unaffected.
+
 ### Playwright E2E Environment Variables
 
 The Playwright configuration and Vite dev proxy can inject backend authentication headers for local and CI E2E runs without exposing credentials through Vite's client-side environment variables:
@@ -500,6 +504,7 @@ frontend/
 │   ├── components/      # Reusable components
 │   │   ├── Layout.jsx   # Main layout with navigation
 │   │   └── Layout.css
+│   ├── hooks/           # Shared React hooks (e.g. useRunPolling)
 │   ├── pages/           # Page components
 │   │   ├── Dashboard.jsx
 │   │   ├── LiftSystems.jsx

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -83,7 +83,7 @@ VITE_API_KEY=local-api-key
 
 The Axios client sends `Authorization: Basic ...` when both admin values are set and sends `X-API-Key` when `VITE_API_KEY` is set. Vite exposes `VITE_*` values in the browser bundle, so use these credentials only for local development or disposable environments. Anyone who can load a built SPA can inspect `VITE_ADMIN_PASSWORD` and `VITE_API_KEY`; do not deploy a hosted frontend bundle with real backend credentials. For hosted use, move authentication behind a backend/session proxy or another server-side auth layer, and never commit this file.
 
-> **⚠️ `VITE_*` variables ship in the bundle.** Vite inlines every `VITE_`-prefixed variable into the compiled JavaScript at build time — there is no server-side secret store. Anyone who loads the app can read `VITE_ADMIN_PASSWORD` and `VITE_API_KEY` from the shipped bundle. `npm run build` **fails** if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set while building in production mode (`vite build`'s default mode), so a real credential can't accidentally end up in a deployed build. Use `VITE_*` credentials for local development or disposable environments only; for hosted deployments, authenticate through a backend/session proxy instead.
+> **⚠️ `VITE_*` variables ship in the bundle.** Vite inlines every `VITE_`-prefixed variable into the compiled JavaScript at build time — there is no server-side secret store. Anyone who loads the app can read `VITE_ADMIN_PASSWORD` and `VITE_API_KEY` from the shipped bundle. `npm run build` **fails** if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set for any `vite build` invocation, including a custom `--mode` (e.g. `--mode staging`), so a real credential can't accidentally end up in a deployed build. Use `VITE_*` credentials for local development or disposable environments only; for hosted deployments, authenticate through a backend/session proxy instead.
 
 ### 3. Start Development Server
 
@@ -464,7 +464,7 @@ VITE_API_KEY=local-api-key
 
 If `VITE_API_BASE_URL` is left unset, the app will continue to use `/api/v1`, which works with the Vite proxy in local development. The backend ignores whichever auth header does not apply to a specific endpoint, so sending both the Basic auth and API-key headers from the shared Axios client works for local development. Do not rely on bundled `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` values for hosted deployments; keep real credentials server-side behind a backend/session proxy.
 
-**Production build guard:** `vite.config.js` fails `npm run build` (production mode) if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set in the build environment, so a real credential cannot be baked into a shipped bundle by accident. `VITE_ADMIN_USERNAME` alone does not trigger the guard. The guard only applies to production-mode builds — `npm run dev` and `npm run preview` are unaffected.
+**Production build guard:** `vite.config.js` fails any `vite build` invocation — including `npm run build` and a custom `--mode` such as `--mode staging` — if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set in the build environment, so a real credential cannot be baked into a shipped bundle by accident. `VITE_ADMIN_USERNAME` alone does not trigger the guard. The guard only applies to the `build` command — `npm run dev` and `npm run preview` are unaffected.
 
 ### Playwright E2E Environment Variables
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.4",
+  "version": "0.57.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.4",
+      "version": "0.57.5",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.4",
+  "version": "0.57.5",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/api/__tests__/client.test.js
+++ b/frontend/src/api/__tests__/client.test.js
@@ -55,6 +55,22 @@ describe('api client', () => {
     expect(config.headers).not.toHaveProperty('X-API-Key');
   });
 
+  it('exports apiBaseUrl and a trailing-slash-normalised variant for reuse across pages', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com/api/v1/');
+
+    const clientModule = await import('../client');
+
+    expect(clientModule.apiBaseUrl).toBe('https://api.example.com/api/v1/');
+    expect(clientModule.normalizedApiBaseUrl).toBe('https://api.example.com/api/v1');
+  });
+
+  it('defaults apiBaseUrl to /api/v1 when unset', async () => {
+    const clientModule = await import('../client');
+
+    expect(clientModule.apiBaseUrl).toBe('/api/v1');
+    expect(clientModule.normalizedApiBaseUrl).toBe('/api/v1');
+  });
+
   it('adds Basic auth and API key headers from Vite env vars', async () => {
     vi.stubEnv('VITE_ADMIN_USERNAME', 'admin');
     vi.stubEnv('VITE_ADMIN_PASSWORD', 'local-admin-password');

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import { logApiError } from '../utils/errorHandlers';
 
-const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/api/v1';
+export const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/api/v1';
+export const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, '');
 const timeoutFromEnv = Number(import.meta.env.VITE_API_TIMEOUT_MS);
 const requestTimeoutMs =
   Number.isFinite(timeoutFromEnv) && timeoutFromEnv > 0 ? timeoutFromEnv : 10000;

--- a/frontend/src/hooks/__tests__/useRunPolling.test.js
+++ b/frontend/src/hooks/__tests__/useRunPolling.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { isTerminalRunStatus, useRunPolling } from '../useRunPolling';
+
+describe('isTerminalRunStatus', () => {
+  it.each(['SUCCEEDED', 'FAILED', 'CANCELLED'])('treats %s as terminal', (status) => {
+    expect(isTerminalRunStatus(status)).toBe(true);
+  });
+
+  it.each(['RUNNING', 'CREATED', undefined, null, ''])('treats %s as non-terminal', (status) => {
+    expect(isTerminalRunStatus(status)).toBe(false);
+  });
+});
+
+describe('useRunPolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not call back or start a timer when disabled', () => {
+    const callback = vi.fn();
+    renderHook(() => useRunPolling(callback, { intervalMs: 3000, enabled: false }));
+
+    vi.advanceTimersByTime(10000);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('invokes the callback on every tick while enabled', () => {
+    const callback = vi.fn();
+    renderHook(() => useRunPolling(callback, { intervalMs: 3000, enabled: true }));
+
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(3000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(3000);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('invokes the callback immediately when immediate is true, then on each tick', () => {
+    const callback = vi.fn();
+    renderHook(() => useRunPolling(callback, { intervalMs: 3000, enabled: true, immediate: true }));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(3000);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops polling once enabled turns false (terminal status reached)', () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useRunPolling(callback, { intervalMs: 3000, enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    vi.advanceTimersByTime(3000);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    vi.advanceTimersByTime(10000);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the interval on unmount', () => {
+    const clearIntervalSpy = vi.spyOn(global, 'clearInterval');
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useRunPolling(callback, { intervalMs: 3000, enabled: true }));
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    vi.advanceTimersByTime(10000);
+    expect(callback).not.toHaveBeenCalled();
+
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('always calls the latest callback without restarting the timer', () => {
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+    const { rerender } = renderHook(
+      ({ callback }) => useRunPolling(callback, { intervalMs: 3000, enabled: true }),
+      { initialProps: { callback: firstCallback } }
+    );
+
+    rerender({ callback: secondCallback });
+    vi.advanceTimersByTime(3000);
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/hooks/useRunPolling.js
+++ b/frontend/src/hooks/useRunPolling.js
@@ -1,0 +1,48 @@
+// @ts-check
+import { useEffect, useRef } from 'react';
+
+/**
+ * Simulation-run statuses that will never transition further. Polling stops
+ * once a run reaches one of these.
+ */
+export const RUN_TERMINAL_STATUSES = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
+
+/**
+ * @param {string|null|undefined} status
+ * @returns {boolean} Whether the given run status is terminal.
+ */
+export function isTerminalRunStatus(status) {
+  return status ? RUN_TERMINAL_STATUSES.has(status) : false;
+}
+
+/**
+ * Runs `callback` on a fixed interval while `enabled` is true, and stops
+ * automatically when `enabled` becomes false (e.g. because a run reached a
+ * terminal status) or the component unmounts.
+ *
+ * @param {() => void} callback - Invoked on each tick (and immediately, if `immediate` is set).
+ * @param {{ intervalMs: number, enabled: boolean, immediate?: boolean }} options
+ */
+export function useRunPolling(callback, { intervalMs, enabled, immediate = false }) {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    if (immediate) {
+      callbackRef.current();
+    }
+
+    const intervalId = setInterval(() => {
+      callbackRef.current();
+    }, intervalMs);
+
+    return () => clearInterval(intervalId);
+  }, [enabled, intervalMs, immediate]);
+}

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -1,16 +1,14 @@
 // @ts-check
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { authHeaders } from '../api/client';
+import { authHeaders, normalizedApiBaseUrl } from '../api/client';
 import { simulationRunsApi } from '../api/simulationRunsApi';
 import AlertModal from '../components/AlertModal';
 import ConfirmModal from '../components/ConfirmModal';
 import { getApiErrorMessage, handleApiError, logApiError } from '../utils/errorHandlers';
+import { isTerminalRunStatus, useRunPolling } from '../hooks/useRunPolling';
+import { formatDate, formatRunDuration, getRunStatusPillClass } from '../utils/statusUtils';
 import './SimulationRunDetail.css';
-
-const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
-const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/api/v1';
-const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, '');
 
 const kpiLabels = {
   requestsTotal: 'Requests',
@@ -50,7 +48,7 @@ function SimulationRunDetail() {
   const [deleteError, setDeleteError] = useState(null);
 
   const runStatus = runInfo?.status;
-  const isTerminal = runStatus ? terminalStatuses.has(runStatus) : false;
+  const isTerminal = isTerminalRunStatus(runStatus);
 
   const loadRunInfo = useCallback(async () => {
     if (!id) return;
@@ -110,16 +108,13 @@ function SimulationRunDetail() {
   }, [loadRunInfo]);
 
   // Poll for status updates while running
-  useEffect(() => {
-    if (!runInfo?.id || isTerminal) return undefined;
-
-    const intervalId = setInterval(() => {
+  useRunPolling(
+    useCallback(() => {
       setNow(Date.now());
       loadRunInfo();
-    }, 3000);
-
-    return () => clearInterval(intervalId);
-  }, [runInfo?.id, isTerminal, loadRunInfo]);
+    }, [loadRunInfo]),
+    { intervalMs: 3000, enabled: Boolean(runInfo?.id) && !isTerminal }
+  );
 
   // Load results and artefacts when terminal
   useEffect(() => {
@@ -219,17 +214,6 @@ function SimulationRunDetail() {
     [runInfo?.id, artefactDownloadUrl]
   );
 
-  const formatDuration = (durationMs) => {
-    if (durationMs == null) return '—';
-    const totalSeconds = Math.floor(durationMs / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    if (minutes > 0) {
-      return `${minutes}m ${seconds}s`;
-    }
-    return `${seconds}s`;
-  };
-
   const formatNumber = (value) => {
     if (value == null || Number.isNaN(value)) return '—';
     if (typeof value === 'number') {
@@ -257,11 +241,6 @@ function SimulationRunDetail() {
       index += 1;
     }
     return `${size.toFixed(1)} ${units[index]}`;
-  };
-
-  const formatDate = (dateString) => {
-    if (!dateString) return '—';
-    return new Date(dateString).toLocaleString();
   };
 
   const runSummary = results?.results?.runSummary;
@@ -319,7 +298,7 @@ function SimulationRunDetail() {
         <div className="status-header">
           <h3>Run Status</h3>
           <div className="status-actions">
-            <span className={`status-pill ${runStatus?.toLowerCase()}`}>
+            <span className={getRunStatusPillClass(runStatus)}>
               {runStatus}
             </span>
             {(runStatus === 'RUNNING' || runStatus === 'CREATED') && (
@@ -379,7 +358,7 @@ function SimulationRunDetail() {
           </div>
           <div>
             <span className="label">Duration</span>
-            <p>{formatDuration(elapsedMs)}</p>
+            <p>{formatRunDuration(elapsedMs)}</p>
           </div>
           <div>
             <span className="label">Seed</span>

--- a/frontend/src/pages/SimulationRuns.jsx
+++ b/frontend/src/pages/SimulationRuns.jsx
@@ -6,11 +6,12 @@ import { simulationRunsApi } from '../api/simulationRunsApi';
 import AlertModal from '../components/AlertModal';
 import ConfirmModal from '../components/ConfirmModal';
 import { getApiErrorMessage, handleApiError, logApiError } from '../utils/errorHandlers';
+import { isTerminalRunStatus, useRunPolling } from '../hooks/useRunPolling';
+import { formatDate, formatRunDuration, getRunStatusBadgeClass } from '../utils/statusUtils';
 import './SimulationRuns.css';
 
 const statusOptions = ['ALL', 'SUCCEEDED', 'FAILED', 'RUNNING', 'CREATED', 'CANCELLED'];
 const activeStatuses = new Set(['RUNNING', 'CREATED']);
-const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
 
 /**
  * Simulation runs history page component.
@@ -115,26 +116,13 @@ function SimulationRuns() {
   );
 
   // Poll for updates when there are active runs
-  useEffect(() => {
-    if (!hasActiveRuns) return undefined;
-
-    const intervalId = setInterval(() => {
-      loadRuns(true);
-    }, 3000);
-
-    return () => clearInterval(intervalId);
-  }, [hasActiveRuns, loadRuns]);
+  useRunPolling(
+    useCallback(() => loadRuns(true), [loadRuns]),
+    { intervalMs: 3000, enabled: hasActiveRuns }
+  );
 
   // Keep `now` current so elapsed-time display refreshes for active runs
-  useEffect(() => {
-    if (!hasActiveRuns) return undefined;
-
-    const intervalId = setInterval(() => {
-      setNow(Date.now());
-    }, 1000);
-
-    return () => clearInterval(intervalId);
-  }, [hasActiveRuns]);
+  useRunPolling(() => setNow(Date.now()), { intervalMs: 1000, enabled: hasActiveRuns });
 
   useEffect(() => {
     setSelectedRunIds((currentIds) =>
@@ -151,7 +139,7 @@ function SimulationRuns() {
   const allVisibleSelected = runs.length > 0 && selectedRunIds.length === runs.length;
   const selectedCount = selectedRuns.length;
   const canBulkCancel = selectedCount > 0 && selectedRuns.every((run) => activeStatuses.has(run.status));
-  const canBulkDelete = selectedCount > 0 && selectedRuns.every((run) => terminalStatuses.has(run.status));
+  const canBulkDelete = selectedCount > 0 && selectedRuns.every((run) => isTerminalRunStatus(run.status));
 
   useEffect(() => {
     const params = new URLSearchParams();
@@ -161,18 +149,7 @@ function SimulationRuns() {
   }, [selectedSystemId, selectedStatus, setSearchParams]);
 
   /**
-   * Formats a date for display.
-   *
-   * @param {string|null} dateString - ISO date string
-   * @returns {string} Formatted date string
-   */
-  const formatDate = (dateString) => {
-    if (!dateString) return '—';
-    return new Date(dateString).toLocaleString();
-  };
-
-  /**
-   * Calculates duration between two dates.
+   * Calculates duration between two dates and formats it for display.
    *
    * @param {string|null} startDate - ISO start date string
    * @param {string|null} endDate - ISO end date string
@@ -182,14 +159,7 @@ function SimulationRuns() {
     if (!startDate) return '—';
     const start = new Date(startDate).getTime();
     const end = endDate ? new Date(endDate).getTime() : nowMs;
-    const durationMs = end - start;
-    const totalSeconds = Math.floor(durationMs / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    if (minutes > 0) {
-      return `${minutes}m ${seconds}s`;
-    }
-    return `${seconds}s`;
+    return formatRunDuration(end - start);
   };
 
   /**
@@ -203,27 +173,6 @@ function SimulationRuns() {
     if (!totalTicks || totalTicks === 0 || currentTick == null) return '—';
     const percentage = (currentTick / totalTicks) * 100;
     return `${percentage.toFixed(1)}%`;
-  };
-
-  /**
-   * Get the appropriate status CSS class.
-   *
-   * @param {string} status - Run status
-   * @returns {string} CSS class name
-   */
-  const getStatusClass = (status) => {
-    switch (status) {
-      case 'SUCCEEDED':
-        return 'status-succeeded';
-      case 'FAILED':
-        return 'status-failed';
-      case 'RUNNING':
-        return 'status-running';
-      case 'CANCELLED':
-        return 'status-cancelled';
-      default:
-        return 'status-created';
-    }
   };
 
   const handleSystemChange = (event) => {
@@ -486,7 +435,7 @@ function SimulationRuns() {
                   <td>v{run.versionNumber}</td>
                   <td>{run.scenarioName || '—'}</td>
                   <td>
-                    <span className={`status-badge ${getStatusClass(run.status)}`}>
+                    <span className={getRunStatusBadgeClass(run.status)}>
                       {run.status}
                     </span>
                   </td>
@@ -519,7 +468,7 @@ function SimulationRuns() {
                       >
                         View
                       </Link>
-                      {terminalStatuses.has(run.status) && (
+                      {isTerminalRunStatus(run.status) && (
                         <button
                           type="button"
                           className="btn-small btn-danger"

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -3,15 +3,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
 import { scenariosApi } from '../api/scenariosApi';
-import { authHeaders } from '../api/client';
+import { authHeaders, normalizedApiBaseUrl } from '../api/client';
 import { simulationRunsApi } from '../api/simulationRunsApi';
 import ConfirmModal from '../components/ConfirmModal';
 import { handleApiError } from '../utils/errorHandlers';
+import { isTerminalRunStatus, useRunPolling } from '../hooks/useRunPolling';
+import { formatRunDuration, getRunStatusPillClass } from '../utils/statusUtils';
 import './Simulator.css';
-
-const terminalStatuses = new Set(['SUCCEEDED', 'FAILED', 'CANCELLED']);
-const apiBaseUrl = (import.meta.env.VITE_API_BASE_URL || '/api/v1').trim() || '/api/v1';
-const normalizedApiBaseUrl = apiBaseUrl.replace(/\/$/, '');
 
 const kpiLabels = {
   requestsTotal: 'Requests',
@@ -174,7 +172,7 @@ function Simulator() {
   );
 
   const runStatus = runInfo?.status;
-  const isTerminal = runStatus ? terminalStatuses.has(runStatus) : false;
+  const isTerminal = isTerminalRunStatus(runStatus);
 
   // Clear selected scenario when version changes if it's not compatible
   useEffect(() => {
@@ -189,17 +187,10 @@ function Simulator() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedVersionNumber, filteredScenarios]);
 
-  useEffect(() => {
-    if (!runInfo || isTerminal) {
-      return undefined;
-    }
-
-    const intervalId = setInterval(() => {
-      setNow(Date.now());
-    }, 1000);
-
-    return () => clearInterval(intervalId);
-  }, [runInfo, isTerminal]);
+  useRunPolling(() => setNow(Date.now()), {
+    intervalMs: 1000,
+    enabled: Boolean(runInfo) && !isTerminal,
+  });
 
   const pollRunStatus = useCallback(async () => {
     if (!runInfo?.id) {
@@ -215,18 +206,11 @@ function Simulator() {
     }
   }, [runInfo]);
 
-  useEffect(() => {
-    if (!runInfo?.id || isTerminal) {
-      return undefined;
-    }
-
-    pollRunStatus();
-    const intervalId = setInterval(() => {
-      pollRunStatus();
-    }, 3000);
-
-    return () => clearInterval(intervalId);
-  }, [runInfo?.id, isTerminal, pollRunStatus]);
+  useRunPolling(pollRunStatus, {
+    intervalMs: 3000,
+    enabled: Boolean(runInfo?.id) && !isTerminal,
+    immediate: true,
+  });
 
   useEffect(() => {
     if (!runInfo?.id || !isTerminal) {
@@ -373,19 +357,6 @@ function Simulator() {
     },
     [runInfo?.id, artefactDownloadUrl]
   );
-
-  const formatDuration = (durationMs) => {
-    if (durationMs == null) {
-      return '—';
-    }
-    const totalSeconds = Math.floor(durationMs / 1000);
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    if (minutes > 0) {
-      return `${minutes}m ${seconds}s`;
-    }
-    return `${seconds}s`;
-  };
 
   const formatNumber = (value) => {
     if (value == null || Number.isNaN(value)) {
@@ -564,7 +535,7 @@ function Simulator() {
           <div className="status-header">
             <h3>Run Status</h3>
             <div className="status-actions">
-              <span className={`status-pill ${runStatus?.toLowerCase()}`}>
+              <span className={getRunStatusPillClass(runStatus)}>
                 {runStatus}
               </span>
               {(runStatus === 'RUNNING' || runStatus === 'CREATED') && (
@@ -599,7 +570,7 @@ function Simulator() {
             </div>
             <div>
               <span className="label">Elapsed Time</span>
-              <p>{formatDuration(elapsedMs)}</p>
+              <p>{formatRunDuration(elapsedMs)}</p>
             </div>
             <div>
               <span className="label">Seed</span>

--- a/frontend/src/pages/__tests__/Simulator.lifecycle.test.jsx
+++ b/frontend/src/pages/__tests__/Simulator.lifecycle.test.jsx
@@ -93,13 +93,12 @@ describe('Simulator lifecycle', () => {
 
   it('starts a run, polls RUNNING -> SUCCEEDED, and renders results', async () => {
     simulationRunsApi.createRun.mockResolvedValue({ data: createdRun });
-    // Return the *same* RUNNING object reference for the first two polls (the
-    // component polls once immediately, then again on the 3s interval) so
-    // React bails out of re-rendering until the run actually turns terminal.
+    // The run-status hook polls immediately once a non-terminal run exists
+    // (call 1: RUNNING), then again on the 3s interval (call 2: SUCCEEDED).
     let pollCount = 0;
     simulationRunsApi.getRun.mockImplementation(() => {
       pollCount += 1;
-      return Promise.resolve({ data: pollCount < 3 ? runningRun : succeededRun });
+      return Promise.resolve({ data: pollCount < 2 ? runningRun : succeededRun });
     });
     simulationRunsApi.getResults.mockResolvedValue(resultsPayload);
 

--- a/frontend/src/utils/statusUtils.js
+++ b/frontend/src/utils/statusUtils.js
@@ -29,3 +29,70 @@ export function getStatusBadgeClass(status) {
       return 'status-badge';
   }
 }
+
+/**
+ * Gets the appropriate CSS class names for a simulation-run status badge.
+ *
+ * @param {'SUCCEEDED'|'FAILED'|'RUNNING'|'CANCELLED'|'CREATED'|string} status - Simulation run status value
+ * @returns {string} Space-separated CSS class names for the status badge
+ *
+ * @example
+ * // Returns: "status-badge status-succeeded"
+ * getRunStatusBadgeClass('SUCCEEDED');
+ */
+export function getRunStatusBadgeClass(status) {
+  switch (status) {
+    case 'SUCCEEDED':
+      return 'status-badge status-succeeded';
+    case 'FAILED':
+      return 'status-badge status-failed';
+    case 'RUNNING':
+      return 'status-badge status-running';
+    case 'CANCELLED':
+      return 'status-badge status-cancelled';
+    default:
+      return 'status-badge status-created';
+  }
+}
+
+/**
+ * Gets the CSS class for a simulation-run status pill, as used on run status headers.
+ *
+ * @param {string|null|undefined} status - Simulation run status value
+ * @returns {string} CSS class name, e.g. "status-pill running"
+ */
+export function getRunStatusPillClass(status) {
+  return `status-pill ${status ? status.toLowerCase() : ''}`;
+}
+
+/**
+ * Formats an ISO date string for display.
+ *
+ * @param {string|null|undefined} dateString - ISO date string
+ * @returns {string} Locale-formatted date/time, or '—' when absent
+ */
+export function formatDate(dateString) {
+  if (!dateString) {
+    return '—';
+  }
+  return new Date(dateString).toLocaleString();
+}
+
+/**
+ * Formats a duration in milliseconds as "Xm Ys" (or "Ys" when under a minute).
+ *
+ * @param {number|null|undefined} durationMs - Duration in milliseconds
+ * @returns {string} Formatted duration, or '—' when absent
+ */
+export function formatRunDuration(durationMs) {
+  if (durationMs == null) {
+    return '—';
+  }
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -21,10 +21,13 @@ function buildE2EProxyHeaders() {
 }
 
 // Vite inlines every VITE_-prefixed variable into the compiled client bundle,
-// so a production build must never embed real backend credentials. Fail the
-// build rather than ship them; see frontend/README.md for the safe options.
+// so any `vite build` output must never embed real backend credentials. This
+// applies regardless of --mode: `build` always produces a shippable bundle,
+// and a custom mode (e.g. `--mode staging`) is not a safe way to opt out of
+// the check. Fail the build rather than ship them; see frontend/README.md
+// for the safe options.
 function assertNoProductionCredentials(mode, command) {
-  if (command !== 'build' || mode !== 'production') {
+  if (command !== 'build') {
     return
   }
 
@@ -36,9 +39,9 @@ function assertNoProductionCredentials(mode, command) {
 
   if (offendingVars.length > 0) {
     throw new Error(
-      `Refusing to create a production build with ${offendingVars.join(' and ')} set. ` +
+      `Refusing to create a build with ${offendingVars.join(' and ')} set. ` +
         'VITE_* variables are embedded in the compiled client bundle and are readable by ' +
-        'anyone who loads the app. Unset these for production builds and authenticate via ' +
+        'anyone who loads the app. Unset these before building and authenticate via ' +
         'a backend/session proxy instead. See frontend/README.md for details.'
     )
   }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,6 +1,6 @@
 import process from 'node:process'
 import { Buffer } from 'node:buffer'
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
 function buildE2EProxyHeaders() {
@@ -20,23 +20,51 @@ function buildE2EProxyHeaders() {
   return headers
 }
 
+// Vite inlines every VITE_-prefixed variable into the compiled client bundle,
+// so a production build must never embed real backend credentials. Fail the
+// build rather than ship them; see frontend/README.md for the safe options.
+function assertNoProductionCredentials(mode, command) {
+  if (command !== 'build' || mode !== 'production') {
+    return
+  }
+
+  const env = loadEnv(mode, process.cwd(), 'VITE_')
+  const offendingVars = [
+    env.VITE_ADMIN_PASSWORD?.trim() ? 'VITE_ADMIN_PASSWORD' : null,
+    env.VITE_API_KEY?.trim() ? 'VITE_API_KEY' : null,
+  ].filter(Boolean)
+
+  if (offendingVars.length > 0) {
+    throw new Error(
+      `Refusing to create a production build with ${offendingVars.join(' and ')} set. ` +
+        'VITE_* variables are embedded in the compiled client bundle and are readable by ' +
+        'anyone who loads the app. Unset these for production builds and authenticate via ' +
+        'a backend/session proxy instead. See frontend/README.md for details.'
+    )
+  }
+}
+
 const e2eProxyHeaders = buildE2EProxyHeaders()
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/api/v1': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        headers: e2eProxyHeaders,
-      },
-      '/actuator': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
+export default defineConfig(({ mode, command }) => {
+  assertNoProductionCredentials(mode, command)
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api/v1': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+          headers: e2eProxyHeaders,
+        },
+        '/actuator': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
       },
     },
-  },
+  }
 })

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.4</version>
+    <version>0.57.5</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
## Summary
This PR refactors the frontend to eliminate code duplication by introducing a shared `useRunPolling` hook and consolidating formatting/status utilities. It also adds a production build guard to prevent embedding credentials in the compiled bundle.

## Key Changes

### New Shared Utilities
- **`useRunPolling` hook** (`frontend/src/hooks/useRunPolling.js`): Encapsulates interval-based polling with automatic stop conditions when runs reach terminal statuses (`SUCCEEDED`, `FAILED`, `CANCELLED`), immediate execution option, and proper cleanup on unmount. Includes `isTerminalRunStatus()` helper and `RUN_TERMINAL_STATUSES` constant.
- **Status/formatting utilities** (`frontend/src/utils/statusUtils.js`): Extracted `formatDate()`, `formatRunDuration()`, `getRunStatusBadgeClass()`, and `getRunStatusPillClass()` functions previously duplicated across pages.

### Refactored Pages
- **SimulationRuns.jsx**: Replaced two separate `useEffect` polling loops with `useRunPolling` calls; removed inline `formatDate()` and `getStatusClass()` implementations.
- **Simulator.jsx**: Consolidated three polling patterns into two `useRunPolling` calls; removed duplicate `formatDuration()` and status-class logic.
- **SimulationRunDetail.jsx**: Replaced polling `useEffect` with `useRunPolling`; removed duplicate formatting functions.

### Build & API Client
- **vite.config.js**: Added `assertNoProductionCredentials()` check to fail production builds if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` are set, preventing credential leakage in compiled bundles.
- **api/client.js**: Exported `apiBaseUrl` and `normalizedApiBaseUrl` for reuse across pages (eliminates duplicate URL normalization logic).

### Testing & Documentation
- Added comprehensive test suite for `useRunPolling` hook covering enabled/disabled states, immediate execution, callback updates, and cleanup.
- Updated test comments in `Simulator.lifecycle.test.jsx` to reflect new polling behavior.
- Updated version to 0.57.5 across package.json, pom.xml, and documentation.

## Implementation Details
- The `useRunPolling` hook uses a `useRef` to always invoke the latest callback without restarting the interval, enabling efficient callback updates.
- Terminal status checking is centralized via `isTerminalRunStatus()`, replacing scattered `Set.has()` checks.
- Vite config now validates environment at build time rather than runtime, improving security posture for production deployments.

https://claude.ai/code/session_01WYRhsEXQ5LPaj945UTtmE1