### PR TITLE
Refactor API.md as conventions reference; move endpoint docs to generated Swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.7] - 2026-07-11
+
+### Changed
+- **API/README documentation slimming**: Rewrote `docs/API.md` (1030 → 220 lines) as an API *conventions* reference — authentication (HTTP Basic + API key), role-based access control, URL versioning, rate limiting, request/artefact size limits, response conventions (201 + `Location`, 202, pagination/sorting), and the shared `ErrorResponse`/`ValidationErrorResponse` shape — with the generated SpringDoc OpenAPI spec (Swagger UI / `api-docs`) promoted as the authoritative, always-current endpoint reference instead of hand-maintained per-endpoint schemas. Relocated the consumer-relevant reference material that the generated spec does not present as tables — the lift-configuration schema and validation rules (with the 0.46.0 floor-range migration note), the scenario payload schema, and the batch-input-generator format — into a new "Configuration and Scenario Schema Reference" section of `docs/Workflows-and-Troubleshooting.md`. Condensed the root `README.md` (434 → 336 lines): merged Rate Limiting and Request/Artefact Size Limits into a single summary linking to `docs/API.md`, shortened the Logging and Testing sections to summaries that link to the authoritative docs, and left Quick Start intact. Slimmed `frontend/README.md` (670 → 308 lines) to frontend-specific setup, scripts, testing methodology, and type-checking, replacing the long CI/CD and deployment sections with pointers to the root README and CI workflows. Fixed a stale Table-of-Contents anchor and verified zero broken internal markdown links in the edited files. Documentation-only; synchronised package metadata for the 0.57.7 pre-MVP patch release.
+
 ## [0.57.6] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.6**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.7**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -99,7 +99,7 @@ The **frontend admin UI** provides:
 
 Run the UI in dev mode with `cd frontend && npm install && npm run dev`; it proxies API requests to the backend on port 8080. See [frontend/README.md](frontend/README.md) for setup, environment variables, and the type-definition (JSDoc) workflow.
 
-The **backend REST API** is versioned under `/api/v1` (base URL `http://localhost:8080/api/v1`). Interactive documentation is available via Swagger UI at `/api/v1/swagger-ui.html` and OpenAPI JSON at `/api/v1/api-docs`. Create endpoints return `201 Created` with browser-readable `Location` headers, runtime simulator launches return `202 Accepted`, and validation errors preserve all messages per field as arrays. For the complete endpoint reference — lift systems, versions, scenarios, simulation runs, runtime configuration, health, and request/response examples — see [docs/API.md](docs/API.md). For CLI/UI run workflows, artefact reproduction, and simulation-run troubleshooting, see [docs/Workflows-and-Troubleshooting.md](docs/Workflows-and-Troubleshooting.md). See [ADR-0020](docs/decisions/0020-url-based-api-versioning.md) for the versioning strategy.
+The **backend REST API** is versioned under `/api/v1` (base URL `http://localhost:8080/api/v1`). The complete, always-current endpoint reference is generated from the code by SpringDoc and served as interactive Swagger UI at `/api/v1/swagger-ui.html` and OpenAPI JSON at `/api/v1/api-docs`. API conventions — authentication, role-based access control, versioning, rate limiting, request-size limits, and the shared error-response shape — are documented in [docs/API.md](docs/API.md). For CLI/UI run workflows, the configuration and scenario schema reference, artefact reproduction, and simulation-run troubleshooting, see [docs/Workflows-and-Troubleshooting.md](docs/Workflows-and-Troubleshooting.md). See [ADR-0020](docs/decisions/0020-url-based-api-versioning.md) for the versioning strategy.
 
 ## Building the Project
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.6.jar
+java -jar target/lift-simulator-0.57.7.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.6.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.7.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,57 +142,24 @@ java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.6.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
 
 ## Testing
 
-Run the full verification suite (tests and JaCoCo coverage gate):
+Run the full verification suite (tests and JaCoCo coverage gate) or a faster test-only cycle:
 ```bash
-mvn verify
-```
-
-For a faster local test-only cycle:
-```bash
-mvn test
+mvn verify   # tests + JaCoCo coverage gate
+mvn test     # tests only
 ```
 
 > **No local PostgreSQL needed.** Integration tests provision a throwaway PostgreSQL container via
 > [Testcontainers](https://java.testcontainers.org/) and run the real Flyway migrations against it; the only
-> requirement is a running **Docker** daemon. (CI uses its own PostgreSQL service container — see
-> `.github/workflows/ci.yml`.)
+> requirement is a running **Docker** daemon. (CI uses its own PostgreSQL service container.)
 
-The suite spans several levels:
-
-- **Unit tests** — controllers, services, and domain logic: request lifecycle transitions (`LiftRequestTest`), artefact path/download/log/result handling (`ArtefactServiceTest`), simulation-run lifecycle transitions (`RunLifecycleManagerTest`), simulation execution artefact orchestration (`SimulationRunExecutionServiceTest`), nearest-request and directional-scan routing, door handling and cancellation (`NaiveLiftControllerTest`, `DirectionalScanLiftControllerTest`), and the tick mechanism (`SimulationEngineTest`).
-- **Integration tests** — full Spring context for REST APIs and repositories, including scenario CRUD, configuration-validation, runtime configuration, simulation-launch, and health controller APIs, multi-request scenarios, dynamic request addition during movement, cancellation, and out-of-service handling (`ScenarioControllerTest`, `ConfigValidationControllerTest`, `RuntimeConfigControllerTest`, `HealthControllerTest`, `DirectionalScanIntegrationTest`, `LiftRequestLifecycleTest`). Scenario fixtures live in `src/test/resources/scenarios`, controller API fixtures live under `src/test/java/com/liftsimulator/admin/controller/fixtures`, and batch-input golden files live under `src/test/resources/batch-input`.
-- **Scenario tests** — `ControllerScenarioTest` exercises realistic multi-request routing for both controller strategies via a deterministic `ScenarioHarness`, guarding against behavioural regressions.
-- **Playwright E2E tests** — browser smoke and feature tests under `frontend/e2e` run against the React dev server (port 3000) and a live backend (port 8080). See [ADR-0014](docs/decisions/0014-playwright-e2e-testing.md).
-
-Run a single class or method:
-```bash
-mvn test -Dtest=ControllerScenarioTest
-mvn test -Dtest=ControllerScenarioTest#testDirectionalScan_CanonicalScenario_FromReadme
-```
-
-The project enforces a minimum **50% line coverage baseline** through JaCoCo during `mvn verify` for production business logic, excluding Spring wiring, DTO/entity/repository boilerplate, package descriptors, and CLI/application entrypoints. CI runs the same Maven phase so pull requests fail if the scoped coverage baseline drops below the threshold. Dependency monitoring is handled by GitHub Dependabot for Maven, frontend npm packages, and GitHub Actions; Dependabot opens weekly update pull requests instead of running an NVD-backed OWASP Dependency-Check scan during CI. Generate only the coverage report (available at `target/site/jacoco/index.html`) with:
-```bash
-mvn jacoco:report
-```
-
-For local frontend E2E runs, start the backend with credentials in one terminal, then run Playwright with matching variables in another:
-```bash
-# Terminal 1: repository root
-export ADMIN_USERNAME=admin ADMIN_PASSWORD=local-admin-password API_KEY=local-api-key
-mvn spring-boot:run -Dspring-boot.run.profiles=dev
-```
-```bash
-# Terminal 2: frontend/
-E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD=local-admin-password E2E_API_KEY=local-api-key npm test
-```
-In CI, the backend test job runs with `SPRING_JPA_HIBERNATE_DDL_AUTO=validate`, matching the checked-in test and runtime profile strategy so Flyway migrations remain the only source of schema changes and mapping drift fails the build. The `backend` job packages the deployable JAR with `mvn -Pfrontend package -DskipTests` and uploads it as a build artifact; the `e2e-playwright` job downloads that JAR (rather than rebuilding it), starts the packaged application, waits for `/api/v1/health` and the React root page, and runs `npm test` in `frontend/`.
+The suite spans backend unit tests, Spring-context integration tests for the REST APIs and repositories, deterministic controller scenario tests, and Playwright browser E2E tests under `frontend/e2e` (see [ADR-0014](docs/decisions/0014-playwright-e2e-testing.md)). `mvn verify` enforces a minimum **50% line coverage baseline** through JaCoCo for production business logic (report at `target/site/jacoco/index.html`); CI runs the same phase so pull requests fail if the scoped baseline drops. For the full setup — test database, categories, environment variables, and IDE integration — see [docs/TESTING-SETUP.md](docs/TESTING-SETUP.md) and [docs/TESTING-ARCHITECTURE-GUIDE.md](docs/TESTING-ARCHITECTURE-GUIDE.md). For local frontend E2E runs and the Playwright configuration, see [frontend/README.md](frontend/README.md#testing).
 
 ## Quality Checks
 
@@ -213,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.6.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.7.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 
@@ -230,59 +197,15 @@ Public endpoints requiring no authentication are `/api/v1/health` and static/fro
 
 Admin APIs support role-based access control with two roles: **ADMIN** (read and write) and **VIEWER** (read-only). Write methods (POST, PUT, PATCH, DELETE) require ADMIN; configure multiple users under `security.users` in `application-dev.yml`. Always keep credentials out of version control, prefer environment variables in production, and use HTTPS so HTTP Basic credentials are not exposed.
 
-For runtime API-key setup and request/response examples, see [docs/API.md](docs/API.md). The security baseline, RBAC, and CORS/CSRF policies are documented in [ADR-0019](docs/decisions/0019-spring-security-baseline.md), [ADR-0021](docs/decisions/0021-role-based-access-control-rbac.md), and [ADR-0022](docs/decisions/0022-explicit-cors-csrf-policy.md).
+For runtime API-key setup, RBAC details, and the shared error-response shape, see [docs/API.md](docs/API.md). The security baseline, RBAC, and CORS/CSRF policies are documented in [ADR-0019](docs/decisions/0019-spring-security-baseline.md), [ADR-0021](docs/decisions/0021-role-based-access-control-rbac.md), and [ADR-0022](docs/decisions/0022-explicit-cors-csrf-policy.md).
 
 ## Frontend timeout retry behavior
 
 The admin UI keeps the default Axios request timeout at 10 seconds, but automatically retries one timed-out safe read request after a short delay. This helps first-use backend cold starts complete while the existing page or action loading indicator remains visible; a user-facing error is shown only if the retry also fails.
 
-## Rate Limiting
+## Rate Limiting and Size Limits
 
-The API is protected by a token-bucket rate limiter (Bucket4j) applied per client IP address. Separate limits apply to the admin and runtime/simulation-run API groups.
-
-Default thresholds (configurable in `application.yml` or overridden per environment):
-
-| API group | Default capacity | Refill |
-|-----------|-----------------|--------|
-| Admin (`/api/v1/**`) | 100 requests | 100 per 60 s |
-| Runtime / simulation-runs | 1 000 requests | 1 000 per 60 s |
-
-When the limit is exceeded the server responds with **HTTP 429 Too Many Requests** and includes:
-- `Retry-After: <seconds>` — how long to wait before retrying
-- `X-RateLimit-Limit: <capacity>` — total bucket capacity
-- `X-RateLimit-Remaining: 0` — tokens remaining (always 0 on a 429)
-
-**Configuration reference** (`application.yml`):
-```yaml
-rate-limiting:
-  enabled: true               # set to false to disable entirely (e.g. in integration tests)
-  trust-forwarded-for: false  # set to true only behind a trusted reverse proxy
-  max-buckets-per-group: 10000 # caps retained client-IP buckets per API group
-  admin:
-    capacity: 100             # bucket capacity (max burst)
-    refill-tokens: 100        # tokens added per period
-    refill-period-seconds: 60
-  runtime:
-    capacity: 1000
-    refill-tokens: 1000
-    refill-period-seconds: 60
-```
-
-**`trust-forwarded-for`** — when `false` (the default), the rate-limiter uses `getRemoteAddr()` as the bucket key, which prevents callers from bypassing limits by spoofing `X-Forwarded-For`. Set to `true` only when the service runs exclusively behind a trusted reverse proxy that controls this header.
-
-Override individual fields per Spring profile to tighten limits in production or loosen them for load testing.
-
-## Request and Artefact Size Limits
-
-The backend rejects oversized API request bodies before JSON deserialization and constrains Jackson JSON nesting/string sizes to reduce denial-of-service risk from very large or deeply nested JSON payloads. By default, `/api/v1/**` and `/actuator/**` request bodies are capped at **1 MiB** and oversized requests receive **HTTP 413 Payload Too Large**.
-
-```yaml
-request-size-limits:
-  enabled: true
-  max-body-bytes: 1048576
-```
-
-Simulation artefact reads are also bounded: full log reads and `results.json` parsing are capped at **1 MiB** each. Prefer the existing `tail` query parameter for large logs; `tail` accepts values from `1` to `10000`, rejects out-of-range values with HTTP 400, and tailed log reads remain capped by line count without materializing the entire file in memory.
+The API is protected by a per-client-IP token-bucket rate limiter (Bucket4j) with separate limits for the admin (100 req/60 s) and runtime/simulation-run (1 000 req/60 s) groups; exceeding a limit returns **HTTP 429** with `Retry-After` and `X-RateLimit-*` headers. Request bodies for `/api/v1/**` and `/actuator/**` are capped at **1 MiB** (**HTTP 413** when exceeded), and simulation artefact log/`results.json` reads are bounded at 1 MiB each. All thresholds are configurable in `application.yml` and overridable per Spring profile. See [docs/API.md](docs/API.md#rate-limiting) for the full configuration reference, response headers, and the `trust-forwarded-for` proxy note.
 
 ## Database Setup
 
@@ -307,28 +230,7 @@ For JPA entities, repositories, and verification-runner usage, see [docs/DEVELOP
 
 ## Logging
 
-The backend uses Logback for logging with both console and file output. All logs are persisted to the `logs/` directory in the project root:
-
-- **Main application log** (`logs/application.log`) — all levels; rotates at 10MB or daily at midnight; 30 days / 1GB retention; archived as `logs/application-YYYY-MM-DD.N.log`.
-- **Error log** (`logs/application-error.log`) — ERROR level only; rotates at 10MB or daily; 90 days / 500MB retention.
-
-Logging is configured via `src/main/resources/logback-spring.xml`, with profile-specific levels (DEBUG and verbose SQL for `dev`, INFO for `prod`) and full stack traces for all exceptions. Log files (`*.log`) are git-ignored; the `logs/` directory is preserved with a `.gitkeep` file.
-
-View and search logs:
-```bash
-tail -f logs/application.log          # follow the main log
-tail -f logs/application-error.log    # follow errors only
-grep "ERROR" logs/application-*.log   # search across archives
-```
-
-To customise log locations without git conflicts, set them in `application-local.yml` (run with `SPRING_PROFILES_ACTIVE=dev,local`):
-```yaml
-logging:
-  file:
-    name: /custom/path/to/application.log
-    path: /custom/path/to/logs
-```
-Alternatively, set `LOGGING_FILE_PATH` as an environment variable.
+The backend uses Logback (configured in `src/main/resources/logback-spring.xml`) with console and file output persisted to `logs/`: `logs/application.log` (all levels, 30-day retention) and `logs/application-error.log` (ERROR only, 90-day retention), both rotating at 10 MB or daily. Levels are profile-specific (DEBUG and verbose SQL for `dev`, INFO for `prod`). Log files are git-ignored; the directory is kept with `.gitkeep`. Override log locations via `application-local.yml` (run with `SPRING_PROFILES_ACTIVE=dev,local`) or the `LOGGING_FILE_PATH` environment variable. For finding and tailing simulation-run logs, see [docs/Workflows-and-Troubleshooting.md#where-to-find-logs](docs/Workflows-and-Troubleshooting.md#where-to-find-logs).
 
 ## Development Setup
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,8 +142,7 @@ Simulation artefact reads are also bounded: full log reads and `results.json` pa
 
 Controllers return typed DTOs for JSON payloads rather than ad-hoc maps.
 
-- **Create endpoints** return `201 Created` with a `Location` header pointing at the created resource (for example `Location: /api/v1/lift-systems/{id}`). The default CORS exposed-headers list includes `Location` so allowed browser clients can read it.
-- **Runtime simulator launches** return `202 Accepted`.
+- **Create endpoints** return `201 Created` with a `Location` header pointing at the created resource (for example `Location: /api/v1/lift-systems/{id}`). The default CORS exposed-headers list includes `Location` so allowed browser clients can read it. Creating a simulation run also returns `201 Created` and starts execution asynchronously.
 - **Deletes** return `204 No Content`.
 
 ### Pagination and Sorting
@@ -205,7 +204,6 @@ The same `valid` / `errors` / `warnings` shape is returned when validation runs 
 |--------|---------|
 | `200 OK` | Successful read or update |
 | `201 Created` | Resource created (includes `Location` header) |
-| `202 Accepted` | Runtime simulator launch accepted |
 | `204 No Content` | Successful delete |
 | `400 Bad Request` | Validation error or malformed request |
 | `401 Unauthorized` | Missing or invalid credentials |

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,441 +1,55 @@
-# REST API Reference
+# REST API Conventions
 
-This document contains the full REST API reference for the Lift Simulator backend. The interactive Swagger UI is available at `http://localhost:8080/api/v1/swagger-ui.html`, and the OpenAPI JSON is available at `http://localhost:8080/api/v1/api-docs` when the backend is running.
+This document covers the cross-cutting conventions of the Lift Simulator backend REST API: authentication, role-based access control, versioning, rate limiting, request-size limits, and the shared error-response shape. **The full, always-current endpoint reference — every path, request/response schema, and field — is generated from the code by SpringDoc, so it is not duplicated here.**
 
-All application endpoints use the `/api/v1` base path unless otherwise noted. Admin endpoints use HTTP Basic authentication, while runtime and simulation execution endpoints use the configured API key header.
+## Generated OpenAPI Specification
 
-### Available Endpoints
+The complete endpoint reference is served by the running backend and is the authoritative source of truth for request/response schemas:
 
-#### Lift System Management
+- **Interactive Swagger UI:** `http://localhost:8080/api/v1/swagger-ui.html`
+- **OpenAPI JSON:** `http://localhost:8080/api/v1/api-docs`
 
-- **Create Lift System**: `POST /api/v1/lift-systems`
-  - Creates a new lift system configuration
-  - Request body:
-    ```json
-    {
-      "systemKey": "building-a-lifts",
-      "displayName": "Building A Lift System",
-      "description": "Main lift system for Building A"
-    }
-    ```
-  - Response (201 Created): includes `Location: /api/v1/lift-systems/{id}`
-    ```json
-    {
-      "id": 1,
-      "systemKey": "building-a-lifts",
-      "displayName": "Building A Lift System",
-      "description": "Main lift system for Building A",
-      "createdAt": "2026-01-11T10:00:00Z",
-      "updatedAt": "2026-01-11T10:00:00Z",
-      "versionCount": 0
-    }
-    ```
+Access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so both URLs require ADMIN-role HTTP Basic authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 
-- **List All Lift Systems**: `GET /api/v1/lift-systems`
-  - Returns all lift systems
-  - Response (200 OK):
-    ```json
-    [
-      {
-        "id": 1,
-        "systemKey": "building-a-lifts",
-        "displayName": "Building A Lift System",
-        "description": "Main lift system for Building A",
-        "createdAt": "2026-01-11T10:00:00Z",
-        "updatedAt": "2026-01-11T10:00:00Z",
-        "versionCount": 3
-      }
-    ]
-    ```
+For operational guidance that the generated spec does not capture — CLI/UI run workflows, artefact reproduction, the configuration and scenario schema reference, and simulation-run troubleshooting — see [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md).
 
-- **Get Lift System by ID**: `GET /api/v1/lift-systems/{id}`
-  - Returns a specific lift system by ID
-  - Response (200 OK): Same as create response (includes `versionCount`)
-  - Error (404 Not Found):
-    ```json
-    {
-      "status": 404,
-      "message": "Lift system not found with id: 999",
-      "timestamp": "2026-01-11T10:00:00Z"
-    }
-    ```
+## Base URL and Versioning
 
-- **Update Lift System**: `PUT /api/v1/lift-systems/{id}`
-  - Updates lift system metadata (display name and description)
-  - Request body:
-    ```json
-    {
-      "displayName": "Updated Building A Lift System",
-      "description": "Updated description"
-    }
-    ```
-  - Response (200 OK): Updated lift system details
-  - Note: System key cannot be changed after creation
+All application endpoints use the `/api/v1` base path (base URL `http://localhost:8080/api/v1`) unless otherwise noted. The version is carried in the URL path; a future breaking revision would be published under a new prefix (`/api/v2`) so existing clients keep working. See [ADR-0020: URL-Based API Versioning](decisions/0020-url-based-api-versioning.md) for the rationale.
 
-- **Delete Lift System**: `DELETE /api/v1/lift-systems/{id}`
-  - Deletes a lift system and all its versions (cascade delete)
-  - Response (204 No Content): Success with no body
-  - Error (404 Not Found): If lift system doesn't exist
+## Authentication
 
-#### Version Management
+The backend requires authentication for all API access except the public endpoints listed below. Two mechanisms are used, selected by endpoint group:
 
-- **Create Version**: `POST /api/v1/lift-systems/{systemId}/versions`
-  - Creates a new version for a lift system
-  - Optionally clones configuration from an existing version
-  - Request body (with new config):
-    ```json
-    {
-      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2}",
-      "cloneFromVersionNumber": null
-    }
-    ```
-  - Request body (cloning from version):
-    ```json
-    {
-      "config": "{}",
-      "cloneFromVersionNumber": 1
-    }
-    ```
-  - Response (201 Created): includes `Location: /api/v1/lift-systems/{systemId}/versions/{versionNumber}`
-    ```json
-    {
-      "id": 1,
-      "liftSystemId": 1,
-      "versionNumber": 1,
-      "status": "DRAFT",
-      "isPublished": false,
-      "publishedAt": null,
-      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2}",
-      "createdAt": "2026-01-11T10:00:00Z",
-      "updatedAt": "2026-01-11T10:00:00Z"
-    }
-    ```
-  - Version numbers auto-increment per lift system
+| Endpoint group | Paths | Scheme |
+|----------------|-------|--------|
+| Admin / management | `/api/v1/**` (except `/api/v1/health`) | HTTP Basic |
+| Runtime & simulation execution | `/api/v1/runtime/**`, `/api/v1/simulation-runs/**` | API key header |
+| Public | `/api/v1/health`, static/frontend routes | none |
+| Actuator | `/actuator/**` | ADMIN-role HTTP Basic |
 
-- **Update Version Config**: `PUT /api/v1/lift-systems/{systemId}/versions/{versionNumber}`
-  - Updates the configuration JSON for a specific version
-  - Request body:
-    ```json
-    {
-      "config": "{\"minFloor\": 0, \"maxFloor\": 14, \"lifts\": 3}"
-    }
-    ```
-  - Response (200 OK): Updated version details
+Unauthenticated requests return **HTTP 401**; authenticated requests lacking permission return **HTTP 403**. Actuator endpoints (`/actuator/health`, `/actuator/info`, and any future `/actuator/**` exposure) return redacted health details unless authorised. Always use HTTPS in shared environments so HTTP Basic credentials and API keys are not exposed in transit.
 
-- **List Versions**: `GET /api/v1/lift-systems/{systemId}/versions`
-  - Returns all versions for a lift system, ordered by version number descending
-  - Response (200 OK):
-    ```json
-    [
-      {
-        "id": 2,
-        "liftSystemId": 1,
-        "versionNumber": 2,
-        "status": "DRAFT",
-        "isPublished": false,
-        "publishedAt": null,
-        "config": "{\"minFloor\": 0, \"maxFloor\": 14}",
-        "createdAt": "2026-01-11T11:00:00Z",
-        "updatedAt": "2026-01-11T11:00:00Z"
-      },
-      {
-        "id": 1,
-        "liftSystemId": 1,
-        "versionNumber": 1,
-        "status": "DRAFT",
-        "isPublished": false,
-        "publishedAt": null,
-        "config": "{\"minFloor\": 0, \"maxFloor\": 9}",
-        "createdAt": "2026-01-11T10:00:00Z",
-        "updatedAt": "2026-01-11T10:00:00Z"
-      }
-    ]
-    ```
+### HTTP Basic (Admin APIs)
 
-- **Get Version**: `GET /api/v1/lift-systems/{systemId}/versions/{versionNumber}`
-  - Returns a specific version by version number
-  - Response (200 OK): Version details
-  - Error (404 Not Found): If version doesn't exist
+Set credentials under `security.admin` in `application-dev.yml`, or via the `ADMIN_USERNAME` / `ADMIN_PASSWORD` environment variables. Configure additional users under `security.users`.
 
-- **Publish Version**: `POST /api/v1/lift-systems/{systemId}/versions/{versionNumber}/publish`
-  - Publishes a version after validating its configuration
-  - Automatically archives any previously published version for the same lift system
-  - Ensures exactly one published version per lift system at any given time
-  - Only versions with valid configurations can be published
-  - Response (200 OK): Published version details with `status: "PUBLISHED"` and `isPublished: true`
-  - Error (400 Bad Request with validation errors): If configuration is invalid
-  - Error (409 Conflict): If version is already published
-  - Note: Publishing is blocked if the configuration has validation errors
-  - Note: Previously published versions are automatically set to `status: "ARCHIVED"`
-
-#### Configuration Validation
-
-The backend includes a comprehensive validation framework for lift system configurations. All configurations are validated before being saved or published.
-
-- **Validate Configuration**: `POST /api/v1/config/validate`
-  - Validates a configuration JSON without persisting it
-  - Request body:
-    ```json
-    {
-      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2, \"travelTicksPerFloor\": 1, \"doorTransitionTicks\": 2, \"doorDwellTicks\": 3, \"doorReopenWindowTicks\": 2, \"homeFloor\": 0, \"idleTimeoutTicks\": 5, \"controllerStrategy\": \"NEAREST_REQUEST_ROUTING\", \"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}"
-    }
-    ```
-  - Response (200 OK) - Valid configuration:
-    ```json
-    {
-      "valid": true,
-      "errors": [],
-      "warnings": [
-        {
-          "field": "doorDwellTicks",
-          "message": "Door dwell ticks (1) is very low. Consider increasing to allow sufficient time for passengers.",
-          "severity": "WARNING"
-        }
-      ]
-    }
-    ```
-  - Response (200 OK) - Invalid configuration:
-    ```json
-    {
-      "valid": false,
-      "errors": [
-        {
-          "field": "maxFloor",
-          "message": "Maximum floor (0) must be greater than minimum floor (0)",
-          "severity": "ERROR"
-        },
-        {
-          "field": "doorReopenWindowTicks",
-          "message": "Door reopen window ticks (5) must not exceed door transition ticks (2)",
-          "severity": "ERROR"
-        }
-      ],
-      "warnings": []
-    }
-    ```
-
-#### Scenario Management
-
-Scenario payloads define passenger flow for UI-driven simulation runs. The scenario schema is separate from the batch `.scenario` files used by the CLI.
-
-- **Create Scenario**: `POST /api/v1/scenarios`
-  - Saves a scenario JSON payload after validation
-  - Request body:
-    ```json
-    {
-      "scenarioJson": {
-        "durationTicks": 60,
-        "passengerFlows": [
-          {
-            "startTick": 0,
-            "originFloor": 0,
-            "destinationFloor": 5,
-            "passengers": 3
-          }
-        ],
-        "seed": 42
-      }
-    }
-    ```
-  - Response (201 Created): includes `Location: /api/v1/scenarios/{id}`
-    ```json
-    {
-      "id": 1,
-      "scenarioJson": {
-        "durationTicks": 60,
-        "passengerFlows": [
-          {
-            "startTick": 0,
-            "originFloor": 0,
-            "destinationFloor": 5,
-            "passengers": 3
-          }
-        ],
-        "seed": 42
-      },
-      "simulationRunCount": 0,
-      "createdAt": "2026-01-11T10:00:00Z",
-      "updatedAt": "2026-01-11T10:00:00Z"
-    }
-    ```
-  - Error (409 Conflict): If a scenario with the same `name` already exists for the target lift system version. Scenario names must be unique within a lift system version.
-
-- **Update Scenario**: `PUT /api/v1/scenarios/{id}`
-  - Updates an existing scenario payload after validation
-  - Request body: same as create
-  - Response (200 OK): Updated scenario details
-  - Error (409 Conflict): If renaming the scenario would collide with another scenario's `name` in the same lift system version
-
-- **Get Scenario**: `GET /api/v1/scenarios/{id}`
-  - Returns a stored scenario by ID
-  - Response (200 OK): Scenario details, including `simulationRunCount` for deletion-impact warnings
-
-- **Get Scenario Run Count**: `GET /api/v1/scenarios/{id}/run-count`
-  - Returns the number of simulation runs that reference the scenario
-  - Response (200 OK): Numeric count used by clients before confirming destructive scenario deletion
-
-- **Delete Scenario**: `DELETE /api/v1/scenarios/{id}`
-  - Deletes the scenario and intentionally cascades its associated simulation-run history
-  - Associated run artefact directories are removed after the delete transaction commits so cascade-deleted runs do not leave orphaned files
-  - Clients should warn users with the run count before calling this endpoint
-  - Response (204 No Content): Scenario deleted
-
-#### Scenario Validation
-
-- **Validate Scenario**: `POST /api/v1/scenarios/validate`
-  - Validates a scenario JSON payload without saving it
-  - Request body:
-    ```json
-    {
-      "scenarioJson": {
-        "durationTicks": 60,
-        "passengerFlows": [
-          {
-            "startTick": 0,
-            "originFloor": 0,
-            "destinationFloor": 5,
-            "passengers": 3
-          }
-        ],
-        "seed": 42
-      }
-    }
-    ```
-  - Response (200 OK) - Valid scenario:
-    ```json
-    {
-      "valid": true,
-      "errors": [],
-      "warnings": []
-    }
-    ```
-  - Response (200 OK) - Invalid scenario:
-    ```json
-    {
-      "valid": false,
-      "errors": [
-        {
-          "field": "passengerFlows[0].startTick",
-          "message": "startTick must be less than durationTicks (60)",
-          "severity": "ERROR"
-        }
-      ],
-      "warnings": []
-    }
-    ```
-
-**Scenario Validation Rules:**
-
-| Field | Type | Constraints | Description |
-|-------|------|-------------|-------------|
-| `durationTicks` | Integer | Required, ≥ 1 | Total number of ticks to simulate |
-| `passengerFlows` | Array | Required, ≥ 1 entry | Passenger flow entries |
-| `passengerFlows[].startTick` | Integer | ≥ 0, < durationTicks | Tick when passengers arrive |
-| `passengerFlows[].originFloor` | Integer | Required | Origin floor for the flow |
-| `passengerFlows[].destinationFloor` | Integer | Required, ≠ origin | Destination floor for the flow |
-| `passengerFlows[].passengers` | Integer | Required, ≥ 1 | Number of passengers in the flow |
-| `seed` | Integer | Optional, ≥ 0 | Random seed for deterministic runs |
-
-#### Batch Input Generator
-
-The batch input generator converts stored scenario definitions and lift configurations into the legacy `.scenario` file format used by the CLI simulator. It exists as a backwards-compatibility bridge so scenarios authored through the UI/API can be replayed by the existing CLI batch infrastructure without manual conversion. It runs internally as part of starting a simulation run; there is no standalone public endpoint.
-
-| Direction | Format |
-|-----------|--------|
-| Input | Lift system version configuration plus scenario JSON (passenger flows) — see [Scenario Management](#scenario-management) for the scenario schema and field constraints |
-| Output | A `.scenario` file consumed by the CLI runner: a `key: value` configuration header followed by comma-delimited event rows of the form `<tick>, hall_call, <alias>, <originFloor>, <direction>`. See the Scenario Runner section in [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md) for running the generated file. |
-
-##### Configuration Structure
-
-All lift system configurations must conform to the following structure:
-
-```json
-{
-  "minFloor": 0,
-  "maxFloor": 9,
-  "lifts": 2,
-  "travelTicksPerFloor": 1,
-  "doorTransitionTicks": 2,
-  "doorDwellTicks": 3,
-  "doorReopenWindowTicks": 2,
-  "homeFloor": 0,
-  "idleTimeoutTicks": 5,
-  "controllerStrategy": "NEAREST_REQUEST_ROUTING",
-  "idleParkingMode": "PARK_TO_HOME_FLOOR"
-}
-```
-
-**Migration Guide (0.46.0 floor range update):**
-
-- Replace `floors` with explicit `minFloor` and `maxFloor`.
-  - For existing configs, set `minFloor` to `0` and `maxFloor` to `floors - 1`.
-- Ensure `homeFloor` is within the new range (`minFloor` to `maxFloor`).
-- Apply the Flyway migration `V2__migrate_floor_range_config.sql` to update stored configuration payloads.
-
-**Validation Rules:**
-
-| Field | Type | Constraints | Description |
-|-------|------|-------------|-------------|
-| `minFloor` | Integer | Required | Minimum floor in the building (can be negative for basements) |
-| `maxFloor` | Integer | > minFloor | Maximum floor in the building (must be greater than minFloor) |
-| `lifts` | Integer | ≥ 1 | Number of lift cars |
-| `travelTicksPerFloor` | Integer | ≥ 1 | Ticks required to travel one floor |
-| `doorTransitionTicks` | Integer | ≥ 1 | Ticks required for doors to open or close |
-| `doorDwellTicks` | Integer | ≥ 1 | Ticks doors stay open before closing |
-| `doorReopenWindowTicks` | Integer | ≥ 0, ≤ doorTransitionTicks | Window during door closing when doors can reopen |
-| `homeFloor` | Integer | minFloor ≤ homeFloor ≤ maxFloor | Idle parking floor (must be within floor range) |
-| `idleTimeoutTicks` | Integer | ≥ 0 | Ticks before idle parking behavior activates |
-| `controllerStrategy` | Enum | NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN | Controller algorithm |
-| `idleParkingMode` | Enum | STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR | Idle parking behavior |
-
-**Validation Features:**
-
-- **Structural Validation**: Ensures JSON is well-formed and all required fields are present
-- **Type Validation**: Validates field types and enum values
-  - **Domain Validation**: Enforces business rules and cross-field constraints
-  - doorReopenWindowTicks must not exceed doorTransitionTicks
-  - maxFloor must be greater than minFloor
-  - homeFloor must be within valid floor range (minFloor to maxFloor)
-- **Warnings**: Non-blocking suggestions for suboptimal configurations
-  - Low doorDwellTicks values
-  - More lifts than floors available in the range
-  - Low idleTimeoutTicks with PARK_TO_HOME_FLOOR mode
-  - Zero doorReopenWindowTicks (disables door reopening)
-
-**Automatic Validation:**
-
-Validation is automatically performed when:
-- Creating a new version (`POST /api/v1/lift-systems/{systemId}/versions`)
-- Updating a version's configuration (`PUT /api/v1/lift-systems/{systemId}/versions/{versionNumber}`)
-- Publishing a version (`POST /api/v1/lift-systems/{systemId}/versions/{versionNumber}/publish`)
-
-If validation fails with errors, the operation will be rejected with a 400 Bad Request response containing detailed error information. The response body uses the same `valid` / `errors` / `warnings` shape shown in the [Configuration Validation](#configuration-validation) examples above.
-
-#### API Key Authentication (Runtime & Simulation Execution)
+### API Key (Runtime & Simulation Execution)
 
 Runtime and simulation execution endpoints require an API key so they can be invoked from CLI tooling and automation.
 
-**Security Requirements:**
-- **Startup Validation**: The application requires `api.auth.key` to be configured and non-empty. If missing or blank, the application will fail to start with a clear error message.
-- **Secure Comparison**: API keys are compared using SHA-256 hashing with constant-time comparison to prevent timing attacks and credential leakage.
+- **Startup validation:** the application requires `api.auth.key` to be configured and non-empty. If it is missing or blank, the application fails to start with a clear error message.
+- **Secure comparison:** API keys are compared using SHA-256 hashing with constant-time comparison to prevent timing attacks and credential leakage.
 
 **Configuration:**
-- `api.auth.key` (required): API key value used for authentication. Must be non-empty and provided via environment variable or property file.
-- `api.auth.header` (optional, default: `X-API-Key`): Header name to read the key from
 
-**Setting Up API Key:**
+- `api.auth.key` (required): API key value. Must be non-empty and provided via environment variable or property file.
+- `api.auth.header` (optional, default `X-API-Key`): header name to read the key from.
 
-Generate a secure random API key (any method producing sufficient entropy is acceptable):
-
-```bash
-# Using OpenSSL (32 bytes of entropy)
-openssl rand -base64 32
-```
-
-Configure via environment variable:
+Generate a secure random key (any method with sufficient entropy is acceptable) and configure it via environment variable:
 
 ```bash
-export API_KEY="<your-generated-api-key>"
+export API_KEY="$(openssl rand -base64 32)"
 ```
 
 Or in `application-dev.yml`:
@@ -447,584 +61,160 @@ api:
     header: X-API-Key
 ```
 
-**Example (Simulation Run):**
+**Example (simulation run):**
+
 ```bash
-curl -H "X-API-Key: <your-api-key>" \\
-  -H "Content-Type: application/json" \\
-  -d '{"liftSystemId":1,"versionNumber":2,"scenarioId":3,"seed":12345}' \\
+curl -H "X-API-Key: <your-api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"liftSystemId":1,"versionNumber":2,"scenarioId":3,"seed":12345}' \
   http://localhost:8080/api/v1/simulation-runs
 ```
 
-**Example (Runtime Config):**
+**Example (runtime config):**
+
 ```bash
-curl -H "X-API-Key: <your-api-key>" \\
+curl -H "X-API-Key: <your-api-key>" \
   http://localhost:8080/api/v1/runtime/systems/{systemKey}/config
 ```
 
+The React admin UI sends both schemes from Vite environment variables when present; the backend ignores whichever header does not apply to a given endpoint, so a single client can send both. Because Vite inlines all `VITE_*` values into the browser bundle, frontend credentials are **not** a production security boundary — do not ship real admin passwords or API keys in a hosted SPA. Use a backend/session proxy or another server-side auth layer for hosted deployments. See [ADR-0018: API Key Authentication](decisions/0018-api-key-authentication-runtime-simulation.md).
 
-#### Simulation Run APIs
+## Role-Based Access Control
 
-The Simulation Run APIs enable UI to start simulations, poll their status, and access results/logs. These endpoints provide the complete lifecycle management for simulation execution.
+Admin APIs support role-based access control with two roles:
 
-### Standard Response DTOs
+| Role | Access |
+|------|--------|
+| `ADMIN` | Read and write |
+| `VIEWER` | Read-only |
 
-Controllers return typed DTOs for JSON payloads rather than ad-hoc maps. Error payloads use the shared `ErrorResponse` shape (`status`, `message`, `timestamp`), bean-validation failures use `ValidationErrorResponse` (`status`, `message`, `fieldErrors`, `timestamp`) where each `fieldErrors` entry is an array of messages so duplicate constraint failures are preserved, and validation endpoints continue to return typed validation responses containing `valid`, `errors`, and `warnings`. Create endpoints return `201 Created` with a `Location` header pointing at the created resource; the default CORS exposed-headers list includes `Location` so allowed browser clients can read it.
+Write methods (`POST`, `PUT`, `PATCH`, `DELETE`) require the `ADMIN` role; read methods (`GET`) are available to both roles. Configure multiple users under `security.users` in `application-dev.yml`. Keep credentials out of version control and prefer environment variables in production. See [ADR-0019: Spring Security Baseline](decisions/0019-spring-security-baseline.md), [ADR-0021: Role-Based Access Control](decisions/0021-role-based-access-control-rbac.md), and [ADR-0022: Explicit CORS and CSRF Policy](decisions/0022-explicit-cors-csrf-policy.md).
 
+## Rate Limiting
 
-For step-by-step CLI usage, UI-driven run workflows, artefact reproduction, the Morning Rush walkthrough, and troubleshooting scenarios, see [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md).
+The API is protected by a token-bucket rate limiter (Bucket4j) applied per client IP address. Separate limits apply to the admin and runtime/simulation-run API groups.
 
-**Key Features:**
-- Create and start simulation runs atomically
-- Poll run status with progress tracking
-- Cancel in-progress simulation runs
-- Retrieve structured results when completed
-- Access logs with optional tail functionality
-- List and manage simulation artefacts
-- Security controls to prevent path traversal attacks
+Default thresholds (configurable in `application.yml` or overridden per environment):
 
-##### Run Artefacts and Results Schema
+| API group | Default capacity | Refill |
+|-----------|-----------------|--------|
+| Admin (`/api/v1/**`) | 100 requests | 100 per 60 s |
+| Runtime / simulation-runs | 1 000 requests | 1 000 per 60 s |
 
-Run artefacts are stored on disk using the configured `simulation.artefacts.base-path` property
-(defaults to `./simulation-runs`). Each run folder is created at `{base-path}/run-{id}/` and contains:
+When the limit is exceeded the server responds with **HTTP 429 Too Many Requests** and includes:
 
-- `config.json` - exact configuration payload used
-- `scenario.json` - scenario payload for passenger flows
-- `run.log` - log output from the runner
-- `results.json` - structured summary of the simulation run for UI rendering
+- `Retry-After: <seconds>` — how long to wait before retrying
+- `X-RateLimit-Limit: <capacity>` — total bucket capacity
+- `X-RateLimit-Remaining: 0` — tokens remaining (always 0 on a 429)
 
-`results.json` provides a minimal, additive results schema suitable for UI consumption:
+**Configuration reference** (`application.yml`):
 
-```json
-{
-  "runSummary": {
-    "runId": 42,
-    "status": "SUCCEEDED",
-    "generatedAt": "2026-02-01T10:05:00Z",
-    "ticks": 120,
-    "durationTicks": 120,
-    "seed": 123,
-    "liftSystemId": 1,
-    "versionNumber": 3,
-    "scenarioId": 5
-  },
-  "kpis": {
-    "requestsTotal": 12,
-    "pickupRequestsServed": 12,
-    "pickupRequestsCancelled": 0,
-    "passengersServed": 12,
-    "passengersCancelled": 0,
-    "avgPickupWaitTicks": 4.5,
-    "maxPickupWaitTicks": 11,
-    "idleTicks": 30,
-    "movingTicks": 50,
-    "doorTicks": 40,
-    "pickupLegUtilisation": 0.75
-  },
-  "perLift": [
-    {
-      "liftId": "lift-1",
-      "minFloor": 0,
-      "maxFloor": 10,
-      "homeFloor": 0,
-      "travelTicksPerFloor": 1,
-      "doorTransitionTicks": 2,
-      "doorDwellTicks": 3,
-      "doorReopenWindowTicks": 2,
-      "controllerStrategy": "NEAREST_REQUEST_ROUTING",
-      "idleParkingMode": "PARK_TO_HOME_FLOOR",
-      "statusCounts": {
-        "IDLE": 30,
-        "MOVING_UP": 25,
-        "MOVING_DOWN": 25,
-        "DOORS_OPENING": 8,
-        "DOORS_OPEN": 20,
-        "DOORS_CLOSING": 12
-      },
-      "totalTicks": 120,
-      "idleTicks": 30,
-      "movingTicks": 50,
-      "doorTicks": 40,
-      "pickupLegUtilisation": 0.75
-    }
-  ],
-  "perFloor": [
-    {
-      "floor": 0,
-      "originPassengers": 5,
-      "destinationPassengers": 2,
-      "liftVisits": 12
-    }
-  ]
-}
+```yaml
+rate-limiting:
+  enabled: true               # set to false to disable entirely (e.g. in integration tests)
+  trust-forwarded-for: false  # set to true only behind a trusted reverse proxy
+  max-buckets-per-group: 10000 # caps retained client-IP buckets per API group
+  admin:
+    capacity: 100             # bucket capacity (max burst)
+    refill-tokens: 100        # tokens added per period
+    refill-period-seconds: 60
+  runtime:
+    capacity: 1000
+    refill-tokens: 1000
+    refill-period-seconds: 60
 ```
 
-- `runSummary` includes tick counts, duration, seed, and lift system/version references.
-- `kpis` includes pickup-request counts, wait-to-pickup latency, and pickup-leg utilisation from the simulation run; passenger destinations are counted in per-floor totals but destination travel is not simulated yet.
-- `perLift` contains single-lift state counts and configuration metadata (one entry for now).
-- `perFloor` aggregates passenger origins/destinations and lift visit counts per floor (counted on floor changes).
+**`trust-forwarded-for`** — when `false` (the default), the rate-limiter uses `getRemoteAddr()` as the bucket key, which prevents callers from bypassing limits by spoofing `X-Forwarded-For`. Set it to `true` only when the service runs exclusively behind a trusted reverse proxy that controls this header. Override individual fields per Spring profile to tighten limits in production or loosen them for load testing.
 
----
+## Request and Artefact Size Limits
 
-##### List Simulation Runs
+The backend rejects oversized API request bodies before JSON deserialization and constrains Jackson JSON nesting/string sizes to reduce denial-of-service risk from very large or deeply nested payloads. By default, `/api/v1/**` and `/actuator/**` request bodies are capped at **1 MiB** and oversized requests receive **HTTP 413 Content Too Large**.
 
-**Endpoint:** `GET /api/v1/simulation-runs`
-
-Lists simulation runs with optional `systemId` and `status` filters. The endpoint returns a Spring Data `Page` envelope and supports capped pagination with `page` (0-based) and `size` (default `20`, maximum `100`).
-
-**Sorting:** pass one or more `sort` query parameters in the Spring Data format, for example `sort=createdAt,desc` or `sort=status,asc&sort=id,desc`. Supported sort properties are allowlisted to `createdAt`, `startedAt`, `endedAt`, `status`, and `id`. Unsupported properties or `ignorecase` sort modifiers return `400 Bad Request` with the allowed property list.
-
-**Example:**
-```http
-GET /api/v1/simulation-runs?page=0&size=20&sort=createdAt,desc
-X-API-Key: <api-key>
+```yaml
+request-size-limits:
+  enabled: true
+  max-body-bytes: 1048576
 ```
 
----
+Simulation artefact reads are also bounded: full log reads and `results.json` parsing are capped at **1 MiB** each. Prefer the `tail` query parameter for large logs; `tail` accepts values from `1` to `10000`, rejects out-of-range values with HTTP 400, and tailed log reads remain capped by line count without materializing the entire file in memory.
 
-##### Create and Start Simulation Run
+## Response Conventions
 
-**Endpoint:** `POST /api/v1/simulation-runs`
+Controllers return typed DTOs for JSON payloads rather than ad-hoc maps.
 
-Creates a new simulation run, sets up the artefact directory, and immediately starts execution.
-All simulation run endpoints require the configured API key header.
+- **Create endpoints** return `201 Created` with a `Location` header pointing at the created resource (for example `Location: /api/v1/lift-systems/{id}`). The default CORS exposed-headers list includes `Location` so allowed browser clients can read it.
+- **Runtime simulator launches** return `202 Accepted`.
+- **Deletes** return `204 No Content`.
 
-**Request Body:**
-```json
-{
-  "liftSystemId": 1,
-  "liftSystemName": "Downtown Tower",
-  "versionId": 2,
-  "versionNumber": 2,
-  "scenarioId": 3,
-  "scenarioName": "Morning Rush",
-  "seed": 12345
-}
-```
+### Pagination and Sorting
 
-**Request Fields:**
-- `liftSystemId` (required): ID of the lift system to simulate
-- `versionNumber` (required): version number to use within the selected lift system
-- `scenarioId` (optional): ID of the scenario to run (null for ad-hoc runs)
-- `seed` (optional): Random seed for reproducibility (auto-generated if not provided)
+List endpoints that support paging (for example `GET /api/v1/simulation-runs`) return a Spring Data `Page` envelope and accept:
 
-**Response (201 Created):** includes `Location: /api/v1/simulation-runs/{id}`
-```json
-{
-  "id": 1,
-  "liftSystemId": 1,
-  "liftSystemName": "Downtown Tower",
-  "versionId": 2,
-  "versionNumber": 2,
-  "scenarioId": 3,
-  "scenarioName": "Morning Rush",
-  "status": "RUNNING",
-  "createdAt": "2026-01-23T10:00:00Z",
-  "startedAt": "2026-01-23T10:00:01Z",
-  "endedAt": null,
-  "totalTicks": 10000,
-  "currentTick": 0,
-  "seed": 12345,
-  "errorMessage": null
-}
-```
+- `page` — 0-based page index
+- `size` — page size (default `20`, maximum `100`)
+- `sort` — one or more parameters in Spring Data format, for example `sort=createdAt,desc` or `sort=status,asc&sort=id,desc`
 
-**Status Values:**
+Sortable properties are allowlisted per endpoint. Unsupported properties or `ignorecase` sort modifiers return **HTTP 400 Bad Request** with the list of allowed properties.
 
-| Status | Description |
-|--------|-------------|
-| `CREATED` | Run created but not yet started |
-| `RUNNING` | Simulation is currently executing |
-| `SUCCEEDED` | Simulation completed successfully |
-| `FAILED` | Simulation failed with error |
-| `CANCELLED` | Simulation was cancelled |
+## Error Response Structure
 
----
+Error payloads use the shared `ErrorResponse` shape:
 
-##### Get Simulation Run Status
-
-**Endpoint:** `GET /api/v1/simulation-runs/{id}`
-
-Retrieves the current status and details of a simulation run, including progress information.
-
-**Response (200 OK):**
-```json
-{
-  "id": 1,
-  "liftSystemId": 1,
-  "liftSystemName": "Downtown Tower",
-  "versionId": 2,
-  "versionNumber": 2,
-  "scenarioId": 3,
-  "scenarioName": "Morning Rush",
-  "status": "RUNNING",
-  "createdAt": "2026-01-23T10:00:00Z",
-  "startedAt": "2026-01-23T10:00:01Z",
-  "endedAt": null,
-  "totalTicks": 10000,
-  "currentTick": 5432,
-  "seed": 12345,
-  "errorMessage": null
-}
-```
-
-**Progress Calculation:**
-- Progress percentage: `(currentTick / totalTicks) × 100`
-- Example: `(5432 / 10000) × 100 = 54.32%`
-
-**Error Response (404 Not Found):**
 ```json
 {
   "status": 404,
-  "message": "Simulation run not found with id: 999",
-  "timestamp": "2026-01-23T10:00:00Z"
+  "message": "Lift system not found with id: 999",
+  "timestamp": "2026-01-11T10:00:00Z"
 }
 ```
 
----
+Bean-validation failures use `ValidationErrorResponse`, where each `fieldErrors` entry is an array of messages so duplicate constraint failures are preserved:
 
-##### Cancel Simulation Run
-
-**Endpoint:** `POST /api/v1/simulation-runs/{id}/cancel`
-
-Cancels a running simulation run and transitions it to a terminal `CANCELLED` state.
-
-**Response (200 OK):**
 ```json
 {
-  "id": 1,
-  "liftSystemId": 1,
-  "liftSystemName": "Downtown Tower",
-  "versionId": 2,
-  "versionNumber": 2,
-  "scenarioId": 3,
-  "scenarioName": "Morning Rush",
-  "status": "CANCELLED",
-  "createdAt": "2026-01-23T10:00:00Z",
-  "startedAt": "2026-01-23T10:00:01Z",
-  "endedAt": "2026-01-23T10:05:00Z",
-  "totalTicks": 10000,
-  "currentTick": 4321,
-  "seed": 12345,
-  "errorMessage": null
-}
-```
-
-**Error Response (409 Conflict):**
-```json
-{
-  "status": 409,
-  "message": "Can only cancel a run in CREATED or RUNNING state. Current state: SUCCEEDED",
-  "timestamp": "2026-01-23T10:05:30Z"
-}
-```
-
----
-
-
-##### Delete Simulation Run
-
-**Endpoint:** `DELETE /api/v1/simulation-runs/{id}`
-
-Deletes a terminal simulation-run database record. Only runs in `SUCCEEDED`, `FAILED`, or `CANCELLED` state can be deleted; `CREATED` and `RUNNING` runs return `409 Conflict`.
-
-Artefact cleanup is intentionally best-effort and runs only after the delete transaction commits, so rollback or commit failures cannot remove files for a surviving run row. If post-commit artefact deletion fails, the API response still reflects the committed database delete and the server logs a warning with the run id and artefact path for operator cleanup.
-
-**Response:** `204 No Content`
-
-**Error Response (409 Conflict):**
-```json
-{
-  "status": 409,
-  "message": "Cannot delete a simulation run in RUNNING state. Only completed runs (SUCCEEDED, FAILED, CANCELLED) can be deleted.",
-  "timestamp": "2026-01-23T10:05:30Z"
-}
-```
-
----
-
-##### Get Simulation Results
-
-**Endpoint:** `GET /api/v1/simulation-runs/{id}/results`
-
-Retrieves the results of a simulation run. Response varies based on run status.
-
-**Response for SUCCEEDED (200 OK):**
-```json
-{
-  "runId": 1,
-  "status": "SUCCEEDED",
-  "results": {
-    "totalPassengersServed": 150,
-    "averageWaitTime": 12.5,
-    "maxWaitTime": 45.2,
-    "liftsUtilization": {
-      "lift1": 0.85,
-      "lift2": 0.78
-    }
+  "status": 400,
+  "message": "Validation failed",
+  "fieldErrors": {
+    "size": ["must be less than or equal to 100"]
   },
-  "errorMessage": null,
-  "logsUrl": "/api/simulation-runs/1/logs"
+  "timestamp": "2026-01-11T10:00:00Z"
 }
 ```
 
-**Response for SUCCEEDED without results file (200 OK):**
+Configuration- and scenario-validation endpoints return a typed validation response with `valid`, `errors`, and `warnings`. `errors` block the operation; `warnings` are non-blocking suggestions:
+
 ```json
 {
-  "runId": 1,
-  "status": "SUCCEEDED",
-  "results": null,
-  "errorMessage": "Results file not available: No results file found for simulation run 1",
-  "logsUrl": "/api/simulation-runs/1/logs"
-}
-```
-
-*Note: If a simulation completed successfully but the results file cannot be read (e.g., file not found, permission denied), the response preserves the SUCCEEDED status while indicating results are unavailable via errorMessage.*
-
-**Response for FAILED (200 OK):**
-```json
-{
-  "runId": 1,
-  "status": "FAILED",
-  "results": null,
-  "errorMessage": "Simulation engine crashed at tick 1234",
-  "logsUrl": "/api/simulation-runs/1/logs"
-}
-```
-
-**Response for RUNNING (409 Conflict):**
-```json
-{
-  "runId": 1,
-  "status": "RUNNING",
-  "results": null,
-  "errorMessage": "Simulation is still running",
-  "logsUrl": null
-}
-```
-
-**Response for CREATED/CANCELLED (400 Bad Request):**
-```json
-{
-  "runId": 1,
-  "status": "CREATED",
-  "results": null,
-  "errorMessage": "Results not available for CREATED runs",
-  "logsUrl": null
-}
-```
-
----
-
-##### Get Simulation Logs
-
-**Endpoint:** `GET /api/v1/simulation-runs/{id}/logs?tail=N`
-
-Retrieves simulation logs with optional tail functionality.
-
-**Query Parameters:**
-- `tail` (optional): Number of lines to retrieve from end of log
-  - Default: All lines
-  - Minimum: 1 line
-  - Maximum: 10,000 lines
-  - Values below 1 or above 10,000 return HTTP 400 with a validation error response
-  - Large tails are buffered with fixed-size deque storage, so reading the last lines of large logs uses bounded memory and linear time.
-
-**Response (200 OK):**
-```json
-{
-  "runId": 1,
-  "logs": "Starting simulation...\nTick 0: Initializing lifts\nTick 1: Processing requests\n...",
-  "tail": 100,
-  "error": null
-}
-```
-
-**Log File:**
-- `run.log`
-
-**Error Response (500 Internal Server Error):**
-```json
-{
-  "runId": 1,
-  "logs": null,
-  "tail": null,
-  "error": "Failed to read logs: Artefact base path is not set for run 1"
-}
-```
-
-**Example Usage:**
-```bash
-# Get all logs
-curl http://localhost:8080/api/simulation-runs/1/logs
-
-# Get last 100 lines
-curl http://localhost:8080/api/simulation-runs/1/logs?tail=100
-```
-
----
-
-##### List Simulation Artefacts
-
-**Endpoint:** `GET /api/v1/simulation-runs/{id}/artefacts`
-
-Lists all artefacts (downloadable files) associated with a simulation run.
-
-**Response (200 OK):**
-```json
-[
-  {
-    "name": "results.json",
-    "path": "results.json",
-    "size": 1024,
-    "mimeType": "application/json"
-  },
-  {
-    "name": "run.log",
-    "path": "run.log",
-    "size": 5120,
-    "mimeType": "text/plain"
-  },
-  {
-    "name": "input.scenario",
-    "path": "input.scenario",
-    "size": 2048,
-    "mimeType": "text/plain"
-  }
-]
-```
-
-**Artefact Structure:**
-- `name`: File name
-- `path`: Relative path within artefact directory
-- `size`: File size in bytes
-- `mimeType`: MIME type based on file extension
-
-**Supported MIME Types:**
-- `.json` → `application/json`
-- `.txt`, `.log` → `text/plain`
-- `.csv` → `text/csv`
-- `.scenario` → `text/plain`
-- Others → `application/octet-stream`
-
-**Empty Directory Response (200 OK):**
-```json
-[]
-```
-
----
-
-##### Download Simulation Artefact
-
-**Endpoint:** `GET /api/v1/simulation-runs/{id}/artefacts/{path}`
-
-Downloads a specific artefact file for a simulation run. The `{path}` value should match the
-`path` field returned by the artefact list endpoint.
-
-**Response (200 OK):**
-- Binary file content with `Content-Disposition: attachment` and the appropriate MIME type.
-
-**Error Responses:**
-- **404 Not Found** when the artefact does not exist.
-- **400 Bad Request** when the artefact path is invalid or attempts path traversal.
-- **409 Conflict** when the run artefact base path is not configured.
-
-**Example Usage:**
-```bash
-curl -O http://localhost:8080/api/simulation-runs/1/artefacts/results.json
-```
-
----
-
-**Security Features:**
-- **Path Traversal Prevention**: All file access paths are normalized and validated
-- **Directory Isolation**: Artefacts are restricted to run-specific directories
-- **Secure Resolution**: Attempts to access files outside the artefact directory are blocked
-
-**Configuration:**
-```yaml
-# Base directory for simulation artefacts (application.yml)
-simulation:
-  artefacts:
-    base-path: ./simulation-runs
-```
-
-For the layout of each run folder and the files it contains, see [Run Artefacts and Results Schema](#run-artefacts-and-results-schema) above.
-
----
-
-#### Runtime Configuration API
-
-The backend provides dedicated runtime APIs for retrieving published configurations. These APIs are read-only and return only configurations with `PUBLISHED` status.
-Runtime endpoints require the configured API key header (default `X-API-Key`).
-
-Example:
-```bash
-curl -H "X-API-Key: replace-with-secure-key" \\
-  http://localhost:8080/api/v1/runtime/systems/building-a-lifts/config
-```
-
-- **Get Published Configuration**: `GET /api/v1/runtime/systems/{systemKey}/config`
-  - Retrieves the currently published configuration for a lift system by system key
-  - Returns the latest published version
-  - Response (200 OK):
-    ```json
+  "valid": false,
+  "errors": [
     {
-      "systemKey": "building-a-lifts",
-      "displayName": "Building A Lift System",
-      "versionNumber": 3,
-      "config": "{\"minFloor\": 0, \"maxFloor\": 9, \"lifts\": 2, \"travelTicksPerFloor\": 1, \"doorTransitionTicks\": 2, \"doorDwellTicks\": 3, \"doorReopenWindowTicks\": 2, \"homeFloor\": 0, \"idleTimeoutTicks\": 5, \"controllerStrategy\": \"NEAREST_REQUEST_ROUTING\", \"idleParkingMode\": \"PARK_TO_HOME_FLOOR\"}",
-      "publishedAt": "2026-01-11T14:30:00Z"
+      "field": "maxFloor",
+      "message": "Maximum floor (0) must be greater than minimum floor (0)",
+      "severity": "ERROR"
     }
-    ```
-  - Error (404 Not Found):
-    - If lift system with the given key doesn't exist
-    - If no published version exists for the system
-    ```json
-    {
-      "status": 404,
-      "message": "No published version found for lift system: building-a-lifts",
-      "timestamp": "2026-01-11T15:00:00Z"
-    }
-    ```
+  ],
+  "warnings": []
+}
+```
 
-- **Get Specific Published Version**: `GET /api/v1/runtime/systems/{systemKey}/versions/{versionNumber}`
-  - Retrieves a specific version by system key and version number
-  - Only returns the version if it is currently published
-  - Response (200 OK): Same format as above
-  - Error (404 Not Found):
-    - If lift system doesn't exist
-    - If version doesn't exist
-    - If version exists but is not published (status is DRAFT or ARCHIVED)
-    ```json
-    {
-      "status": 404,
-      "message": "Version 2 is not published for lift system: building-a-lifts",
-      "timestamp": "2026-01-11T15:00:00Z"
-    }
-    ```
+The same `valid` / `errors` / `warnings` shape is returned when validation runs implicitly while creating, updating, or publishing a version (a `400 Bad Request` with the error detail).
 
-**Design Notes:**
-- Runtime APIs use system key (not internal ID) for lookups
-- Runtime APIs are read-only - no create, update, or delete operations
-- Only published configurations are returned - draft and archived versions are hidden
-- Lightweight response format optimized for runtime consumption
-- Clear separation between admin APIs (management) and runtime APIs (consumption)
+### Common Status Codes
 
-**Use Cases:**
-- Lift simulator runtime fetching current configuration on startup
-- Admin UI launching a local simulator instance for a published configuration
-- Configuration service providing settings to running lift systems
-- Monitoring systems checking which configuration version is active
-- API clients that should only see production-ready configurations
+| Status | Meaning |
+|--------|---------|
+| `200 OK` | Successful read or update |
+| `201 Created` | Resource created (includes `Location` header) |
+| `202 Accepted` | Runtime simulator launch accepted |
+| `204 No Content` | Successful delete |
+| `400 Bad Request` | Validation error or malformed request |
+| `401 Unauthorized` | Missing or invalid credentials |
+| `403 Forbidden` | Authenticated but insufficient role |
+| `404 Not Found` | Resource does not exist |
+| `409 Conflict` | State conflict (e.g. already published, non-terminal run, duplicate name) |
+| `413 Content Too Large` | Request body exceeds the configured size limit |
+| `429 Too Many Requests` | Rate limit exceeded (includes `Retry-After`) |
 
+## Schema Reference and Operational Details
 
-#### Health & Monitoring
-
-- **Custom Health Check**: `GET /api/v1/health`
-  - Returns custom health status with service name and timestamp
-- **Actuator Health**: `GET /actuator/health`
-  - Requires ADMIN-role HTTP Basic authentication
-  - Returns Spring Boot actuator health information with details only when authorized
-- **Actuator Info**: `GET /actuator/info`
-  - Requires ADMIN-role HTTP Basic authentication
-  - Returns application information
+The lift-configuration and scenario schemas (field constraints, validation rules, the floor-range migration note, and the batch-input-generator format), the run-artefact directory layout, and the `results.json` schema are documented in [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md#configuration-and-scenario-schema-reference). Step-by-step CLI usage, UI-driven run workflows, artefact reproduction, and troubleshooting live in the same guide.

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.6.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.7.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -7,11 +7,15 @@ This guide explains how to run Lift Simulator simulations from the command line 
 - [CLI and UI-Run Workflows](#cli-and-ui-run-workflows)
   - [Overview](#overview)
   - [CLI Usage (Unchanged)](#cli-usage-unchanged)
-  - [UI-Driven Run Workflow](#ui-driven-run-workflow)
+  - [UI-Driven Run Workflow](#ui-driven-run-workflow-new-in-v0460)
   - [Artefact Storage](#artefact-storage)
   - [Reproducing UI Runs via CLI](#reproducing-ui-runs-via-cli)
   - [Example Scenario Walkthrough: Morning Rush Hour](#example-scenario-walkthrough-morning-rush-hour)
   - [Troubleshooting](#troubleshooting)
+- [Configuration and Scenario Schema Reference](#configuration-and-scenario-schema-reference)
+  - [Lift Configuration Schema](#lift-configuration-schema)
+  - [Scenario Payload Schema](#scenario-payload-schema)
+  - [Batch Input Generator Format](#batch-input-generator-format)
 - [General Troubleshooting](#general-troubleshooting)
   - [Quick Start Troubleshooting](#quick-start-troubleshooting)
   - [Database Troubleshooting](#database-troubleshooting)
@@ -46,7 +50,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.6.jar \
+java -cp target/lift-simulator-0.57.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -60,12 +64,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.6.jar \
+java -cp target/lift-simulator-0.57.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.6.jar \
+java -cp target/lift-simulator-0.57.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -109,7 +113,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.6.jar \
+java -cp target/lift-simulator-0.57.7.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -387,7 +391,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.6.jar \
+   java -cp target/lift-simulator-0.57.7.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -432,7 +436,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.6.jar \
+java -cp target/lift-simulator-0.57.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -524,7 +528,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.6.jar \
+java -cp target/lift-simulator-0.57.7.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```
@@ -856,6 +860,107 @@ seed must be a valid integer
 - Use exact same seed from UI run
 - Verify all configuration parameters match
 - Rebuild CLI JAR if versions don't match: `mvn clean package`
+
+---
+
+## Configuration and Scenario Schema Reference
+
+This section documents the payload schemas that clients construct when creating lift-system versions, authoring scenarios, and reproducing runs. The field constraints below are enforced by the backend validation framework and are surfaced in the generated OpenAPI spec; they are collected here as human-readable reference. For the API conventions that govern these payloads (auth, error shape, size limits), see [API Conventions](API.md).
+
+### Lift Configuration Schema
+
+All lift system configurations must conform to the following structure:
+
+```json
+{
+  "minFloor": 0,
+  "maxFloor": 9,
+  "lifts": 2,
+  "travelTicksPerFloor": 1,
+  "doorTransitionTicks": 2,
+  "doorDwellTicks": 3,
+  "doorReopenWindowTicks": 2,
+  "homeFloor": 0,
+  "idleTimeoutTicks": 5,
+  "controllerStrategy": "NEAREST_REQUEST_ROUTING",
+  "idleParkingMode": "PARK_TO_HOME_FLOOR"
+}
+```
+
+**Field constraints:**
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `minFloor` | Integer | Required | Minimum floor in the building (can be negative for basements) |
+| `maxFloor` | Integer | > minFloor | Maximum floor in the building (must be greater than minFloor) |
+| `lifts` | Integer | ≥ 1 | Number of lift cars |
+| `travelTicksPerFloor` | Integer | ≥ 1 | Ticks required to travel one floor |
+| `doorTransitionTicks` | Integer | ≥ 1 | Ticks required for doors to open or close |
+| `doorDwellTicks` | Integer | ≥ 1 | Ticks doors stay open before closing |
+| `doorReopenWindowTicks` | Integer | ≥ 0, ≤ doorTransitionTicks | Window during door closing when doors can reopen |
+| `homeFloor` | Integer | minFloor ≤ homeFloor ≤ maxFloor | Idle parking floor (must be within floor range) |
+| `idleTimeoutTicks` | Integer | ≥ 0 | Ticks before idle parking behavior activates |
+| `controllerStrategy` | Enum | NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN | Controller algorithm |
+| `idleParkingMode` | Enum | STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR | Idle parking behavior |
+
+**Validation features:**
+
+- **Structural validation:** ensures JSON is well-formed and all required fields are present.
+- **Type validation:** validates field types and enum values.
+- **Domain validation:** enforces business rules and cross-field constraints — `doorReopenWindowTicks` must not exceed `doorTransitionTicks`, `maxFloor` must be greater than `minFloor`, and `homeFloor` must be within the floor range.
+- **Warnings** (non-blocking): low `doorDwellTicks`, more lifts than floors available in the range, low `idleTimeoutTicks` with `PARK_TO_HOME_FLOOR` mode, and zero `doorReopenWindowTicks` (which disables door reopening).
+
+Validation runs automatically when creating a new version, updating a version's configuration, or publishing a version. If it fails with errors, the operation is rejected with a `400 Bad Request` using the `valid` / `errors` / `warnings` shape documented in [API Conventions](API.md#error-response-structure). To validate without persisting, `POST` the config to the validation endpoint (see the generated OpenAPI spec).
+
+**Migration note (0.46.0 floor-range update):**
+
+- Replace `floors` with explicit `minFloor` and `maxFloor`. For existing configs, set `minFloor` to `0` and `maxFloor` to `floors - 1`.
+- Ensure `homeFloor` is within the new range (`minFloor` to `maxFloor`).
+- Apply the Flyway migration `V2__migrate_floor_range_config.sql` to update stored configuration payloads.
+
+### Scenario Payload Schema
+
+Scenario payloads define passenger flow for UI-driven simulation runs. The scenario schema is separate from the batch `.scenario` files used by the CLI. A scenario JSON payload has the shape:
+
+```json
+{
+  "durationTicks": 60,
+  "passengerFlows": [
+    {
+      "startTick": 0,
+      "originFloor": 0,
+      "destinationFloor": 5,
+      "passengers": 3
+    }
+  ],
+  "seed": 42
+}
+```
+
+**Field constraints:**
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `durationTicks` | Integer | Required, ≥ 1 | Total number of ticks to simulate |
+| `passengerFlows` | Array | Required, ≥ 1 entry | Passenger flow entries |
+| `passengerFlows[].startTick` | Integer | ≥ 0, < durationTicks | Tick when passengers arrive |
+| `passengerFlows[].originFloor` | Integer | Required | Origin floor for the flow |
+| `passengerFlows[].destinationFloor` | Integer | Required, ≠ origin | Destination floor for the flow |
+| `passengerFlows[].passengers` | Integer | Required, ≥ 1 | Number of passengers in the flow |
+| `seed` | Integer | Optional, ≥ 0 | Random seed for deterministic runs |
+
+Scenario names must be unique within a lift system version; a create or rename that collides returns `409 Conflict`. Deleting a scenario intentionally cascades its associated simulation-run history, and clients should warn users with the run count (available from the run-count endpoint) before deleting.
+
+### Batch Input Generator Format
+
+The batch input generator converts stored scenario definitions and lift configurations into the legacy `.scenario` file format used by the CLI simulator. It exists as a backwards-compatibility bridge so scenarios authored through the UI/API can be replayed by the existing CLI batch infrastructure without manual conversion. It runs internally as part of starting a simulation run; there is no standalone public endpoint.
+
+| Direction | Format |
+|-----------|--------|
+| Input | Lift system version configuration plus scenario JSON (passenger flows) — see [Scenario Payload Schema](#scenario-payload-schema) for field constraints |
+| Output | A `.scenario` file consumed by the CLI runner: a `key: value` configuration header followed by comma-delimited event rows of the form `<tick>, hall_call, <alias>, <originFloor>, <direction>`. See [CLI Usage](#cli-usage-unchanged) for running the generated file. |
+
+Generated `input.scenario` artefacts skip same-floor passenger flows so CLI reproduction matches the in-process executor.
 
 ---
 

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -875,7 +875,7 @@ All lift system configurations must conform to the following structure:
 {
   "minFloor": 0,
   "maxFloor": 9,
-  "lifts": 2,
+  "lifts": 1,
   "travelTicksPerFloor": 1,
   "doorTransitionTicks": 2,
   "doorDwellTicks": 3,
@@ -893,7 +893,7 @@ All lift system configurations must conform to the following structure:
 |-------|------|-------------|-------------|
 | `minFloor` | Integer | Required | Minimum floor in the building (can be negative for basements) |
 | `maxFloor` | Integer | > minFloor | Maximum floor in the building (must be greater than minFloor) |
-| `lifts` | Integer | ≥ 1 | Number of lift cars |
+| `lifts` | Integer | Exactly `1` | Number of lift cars. Multi-lift simulation is not supported in v1.0.0, so any value other than `1` is rejected with a validation error |
 | `travelTicksPerFloor` | Integer | ≥ 1 | Ticks required to travel one floor |
 | `doorTransitionTicks` | Integer | ≥ 1 | Ticks required for doors to open or close |
 | `doorDwellTicks` | Integer | ≥ 1 | Ticks doors stay open before closing |
@@ -908,7 +908,7 @@ All lift system configurations must conform to the following structure:
 - **Structural validation:** ensures JSON is well-formed and all required fields are present.
 - **Type validation:** validates field types and enum values.
 - **Domain validation:** enforces business rules and cross-field constraints — `doorReopenWindowTicks` must not exceed `doorTransitionTicks`, `maxFloor` must be greater than `minFloor`, and `homeFloor` must be within the floor range.
-- **Warnings** (non-blocking): low `doorDwellTicks`, more lifts than floors available in the range, low `idleTimeoutTicks` with `PARK_TO_HOME_FLOOR` mode, and zero `doorReopenWindowTicks` (which disables door reopening).
+- **Warnings** (non-blocking): low `doorDwellTicks`, low `idleTimeoutTicks` with `PARK_TO_HOME_FLOOR` mode, and zero `doorReopenWindowTicks` (which disables door reopening).
 
 Validation runs automatically when creating a new version, updating a version's configuration, or publishing a version. If it fails with errors, the operation is rejected with a `400 Bad Request` using the `valid` / `errors` / `warnings` shape documented in [API Conventions](API.md#error-response-structure). To validate without persisting, `POST` the config to the validation endpoint (see the generated OpenAPI spec).
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,12 +13,11 @@ React-based admin interface for managing lift system configurations.
 This is the frontend admin application for the Lift Simulator system. It provides a web-based interface for:
 - Managing lift systems and configurations
 - Creating and publishing configuration versions
-- Validating configuration JSON
-- Displaying detailed validation errors when configuration JSON is invalid
+- Validating configuration JSON and displaying detailed validation errors
+- Managing simulation runs, including multi-select bulk cancellation for active runs and bulk deletion for completed runs
 - Monitoring system health
-- Reviewing per-system version counts in the Lift Systems list
-- Maintaining consistent form control alignment across scenario creation screens
-- Managing Simulation Runs with multi-select bulk cancellation for active runs and bulk deletion for completed runs
+
+For the overall project setup (backend, database, and Quick Start), see the [root README](../README.md). Backend REST API conventions (auth, RBAC, rate limits, error shape) live in [docs/API.md](../docs/API.md), and the always-current endpoint reference is the generated Swagger UI at `/api/v1/swagger-ui.html`.
 
 ## Versioning
 
@@ -81,7 +80,7 @@ VITE_ADMIN_PASSWORD=local-admin-password
 VITE_API_KEY=local-api-key
 ```
 
-The Axios client sends `Authorization: Basic ...` when both admin values are set and sends `X-API-Key` when `VITE_API_KEY` is set. Vite exposes `VITE_*` values in the browser bundle, so use these credentials only for local development or disposable environments. Anyone who can load a built SPA can inspect `VITE_ADMIN_PASSWORD` and `VITE_API_KEY`; do not deploy a hosted frontend bundle with real backend credentials. For hosted use, move authentication behind a backend/session proxy or another server-side auth layer, and never commit this file.
+The Axios client sends `Authorization: Basic ...` when both admin values are set and sends `X-API-Key` when `VITE_API_KEY` is set.
 
 > **⚠️ `VITE_*` variables ship in the bundle.** Vite inlines every `VITE_`-prefixed variable into the compiled JavaScript at build time — there is no server-side secret store. Anyone who loads the app can read `VITE_ADMIN_PASSWORD` and `VITE_API_KEY` from the shipped bundle. `npm run build` **fails** if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set for any `vite build` invocation, including a custom `--mode` (e.g. `--mode staging`), so a real credential can't accidentally end up in a deployed build. Use `VITE_*` credentials for local development or disposable environments only; for hosted deployments, authenticate through a backend/session proxy instead.
 
@@ -91,11 +90,11 @@ The Axios client sends `Authorization: Basic ...` when both admin values are set
 npm run dev
 ```
 
-The application will start on **http://localhost:3000**
+The application will start on **http://localhost:3000**.
 
 ### 4. Start Backend Service
 
-Make sure the Spring Boot backend is running on port 8080. The authenticated admin and simulation APIs require credentials even during E2E runs, so export backend credentials before starting Spring Boot. The matching browser-test credentials are injected by Playwright at test time, not by the application bundle:
+Make sure the Spring Boot backend is running on port 8080. The authenticated admin and simulation APIs require credentials, so export backend credentials before starting Spring Boot:
 
 ```bash
 export ADMIN_USERNAME=admin
@@ -125,150 +124,51 @@ The frontend uses **Playwright** for end-to-end (E2E) UI automation testing.
 
 ### Testing Strategy
 
-- **E2E tests (Playwright)**: Full user journeys against the running application
-- **Unit tests**: Components, hooks, and utility functions (future addition)
-- **Integration tests**: Page-level flows with mocked API calls (future addition)
+- **E2E tests (Playwright)**: Full user journeys against the running application, located in `e2e/*.spec.ts`
+- **Unit tests** (future): Components, hooks, and utilities as `*.test.jsx` alongside component files
+- **Integration tests** (future): Page-level flows with mocked API calls as `*.spec.jsx` in `src/__tests__/`
 
-### E2E Testing with Playwright
+### First-Time Setup
 
-Playwright is configured to test the application against a real browser. Tests are located in `e2e/*.spec.ts`.
-
-#### First-Time Setup
-
-Install Playwright browser binaries:
+Install Playwright browser binaries (once per machine):
 
 ```bash
-npx playwright install
+npx playwright install          # Chromium, Firefox, WebKit
+npx playwright install chromium # Chromium only, to save disk space
 ```
 
-This downloads Chromium, Firefox, and WebKit browsers. You only need to do this once per machine.
+### Running Tests
 
-> **Note:** If you only need Chromium, use `npx playwright install chromium` to save disk space.
-
-#### Running Tests
-
-Run all tests (headless mode) after the backend is running with matching Playwright-only credentials:
+Start the backend first (see step 4 above), then run Playwright with matching E2E-only credentials. Do **not** use `VITE_*` variables for E2E secrets — Vite exposes those to the browser bundle by design; the `E2E_*` variables are injected at browser-context level and are never bundled.
 
 ```bash
 export E2E_ADMIN_USERNAME=admin
 export E2E_ADMIN_PASSWORD=local-admin-password
 export E2E_API_KEY=local-api-key
-npm test
+npm test              # headless
+npm run test:headed   # with browser UI
+npm run test:ui       # interactive UI (recommended for debugging)
+npm run test:debug    # step-by-step debug
+npm run test:report   # view the HTML report
 ```
 
-Run tests with browser UI visible:
+The Playwright web server automatically starts the frontend dev server before tests and shuts it down afterward. Start the backend separately first so feature tests run instead of being skipped.
 
-```bash
-npm run test:headed
-```
-
-Run tests in interactive UI mode (recommended for debugging):
-
-```bash
-npm run test:ui
-```
-
-Run tests in debug mode with step-by-step execution:
-
-```bash
-npm run test:debug
-```
-
-View HTML test report:
-
-```bash
-npm run test:report
-```
-
-#### Configuration
+### Configuration
 
 Playwright is configured in `playwright.config.ts` with:
 
 - **Base URL**: http://localhost:3000
 - **API URL**: `/api/v1` by default, proxied by Vite to `http://localhost:8080/api/v1`
-- **Backend Health URL**: Feature tests check `http://localhost:8080/api/v1/health` before executing
-- **E2E Auth Headers**: Playwright injects optional `E2E_ADMIN_USERNAME`/`E2E_ADMIN_PASSWORD` Basic auth and `E2E_API_KEY` headers at browser-context level, and the Vite dev proxy mirrors those headers for `/api/v1` requests; these values are never read by app code or bundled by Vite
-- **Web Server**: Automatically starts `npm run dev` before tests
-- **Test Directory**: `e2e/`
+- **Backend Health URL**: feature tests check `http://localhost:8080/api/v1/health` before executing
+- **E2E Auth Headers**: Playwright injects optional `E2E_ADMIN_USERNAME`/`E2E_ADMIN_PASSWORD` Basic auth and `E2E_API_KEY` headers at browser-context level, mirrored by the Vite dev proxy for `/api/v1` requests; these values are never read by app code or bundled by Vite
 - **Retries on CI**: 2 retries to handle flaky tests
-- **Artifacts**: Screenshots and videos on failure, traces on retry
+- **Artifacts**: screenshots and videos on failure, traces on retry
 - **Browsers**: Chromium (default), with Firefox and WebKit commented out
 
-The configuration automatically starts the frontend dev server before running tests and shuts it down afterward. Start the backend separately first so feature tests run instead of being skipped.
+### Current Coverage and Structure
 
-#### CI Integration
-
-Playwright tests run automatically in GitHub Actions CI on:
-- Pull requests to main
-- Pushes to main
-
-**Test Reports in CI:**
-
-When tests run in CI, Playwright generates an HTML report that is uploaded as a GitHub Actions artifact. To view the report:
-
-1. Go to the [Actions tab](../../actions) in GitHub
-2. Click on the workflow run you want to inspect
-3. Scroll down to the "Artifacts" section at the bottom of the page
-4. Download the `playwright-report` artifact (available for 30 days)
-5. Extract the zip file and open `index.html` in your browser
-
-**Test Artifacts on Failure:**
-
-If tests fail, additional artifacts are uploaded:
-- Screenshots of failed tests
-- Videos of test execution
-- Playwright traces for debugging
-
-These are available in the `playwright-test-artifacts` artifact in the same location.
-
-**CI Behavior:**
-- The dedicated `e2e-playwright` job depends on successful backend and frontend jobs
-- CI provisions PostgreSQL, packages the Spring Boot JAR, starts the backend on port 8080, and waits for `/api/v1/health` before running Playwright
-- Test failures will fail the CI workflow and block PR merges
-- Tests run with 2 retries on CI to handle transient issues
-- Only Chromium browser is tested in CI (for speed and reliability)
-- The Playwright web server automatically starts the frontend on port 3000 before tests begin
-
-#### Test Structure & Naming
-
-- All E2E tests go in `e2e/*.spec.ts`
-- Unit tests (when added): `*.test.jsx` alongside component files
-- Integration tests (when added): `*.spec.jsx` in `src/__tests__/`
-
-Example structure:
-
-```
-frontend/
-  e2e/
-    smoke.spec.ts           # E2E smoke tests
-    lift-systems.spec.ts    # E2E tests for lift systems
-  src/
-    components/
-      SystemCard.jsx
-      SystemCard.test.jsx   # Unit tests (future)
-    __tests__/
-      integration.spec.jsx  # Integration tests (future)
-```
-
-#### Current Test Coverage
-
-**Smoke Tests** (`e2e/smoke.spec.ts`):
-- Application loads and displays dashboard
-- Navigation to Lift Systems page works
-- Health check page is accessible
-- Configuration validator page is accessible
-- Footer displays version information
-
-#### Example Scenarios to Cover
-
-- **E2E**: Create a new lift system, publish a version, and verify it appears in the versions list
-- **E2E**: Validate configuration JSON and check for error messages
-- **Unit** (future): Render a status badge with the correct color based on status
-- **Integration** (future): Load the Lift Systems list with mocked API responses and verify pagination
-
-#### Writing New Tests
-
-Create a new test file in `e2e/`:
+Smoke tests (`e2e/smoke.spec.ts`) cover: application loads and displays the dashboard, navigation to Lift Systems works, and the Health Check and Configuration Validator pages are accessible with the footer version shown. Add new tests as `e2e/*.spec.ts`:
 
 ```typescript
 import { test, expect } from '@playwright/test';
@@ -281,58 +181,19 @@ test.describe('Feature Name', () => {
 });
 ```
 
-See [Playwright documentation](https://playwright.dev/docs/writing-tests) for more details.
+See the [Playwright documentation](https://playwright.dev/docs/writing-tests) for more details.
 
 ### Future Testing Additions
 
 - **Unit tests**: Vitest + React Testing Library for component testing
 - **Integration tests**: Mock Service Worker (MSW) for API mocking
-- **Coverage**: Target ≥80% statement/branch coverage for new code
+- **Coverage**: target ≥80% statement/branch coverage for new code
 
 ## CI/CD
 
-The repository uses **GitHub Actions** with the CI workflow defined in
-`.github/workflows/ci.yml` and CodeQL security scanning defined in
-`.github/workflows/codeql.yml`.
+The frontend is built and tested as part of the repository-wide GitHub Actions pipeline (`.github/workflows/ci.yml`), which runs `npm ci`, `npm run lint`, `npm run build`, and the Playwright E2E job against a live backend, plus CodeQL security scanning (`.github/workflows/codeql.yml`). The Playwright HTML report and failure artifacts (screenshots, videos, traces) are uploaded as GitHub Actions artifacts, available under the **Artifacts** section of each workflow run for 30 days. For the full job breakdown and how to run the same checks locally, see the [root README Testing and Quality Checks sections](../README.md#testing).
 
-### What Runs on Pull Requests
-
-- **Backend**
-  - Unit tests, coverage report (JaCoCo), and coverage gate (`mvn verify`)
-  - SpotBugs static analysis
-  - Package build with the frontend profile (tests skipped for the final
-    package step), then upload the packaged JAR as a build artifact
-- **Frontend**
-  - `npm ci`
-  - `npm run lint`
-  - `npm run build`
-- **Playwright E2E with backend**
-  - Download the JAR packaged by the `backend` job (not rebuilt)
-  - Provision PostgreSQL and start the Spring Boot backend from that JAR
-  - Wait for `/api/v1/health`
-  - Run `npm test` in `frontend/` against the live backend
-  - Upload the Playwright HTML report and failure artifacts
-- **CodeQL** (separate workflow: pull requests to `main` and a weekly
-  schedule)
-  - Static security analysis of the `java-kotlin` and `javascript-typescript`
-    languages
-
-The PostgreSQL schema-creation and packaged-JAR asset-verification steps used
-by the `backend` and `e2e-playwright` jobs are shared scripts,
-`scripts/ci-create-test-schema.sh` and `scripts/ci-verify-jar-assets.sh`,
-rather than duplicated inline blocks.
-
-### Run CI Checks Locally
-
-From the repository root:
-
-```bash
-mvn -q verify
-mvn -q spotbugs:check
-mvn -q -Pfrontend package -DskipTests
-```
-
-From `frontend/` (with the backend already running for the E2E step):
+To reproduce the frontend CI steps locally:
 
 ```bash
 npm ci
@@ -341,106 +202,14 @@ npm run build
 E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD=local-admin-password E2E_API_KEY=local-api-key npm test
 ```
 
-### Deployment Automation
-
-There is currently **no automated deployment pipeline** configured. Use the deployment guidance below and consider wiring builds to your preferred platform.
-
 ## Deployment
 
-This section covers production deployment options for the admin UI.
+There is currently **no automated deployment pipeline**. Two deployment models are supported:
 
-### Primary Deployment: Spring Boot Integration (Recommended)
+- **Spring Boot integration (recommended for this monorepo):** the backend serves the built frontend from the same origin, producing a single JAR with no CORS configuration and consistent versioning. Build and run it from the repository root with the Maven `frontend` profile — see [Building the Project](../README.md#building-the-project) in the root README for the exact commands and asset verification.
+- **Standalone static hosting (CDN / Netlify / Vercel / S3+CloudFront):** run `npm run build` and deploy the generated `dist/` directory. When the frontend and backend are hosted separately you must set `VITE_API_BASE_URL` to the backend API URL at build time and configure CORS on the backend to allow the frontend origin. Because `VITE_*` values are inlined into the bundle, never bake real admin passwords or API keys into a hosted build; authenticate through a backend/session proxy instead.
 
-**Use this approach for the monorepo setup where the frontend is served by the Spring Boot backend.**
-
-This is the recommended deployment model for most use cases. It provides:
-- Single JAR deployment with both frontend and backend
-- Simplified deployment and operations
-- No CORS configuration needed
-- Consistent versioning across frontend and backend
-
-**Build and deploy:**
-
-From the repository root:
-
-```bash
-mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.6.jar
-```
-
-This command:
-1. Builds the React app using Vite
-2. Copies the build output to `src/main/resources/static`
-3. Packages everything into a single Spring Boot JAR
-4. Serves the frontend from `http://localhost:8080/`
-5. Serves the API from `http://localhost:8080/api`
-
-**Access the application:**
-- Frontend: http://localhost:8080
-- API: http://localhost:8080/api/v1
-- Actuator: http://localhost:8080/actuator
-
-### Alternative Deployment: Standalone Static Hosting
-
-**Use this approach if you need to deploy the frontend separately (CDN, static hosting, etc.).**
-
-This deployment model is suitable when:
-- You want to serve the frontend from a CDN
-- You need separate scaling for frontend and backend
-- You're deploying to a static hosting service (Netlify, Vercel, etc.)
-
-**Build the frontend:**
-
-```bash
-cd frontend
-npm run build
-```
-
-The build output will be in the `dist/` directory.
-
-**Preview the production build locally:**
-
-```bash
-npm run preview
-```
-
-**Deploy the `dist/` directory to:**
-- Static web server (nginx, Apache)
-- CDN (CloudFront, Cloudflare)
-- Static hosting platforms (Netlify, Vercel, GitHub Pages)
-
-**Important:** When deploying separately, you must:
-1. Configure CORS on the backend to allow requests from your frontend domain
-2. Set `VITE_API_BASE_URL` environment variable to point to your backend API URL
-3. Ensure the backend is accessible from the frontend domain
-
-#### Deployment Options
-
-**Vercel / Netlify (JAMstack)**
-
-- Build command: `npm run build`
-- Output directory: `dist`
-- Environment variables:
-  - `VITE_API_BASE_URL=https://api.example.com/api`
-  - `VITE_API_TIMEOUT_MS=10000`
-
-**AWS S3 + CloudFront**
-
-- Upload `dist/` to an S3 bucket configured for static hosting.
-- Create a CloudFront distribution pointing at the bucket.
-- Set environment variables at build time (CI/CD) before running `npm run build`.
-
-**Docker Container**
-
-- Build a static image that serves `dist/` via nginx.
-- Pass `VITE_API_BASE_URL` and `VITE_API_TIMEOUT_MS` at build time so the bundle is configured correctly.
-
-**Spring Boot Integration**
-
-- Recommended for this repo; the backend serves the frontend from the same origin.
-- Use `mvn -Pfrontend clean package` to bundle and deploy a single JAR.
-
-### Deployment Checklist
+**Deployment checklist:**
 
 - [ ] Confirm `VITE_API_BASE_URL` targets the correct environment.
 - [ ] Ensure CORS is configured if frontend and backend are hosted separately.
@@ -457,28 +226,16 @@ The API client can be configured at build time via Vite environment variables:
 | Variable | Description | Default |
 | --- | --- | --- |
 | `VITE_API_BASE_URL` | Base URL for API requests (e.g., `https://api.example.com/api/v1`) | `/api/v1` |
-| `VITE_API_TIMEOUT_MS` | Axios request timeout in milliseconds. Timed-out safe read requests are retried once after a short delay so cold-started backends can continue showing the current loading indicator before an error is displayed; if the backend remains unreachable, the UI shows a plain-language server-reachability message instead of raw transport details such as status code 502. | `10000` |
+| `VITE_API_TIMEOUT_MS` | Axios request timeout in milliseconds. Timed-out safe read requests are retried once after a short delay so cold-started backends can keep showing the current loading indicator before an error is displayed; if the backend stays unreachable, the UI shows a plain-language server-reachability message rather than raw transport details. | `10000` |
 | `VITE_ADMIN_USERNAME` | Optional admin username used with `VITE_ADMIN_PASSWORD` to build an HTTP Basic `Authorization` header | unset |
 | `VITE_ADMIN_PASSWORD` | Optional admin password used with `VITE_ADMIN_USERNAME` to build an HTTP Basic `Authorization` header | unset |
 | `VITE_API_KEY` | Optional runtime/simulation API key sent as `X-API-Key` | unset |
 
-Example `.env` file:
-
-```bash
-VITE_API_BASE_URL=http://localhost:8080/api/v1
-VITE_API_TIMEOUT_MS=15000
-VITE_ADMIN_USERNAME=admin
-VITE_ADMIN_PASSWORD=local-admin-password
-VITE_API_KEY=local-api-key
-```
-
-If `VITE_API_BASE_URL` is left unset, the app will continue to use `/api/v1`, which works with the Vite proxy in local development. The backend ignores whichever auth header does not apply to a specific endpoint, so sending both the Basic auth and API-key headers from the shared Axios client works for local development. Do not rely on bundled `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` values for hosted deployments; keep real credentials server-side behind a backend/session proxy.
-
-**Production build guard:** `vite.config.js` fails any `vite build` invocation — including `npm run build` and a custom `--mode` such as `--mode staging` — if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set in the build environment, so a real credential cannot be baked into a shipped bundle by accident. `VITE_ADMIN_USERNAME` alone does not trigger the guard. The guard only applies to the `build` command — `npm run dev` and `npm run preview` are unaffected.
+If `VITE_API_BASE_URL` is left unset, the app uses `/api/v1`, which works with the Vite proxy in local development. The backend ignores whichever auth header does not apply to a specific endpoint, so the shared Axios client can safely send both. As noted above, `vite.config.js` fails any `vite build` (including `npm run build` and custom `--mode`) if `VITE_ADMIN_PASSWORD` or `VITE_API_KEY` is set; `VITE_ADMIN_USERNAME` alone does not trigger the guard, and `npm run dev`/`npm run preview` are unaffected.
 
 ### Playwright E2E Environment Variables
 
-The Playwright configuration and Vite dev proxy can inject backend authentication headers for local and CI E2E runs without exposing credentials through Vite's client-side environment variables:
+The Playwright configuration and Vite dev proxy inject backend authentication headers for local and CI E2E runs without exposing credentials through Vite's client-side environment variables:
 
 | Variable | Description | Default |
 | --- | --- | --- |
@@ -486,21 +243,9 @@ The Playwright configuration and Vite dev proxy can inject backend authenticatio
 | `E2E_ADMIN_PASSWORD` | Optional admin password used to build a Basic auth header for Playwright browser requests | unset |
 | `E2E_API_KEY` | Optional runtime/simulation API key sent as `X-API-Key` by Playwright browser requests | unset |
 
-Do not use `VITE_*` variables for E2E secrets. Vite exposes `VITE_*` values to browser bundles by design.
+### Proxy and Ports
 
-### Proxy Setup
-
-The Vite dev server is configured to proxy API requests to the backend:
-
-- `/api/*` → `http://localhost:8080/api/*`
-- `/actuator/*` → `http://localhost:8080/actuator/*`
-
-This eliminates CORS issues during local development.
-
-### Ports
-
-- **Frontend**: http://localhost:3000
-- **Backend**: http://localhost:8080
+The Vite dev server proxies `/api/*` and `/actuator/*` to `http://localhost:8080`, eliminating CORS issues during local development. The frontend runs on **http://localhost:3000** and the backend on **http://localhost:8080**.
 
 ## Project Structure
 
@@ -530,140 +275,33 @@ frontend/
 
 ## Features
 
-### Dashboard
-- Overview of lift systems
-- Quick statistics
-- Quick action links
+- **Dashboard** — overview of lift systems with quick statistics and action links
+- **Lift Systems Management** — view, create, and inspect systems and their versions; jump to the versions section; launch a local simulator for published configurations
+- **Configuration Validator** — validate configuration JSON with real-time feedback and a sample configuration
+- **Health Check** — monitor backend service health
 
-### Lift Systems Management
-- View all lift systems
-- Create new systems
-- View system details and versions
-- Jump directly to the versions section from the Lift Systems list
-- Launch a local simulator for published configurations
-
-### Configuration Validator
-- Validate lift system configuration JSON
-- Real-time validation feedback
-- Sample configuration provided
-
-### Health Check
-- Monitor backend service health
-- Real-time status updates
-- Detailed health information
-
-## Sanity Checks
-
-- From the **Lift Systems** list, select **Manage Versions** and confirm the detail view scrolls to the Versions section.
-
-## API Integration
-
-The frontend integrates with these backend endpoints:
-
-### Admin APIs
-- `GET /api/v1/lift-systems` - List all systems
-- `POST /api/v1/lift-systems` - Create system
-- `GET /api/v1/lift-systems/{id}` - Get system details
-- `PUT /api/v1/lift-systems/{id}` - Update system
-- `DELETE /api/v1/lift-systems/{id}` - Delete system
-- `GET /api/v1/lift-systems/{systemId}/versions` - List versions
-- `POST /api/v1/lift-systems/{systemId}/versions` - Create version
-- `PUT /api/v1/lift-systems/{systemId}/versions/{versionNumber}` - Update version
-- `POST /api/v1/lift-systems/{systemId}/versions/{versionNumber}/publish` - Publish version
-
-### Runtime APIs
-
-### Validation API
-- `POST /api/v1/config/validate` - Validate configuration
-
-### Health API
-- `GET /api/v1/health` - Health check
+The frontend integrates with the backend `/api/v1` endpoints (lift systems, versions, validation, simulation runs, runtime configuration, and health). The authoritative endpoint reference is the generated Swagger UI (`/api/v1/swagger-ui.html`); cross-cutting conventions are documented in [docs/API.md](../docs/API.md).
 
 ## Troubleshooting
 
-### Backend Connection Issues
+- **Backend connection issues** (e.g. `Cannot reach the server. Please check it is running and try again.`): verify the backend is running (`curl http://localhost:8080/api/v1/health`), check backend logs, and confirm PostgreSQL is running and accessible.
+- **Port already in use**: if port 3000 is busy, Vite tries the next available port — check the console output for the actual port.
+- **CORS errors**: the proxy configuration should prevent these locally; verify `vite.config.js` proxy settings, restart `npm run dev`, and clear the browser cache.
 
-If you see errors about failed API calls, including the friendly message `Cannot reach the server. Please check it is running and try again.`:
-
-1. Verify backend is running: `curl http://localhost:8080/api/v1/health`
-2. Check backend logs for errors
-3. Ensure PostgreSQL database is running and accessible
-
-### Port Already in Use
-
-If port 3000 is in use, Vite will automatically try the next available port. Check the console output for the actual port.
-
-### CORS Errors
-
-The proxy configuration should prevent CORS issues. If you encounter CORS errors:
-1. Verify `vite.config.js` proxy settings are correct
-2. Restart the dev server: `npm run dev`
-3. Clear browser cache and reload
+For broader setup and database troubleshooting, see [docs/Workflows-and-Troubleshooting.md](../docs/Workflows-and-Troubleshooting.md).
 
 ## Maintenance
 
-### Dependency Updates
-
-To keep dependencies up to date and secure, periodically check for and apply updates:
-
-**Check for outdated dependencies:**
+Keep dependencies current and in sync with this README:
 
 ```bash
-npm outdated
+npm outdated                        # list outdated dependencies
+npx npm-check-updates --interactive # review and choose updates
+npm install                         # apply
+npm audit                           # check for vulnerabilities
 ```
 
-**Update dependencies interactively:**
-
-```bash
-npx npm-check-updates --interactive
-```
-
-This allows you to:
-- Review available updates for each dependency
-- Choose which updates to apply (major, minor, patch)
-- See breaking change warnings
-
-**Apply selected updates:**
-
-```bash
-npx npm-check-updates -u
-npm install
-```
-
-**Best practices:**
-- Review changelogs before applying major version updates
-- Test thoroughly after updating dependencies
-- Update dependencies regularly (monthly recommended)
-- Keep the `package.json` ranges in sync with this README
-- Run `npm audit` to check for security vulnerabilities
-
-**After updating:**
-
-```bash
-npm test          # Run tests (if available)
-npm run build     # Verify build still works
-npm run dev       # Test in development mode
-```
-
-### Version Synchronization
-
-When updating dependency versions:
-1. Update `package.json` with new version ranges
-2. Update the "Tech Stack" section in this README to match
-3. Test the application thoroughly
-4. Document breaking changes in the project CHANGELOG
-
-## Next Steps
-
-This is a basic scaffold. Future enhancements could include:
-
-- Full CRUD operations for lift systems and versions
-- Rich configuration editor with validation
-- User authentication and authorization
-- Real-time monitoring and metrics
-- Deployment automation
-- Unit/integration tests with Vitest + Testing Library
-- Expand E2E test coverage with Playwright
+Review changelogs before major-version updates, test after updating (`npm test`, `npm run build`, `npm run dev`), and when versions change update `package.json`, the **Tech Stack** section above, and the project CHANGELOG.
 
 ## Contributing
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.6",
+  "version": "0.57.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.6",
+      "version": "0.57.7",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.6",
+  "version": "0.57.7",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.6</version>
+    <version>0.57.7</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
## Summary

Restructured `docs/API.md` from a 1000+ line endpoint reference into a concise 220-line conventions guide. The complete, always-current endpoint reference is now generated from code by SpringDoc and served as interactive Swagger UI and OpenAPI JSON, eliminating duplication and maintenance burden.

## Key Changes

- **API.md refactored** (1030 → 220 lines):
  - Removed all hardcoded endpoint examples, request/response schemas, and field documentation
  - Kept only cross-cutting conventions: authentication (HTTP Basic + API key), role-based access control (ADMIN/VIEWER), versioning strategy, rate limiting (Bucket4j), and error-response shape
  - Added clear pointer to generated Swagger UI (`/api/v1/swagger-ui.html`) and OpenAPI JSON as authoritative sources
  - Moved configuration/scenario schema reference and batch input generator format to `Workflows-and-Troubleshooting.md`

- **README.md updated**:
  - Clarified that the complete endpoint reference is generated by SpringDoc, not duplicated in docs
  - Adjusted API documentation links to reflect the new structure

- **frontend/README.md streamlined**:
  - Removed redundant credential security warnings (consolidated into API.md)
  - Simplified E2E testing section with clearer command examples
  - Removed verbose CI/CD explanation (kept in `.github/workflows/`)

- **Workflows-and-Troubleshooting.md expanded**:
  - Added new "Configuration and Scenario Schema Reference" section with lift configuration and scenario payload schemas
  - Moved batch input generator format documentation here for operational context

- **Version bumped** to 0.57.7 across `pom.xml`, `frontend/package.json`, and documentation

## Implementation Details

- No backend code changes; this is purely documentation restructuring
- The generated Swagger UI remains the single source of truth for all endpoint paths, request/response schemas, and field definitions
- Conventions documentation (auth, RBAC, rate limits) stays in `docs/API.md` for operational reference
- Schema reference moved to `Workflows-and-Troubleshooting.md` alongside CLI/UI run workflows for better discoverability
- All version references updated consistently across the project

https://claude.ai/code/session_01XRua223S5xuyxAW74LUYuZ