### PR TITLE
Refactor CI pipeline: deduplicate scripts, add CodeQL, optimize E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,26 +38,12 @@ jobs:
         cache: 'maven'
 
     - name: Create test database schema
-      run: |
-        # Wait for PostgreSQL to be ready
-        for i in {1..30}; do
-          pg_isready -h localhost -p 5432 -U lift_admin && break
-          echo "Waiting for postgres... ($i/30)"
-          sleep 1
-        done
-        
-        # Create schema with safe DDL
-        PGPASSWORD=liftpassword psql -h localhost -U lift_admin -d lift_simulator_test -c "DROP SCHEMA IF EXISTS lift_simulator CASCADE;"
-        PGPASSWORD=liftpassword psql -h localhost -U lift_admin -d lift_simulator_test -c "CREATE SCHEMA IF NOT EXISTS lift_simulator;"
-        PGPASSWORD=liftpassword psql -h localhost -U lift_admin -d lift_simulator_test -c "GRANT ALL PRIVILEGES ON SCHEMA lift_simulator TO lift_admin;"
+      run: ./scripts/ci-create-test-schema.sh
       env:
         PGPASSWORD: liftpassword
 
     - name: Verify version consistency
       run: ./scripts/sync-versions.sh --check
-
-    - name: Build project
-      run: mvn -q clean compile
 
     - name: Verify tests and coverage gate
       run: mvn -q verify
@@ -87,12 +73,17 @@ jobs:
         mvn -q -Pfrontend package -DskipTests
 
     - name: Verify packaged frontend assets
-      run: |
-        JAR_FILE=$(find target -maxdepth 1 -name 'lift-simulator-*.jar' ! -name '*.original' | head -n 1)
-        test -n "$JAR_FILE"
-        echo "Verifying frontend assets in $JAR_FILE"
-        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/index.html$'
-        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/assets/'
+      run: ./scripts/ci-verify-jar-assets.sh
+
+    - name: Upload packaged JAR
+      uses: actions/upload-artifact@v7
+      with:
+        name: packaged-jar
+        path: |
+          target/lift-simulator-*.jar
+          !target/lift-simulator-*.original
+        retention-days: 1
+        if-no-files-found: error
 
   frontend:
     runs-on: ubuntu-latest
@@ -150,12 +141,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
 
-    - name: Set up JDK 21
+    - name: Set up JDK 21 (runtime for packaged JAR)
       uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: 'maven'
 
     - name: Set up Node.js
       uses: actions/setup-node@v6
@@ -172,30 +162,17 @@ jobs:
       working-directory: frontend
       run: npx playwright install --with-deps chromium
 
-    - name: Package deployable JAR for E2E with frontend profile
-      run: |
-        echo "Activating Maven frontend profile: mvn -Pfrontend package -DskipTests"
-        mvn -q -Pfrontend package -DskipTests
+    - name: Download packaged JAR
+      uses: actions/download-artifact@v7
+      with:
+        name: packaged-jar
+        path: target
 
-    - name: Verify E2E packaged frontend assets
-      run: |
-        JAR_FILE=$(find target -maxdepth 1 -name 'lift-simulator-*.jar' ! -name '*.original' | head -n 1)
-        test -n "$JAR_FILE"
-        echo "Verifying frontend assets in $JAR_FILE"
-        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/index.html$'
-        jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/assets/'
+    - name: Verify packaged frontend assets
+      run: ./scripts/ci-verify-jar-assets.sh
 
     - name: Create E2E database schema
-      run: |
-        for i in {1..30}; do
-          pg_isready -h localhost -p 5432 -U lift_admin && break
-          echo "Waiting for postgres... ($i/30)"
-          sleep 1
-        done
-
-        PGPASSWORD=liftpassword psql -h localhost -U lift_admin -d lift_simulator_test -c "DROP SCHEMA IF EXISTS lift_simulator CASCADE;"
-        PGPASSWORD=liftpassword psql -h localhost -U lift_admin -d lift_simulator_test -c "CREATE SCHEMA IF NOT EXISTS lift_simulator;"
-        PGPASSWORD=liftpassword psql -h localhost -U lift_admin -d lift_simulator_test -c "GRANT ALL PRIVILEGES ON SCHEMA lift_simulator TO lift_admin;"
+      run: ./scripts/ci-create-test-schema.sh
       env:
         PGPASSWORD: liftpassword
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: java-kotlin
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up JDK 21
+      if: matrix.language == 'java-kotlin'
+      uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.6] - 2026-07-11
+
+### Changed
+- **CI pipeline deduplication and CodeQL**: The `backend` job now uploads the packaged JAR as a build artifact and the `e2e-playwright` job downloads it instead of rebuilding it (`mvn -Pfrontend package -DskipTests` no longer runs twice per pipeline run), removing the Maven/JDK-build overhead from the E2E job's setup while keeping the Java runtime needed to start the packaged application. The duplicated PostgreSQL schema-creation and packaged-JAR asset-verification script blocks are now shared scripts, `scripts/ci-create-test-schema.sh` and `scripts/ci-verify-jar-assets.sh`, called from both jobs instead of copy-pasted inline. Removed the redundant standalone `mvn clean compile` step in `backend`, since `mvn verify` already compiles. Added `.github/workflows/codeql.yml` running CodeQL static analysis for `java-kotlin` and `javascript-typescript` on pull requests to `main` and weekly. Updated `README.md` and `frontend/README.md` CI sections to match the new job shape.
+
 ## [0.57.5] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.5**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.6**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.5.jar
+java -jar target/lift-simulator-0.57.6.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.5.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.6.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.5.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -192,7 +192,7 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 # Terminal 2: frontend/
 E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD=local-admin-password E2E_API_KEY=local-api-key npm test
 ```
-In CI, the backend test job runs with `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`, matching the checked-in test and runtime profile strategy so Flyway migrations remain the only source of schema changes and mapping drift fails the build. The `e2e-playwright` job packages the backend with `mvn -Pfrontend package -DskipTests`, starts the packaged application, waits for `/api/v1/health` and the React root page, and runs `npm test` in `frontend/`.
+In CI, the backend test job runs with `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`, matching the checked-in test and runtime profile strategy so Flyway migrations remain the only source of schema changes and mapping drift fails the build. The `backend` job packages the deployable JAR with `mvn -Pfrontend package -DskipTests` and uploads it as a build artifact; the `e2e-playwright` job downloads that JAR (rather than rebuilding it), starts the packaged application, waits for `/api/v1/health` and the React root page, and runs `npm test` in `frontend/`.
 
 ## Quality Checks
 
@@ -203,7 +203,7 @@ mvn verify                  # tests and JaCoCo coverage gate
 
 Static analysis is enforced with SpotBugs; the previous no-op Checkstyle gate was removed because it did not enforce repository style rules. SpotBugs suppressions are limited to Spring-managed dependency injection in service constructors.
 
-Dependabot is configured in `.github/dependabot.yml` to check Maven dependencies, frontend npm dependencies, and GitHub Actions weekly.
+Dependabot is configured in `.github/dependabot.yml` to check Maven dependencies, frontend npm dependencies, and GitHub Actions weekly. CodeQL static security analysis runs in `.github/workflows/codeql.yml` for the `java-kotlin` and `javascript-typescript` languages, triggered on pull requests to `main` and weekly.
 
 ## Configuration
 
@@ -213,7 +213,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.5.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.6.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.5.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.6.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -46,7 +46,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.5.jar \
+java -cp target/lift-simulator-0.57.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -60,12 +60,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.5.jar \
+java -cp target/lift-simulator-0.57.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.5.jar \
+java -cp target/lift-simulator-0.57.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -109,7 +109,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.5.jar \
+java -cp target/lift-simulator-0.57.6.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -387,7 +387,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.5.jar \
+   java -cp target/lift-simulator-0.57.6.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -432,7 +432,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.5.jar \
+java -cp target/lift-simulator-0.57.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -524,7 +524,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.5.jar \
+java -cp target/lift-simulator-0.57.6.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -291,35 +291,45 @@ See [Playwright documentation](https://playwright.dev/docs/writing-tests) for mo
 
 ## CI/CD
 
-The repository uses **GitHub Actions** with the workflow defined in `.github/workflows/ci.yml`.
+The repository uses **GitHub Actions** with the CI workflow defined in
+`.github/workflows/ci.yml` and CodeQL security scanning defined in
+`.github/workflows/codeql.yml`.
 
 ### What Runs on Pull Requests
 
 - **Backend**
-  - Compile, unit tests, coverage report (JaCoCo)
-  - Checkstyle and SpotBugs static analysis
-  - Package build (tests skipped for the final package step)
+  - Unit tests, coverage report (JaCoCo), and coverage gate (`mvn verify`)
+  - SpotBugs static analysis
+  - Package build with the frontend profile (tests skipped for the final
+    package step), then upload the packaged JAR as a build artifact
 - **Frontend**
   - `npm ci`
   - `npm run lint`
   - `npm run build`
 - **Playwright E2E with backend**
-  - Provision PostgreSQL
-  - Package and start the Spring Boot backend
+  - Download the JAR packaged by the `backend` job (not rebuilt)
+  - Provision PostgreSQL and start the Spring Boot backend from that JAR
   - Wait for `/api/v1/health`
   - Run `npm test` in `frontend/` against the live backend
   - Upload the Playwright HTML report and failure artifacts
+- **CodeQL** (separate workflow: pull requests to `main` and a weekly
+  schedule)
+  - Static security analysis of the `java-kotlin` and `javascript-typescript`
+    languages
+
+The PostgreSQL schema-creation and packaged-JAR asset-verification steps used
+by the `backend` and `e2e-playwright` jobs are shared scripts,
+`scripts/ci-create-test-schema.sh` and `scripts/ci-verify-jar-assets.sh`,
+rather than duplicated inline blocks.
 
 ### Run CI Checks Locally
 
 From the repository root:
 
 ```bash
-mvn -q clean compile
-mvn -q test jacoco:report
-mvn -q checkstyle:check
+mvn -q verify
 mvn -q spotbugs:check
-mvn -q package -DskipTests
+mvn -q -Pfrontend package -DskipTests
 ```
 
 From `frontend/` (with the backend already running for the E2E step):
@@ -355,7 +365,7 @@ From the repository root:
 
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.5.jar
+java -jar target/lift-simulator-0.57.6.jar
 ```
 
 This command:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.5",
+  "version": "0.57.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.5",
+      "version": "0.57.6",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.5",
+  "version": "0.57.6",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.5</version>
+    <version>0.57.6</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/scripts/ci-create-test-schema.sh
+++ b/scripts/ci-create-test-schema.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Waits for PostgreSQL to accept connections, then (re)creates the test
+# schema. Shared by the backend and e2e-playwright CI jobs, which each run
+# their own postgres service container and need an identically-shaped schema.
+set -euo pipefail
+
+PGHOST="${PGHOST:-localhost}"
+PGPORT="${PGPORT:-5432}"
+PGUSER="${PGUSER:-lift_admin}"
+PGDATABASE="${PGDATABASE:-lift_simulator_test}"
+SCHEMA="${SCHEMA:-lift_simulator}"
+
+for i in $(seq 1 30); do
+  pg_isready -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" && break
+  echo "Waiting for postgres... ($i/30)"
+  sleep 1
+done
+
+psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -c "DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE;"
+psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -c "CREATE SCHEMA IF NOT EXISTS ${SCHEMA};"
+psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -c "GRANT ALL PRIVILEGES ON SCHEMA ${SCHEMA} TO ${PGUSER};"

--- a/scripts/ci-verify-jar-assets.sh
+++ b/scripts/ci-verify-jar-assets.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Verifies that the packaged Spring Boot JAR under target/ embeds the built
+# React frontend. Shared by the backend job (which packages the JAR) and the
+# e2e-playwright job (which downloads it as a build artifact).
+set -euo pipefail
+
+JAR_FILE=$(find target -maxdepth 1 -name 'lift-simulator-*.jar' ! -name '*.original' | head -n 1)
+test -n "$JAR_FILE"
+echo "Verifying frontend assets in $JAR_FILE"
+jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/index.html$'
+jar tf "$JAR_FILE" | grep '^BOOT-INF/classes/static/assets/'


### PR DESCRIPTION
## Summary
This PR refactors the GitHub Actions CI pipeline to eliminate duplication, improve maintainability, and add security scanning. The `backend` job now packages the deployable JAR once and uploads it as a build artifact; the `e2e-playwright` job downloads and reuses that artifact instead of rebuilding it. Duplicated inline shell scripts are extracted into shared reusable scripts. A new CodeQL workflow adds static security analysis for Java and JavaScript.

## Key Changes

- **CI pipeline optimization**: The `backend` job packages the JAR with `mvn -Pfrontend package -DskipTests` and uploads it as a build artifact. The `e2e-playwright` job downloads that artifact instead of rebuilding, eliminating redundant Maven/JDK compilation overhead while retaining the Java runtime needed to start the packaged application.

- **Script extraction and reuse**: 
  - Created `scripts/ci-create-test-schema.sh` to encapsulate PostgreSQL schema setup (wait for readiness, drop/create schema, grant privileges). Called by both `backend` and `e2e-playwright` jobs instead of duplicated inline blocks.
  - Created `scripts/ci-verify-jar-assets.sh` to verify frontend assets are embedded in the packaged JAR. Called by both `backend` and `e2e-playwright` jobs instead of duplicated inline blocks.
  - Both scripts use environment variables (`PGHOST`, `PGPORT`, `PGUSER`, `PGDATABASE`, `SCHEMA`) for flexibility.

- **CodeQL security scanning**: Added `.github/workflows/codeql.yml` running CodeQL analysis for `java-kotlin` and `javascript-typescript` languages on pull requests to `main` and on a weekly schedule.

- **CI pipeline cleanup**: Removed the redundant standalone `mvn clean compile` step from the `backend` job since `mvn verify` already compiles. Removed Maven cache setup from the `e2e-playwright` job's JDK configuration since it no longer builds.

- **Documentation updates**: Updated `README.md`, `frontend/README.md`, and `docs/Workflows-and-Troubleshooting.md` to reflect the new CI architecture, including the artifact sharing pattern and CodeQL workflow.

- **Version bump**: Updated version to 0.57.6 in `pom.xml`, `frontend/package.json`, and all documentation references.

## Implementation Details

- The shared scripts use `set -euo pipefail` for safety and accept environment variable overrides with sensible defaults.
- The JAR artifact upload uses `retention-days: 1` to minimize storage overhead since it's only needed within the same workflow run.
- The `e2e-playwright` job's JDK setup now omits Maven caching since it only needs the Java runtime, not the build toolchain.

https://claude.ai/code/session_01FTVuLJLkHSL31E5ohkWVr5