### PR TITLE
refactor(admin): split simulation run execution responsibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ summary is kept under [Earlier history](#earlier-history).
 ## [0.57.8] - 2026-07-11
 
 ### Changed
-- **Simulation execution service split**: Refactored the admin asynchronous execution path so `SimulationRunExecutionService` owns queueing, cancellation, executor shutdown, and in-flight task tracking, while the new `SimulationRunner` owns validation, lifecycle transitions, progress updates, and simulation ticking, and the new `SimulationArtefactWriter` owns run logs, config/scenario snapshots, generated batch input, and `results.json` writing. This keeps the public simulation-run API unchanged while isolating runner and filesystem responsibilities for easier maintenance. Updated README and package metadata for the 0.57.8 pre-MVP patch release.
+- **Simulation execution service split**: Refactored the admin asynchronous execution path so `SimulationRunExecutionService` owns queueing, cancellation, executor shutdown, and in-flight task tracking, while the new `SimulationRunner` owns validation, lifecycle transitions, progress updates, and simulation ticking, and the new `SimulationArtefactWriter` owns run logs, config/scenario snapshots, generated batch input, and `results.json` writing. This keeps the public simulation-run API unchanged while isolating runner and filesystem responsibilities for easier maintenance. The rejection path now also removes any pre-created cancellation token when a run cannot be queued, preventing token retention for over-capacity submissions. Updated README and package metadata for the 0.57.8 pre-MVP patch release.
 
 ## [0.57.7] - 2026-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.8] - 2026-07-11
+
+### Changed
+- **Simulation execution service split**: Refactored the admin asynchronous execution path so `SimulationRunExecutionService` owns queueing, cancellation, executor shutdown, and in-flight task tracking, while the new `SimulationRunner` owns validation, lifecycle transitions, progress updates, and simulation ticking, and the new `SimulationArtefactWriter` owns run logs, config/scenario snapshots, generated batch input, and `results.json` writing. This keeps the public simulation-run API unchanged while isolating runner and filesystem responsibilities for easier maintenance. Updated README and package metadata for the 0.57.8 pre-MVP patch release.
+
 ## [0.57.7] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.7**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.8**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.7.jar
+java -jar target/lift-simulator-0.57.8.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.7.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.8.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.7.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -180,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.7.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.8.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.7.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.8.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -50,7 +50,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.7.jar \
+java -cp target/lift-simulator-0.57.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -64,12 +64,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.7.jar \
+java -cp target/lift-simulator-0.57.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.7.jar \
+java -cp target/lift-simulator-0.57.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -113,7 +113,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.7.jar \
+java -cp target/lift-simulator-0.57.8.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -391,7 +391,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.7.jar \
+   java -cp target/lift-simulator-0.57.8.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -436,7 +436,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.7.jar \
+java -cp target/lift-simulator-0.57.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -528,7 +528,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.7.jar \
+java -cp target/lift-simulator-0.57.8.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/docs/architecture-diagram.mermaid
+++ b/docs/architecture-diagram.mermaid
@@ -15,7 +15,7 @@ graph TD
 
         subgraph svc["Service Layer"]
             CFGSVC["Config & Scenario Services<br/>LiftSystem · Version · Scenario<br/>ConfigValidation · ScenarioValidation"]
-            RUNSVC["Run Orchestration<br/>SimulationRunService<br/>SimulationRunExecutionService (async)"]
+            RUNSVC["Run Orchestration<br/>SimulationRunService · SimulationRunExecutionService<br/>SimulationRunner · SimulationArtefactWriter"]
             SUPPORT["Support Services<br/>BatchInputGenerator · ArtefactService<br/>RuntimeConfigService"]
         end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ graph TD
 
         subgraph svc["Service Layer"]
             CFGSVC["Config & Scenario Services<br/>LiftSystem · Version · Scenario<br/>ConfigValidation · ScenarioValidation"]
-            RUNSVC["Run Orchestration<br/>SimulationRunService<br/>SimulationRunExecutionService (async)"]
+            RUNSVC["Run Orchestration<br/>SimulationRunService · SimulationRunExecutionService<br/>SimulationRunner · SimulationArtefactWriter"]
             SUPPORT["Support Services<br/>BatchInputGenerator · ArtefactService<br/>RuntimeConfigService"]
         end
 
@@ -118,8 +118,10 @@ Java 21 LTS).
   - *Config & scenario services* manage CRUD, the publish/archive workflow, and
     validation of configuration and scenario JSON.
   - *Run orchestration* — `SimulationRunService` manages run lifecycle state,
-    while `SimulationRunExecutionService` runs simulations asynchronously on a
-    thread pool, supports cancellation, and persists artefacts and KPIs.
+    while `SimulationRunExecutionService` owns asynchronous queueing/cancellation,
+    `SimulationRunner` performs validation, lifecycle updates, and engine ticking,
+    and `SimulationArtefactWriter` persists logs, snapshots, generated batch input,
+    and results/KPIs.
   - *Support services* — `BatchInputGenerator` turns scenarios into engine
     input, `ArtefactService` reads/writes run artefacts, and
     `RuntimeConfigService` backs published-configuration reads for the lightweight runtime API.
@@ -168,6 +170,8 @@ sequenceDiagram
     participant API as SimulationRunController
     participant Run as SimulationRunService
     participant Exec as SimulationRunExecutionService
+    participant Runner as SimulationRunner
+    participant Writer as SimulationArtefactWriter
     participant Gen as BatchInputGenerator
     participant Eng as SimulationEngine
     participant DB as PostgreSQL
@@ -177,12 +181,15 @@ sequenceDiagram
     API->>Run: create & start run
     Run->>DB: persist run (CREATED → RUNNING)
     Run-->>Exec: submit async (after commit)
-    Exec->>Gen: build engine input from scenario
-    Exec->>FS: write config.json / scenario.json / input.scenario
-    Exec->>Eng: run tick loop with chosen controller
-    Eng-->>Exec: per-tick state & completed requests
-    Exec->>FS: write run.log + results.json
-    Exec->>DB: update status (SUCCEEDED / FAILED) + KPIs
+    Exec->>Runner: execute run request
+    Runner->>Writer: write config/scenario snapshots and logs
+    Writer->>Gen: build engine input from scenario
+    Writer->>FS: write config.json / scenario.json / input.scenario
+    Runner->>Eng: run tick loop with chosen controller
+    Eng-->>Runner: per-tick state & completed requests
+    Runner->>Writer: write results.json
+    Writer->>FS: persist run.log + results.json
+    Runner->>DB: update status (SUCCEEDED / FAILED) + KPIs
     UI->>API: GET /simulation-runs/{id} (poll status)
     API-->>UI: status, KPIs, artefact links
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.7",
+  "version": "0.57.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.7",
+      "version": "0.57.8",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.7",
+  "version": "0.57.8",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.7</version>
+    <version>0.57.8</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>

--- a/src/main/java/com/liftsimulator/admin/service/SimulationArtefactWriter.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationArtefactWriter.java
@@ -4,6 +4,7 @@ import com.liftsimulator.admin.dto.LiftConfigDTO;
 import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
 import com.liftsimulator.admin.entity.SimulationRun;
 import com.liftsimulator.admin.service.metrics.RunMetrics;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,6 +34,10 @@ public class SimulationArtefactWriter {
     private final BatchInputGenerator batchInputGenerator;
     private final RunLifecycleManager lifecycleManager;
 
+    @SuppressFBWarnings(
+        value = "EI_EXPOSE_REP2",
+        justification = "Injected collaborators are Spring-managed singleton services/configuration objects."
+    )
     public SimulationArtefactWriter(ObjectMapper objectMapper,
                                     BatchInputGenerator batchInputGenerator,
                                     RunLifecycleManager lifecycleManager) {

--- a/src/main/java/com/liftsimulator/admin/service/SimulationArtefactWriter.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationArtefactWriter.java
@@ -1,0 +1,125 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.admin.dto.LiftConfigDTO;
+import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
+import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.service.metrics.RunMetrics;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Writes the files produced by a simulation run into the run artefact directory.
+ */
+@Service
+public class SimulationArtefactWriter {
+    static final String CONFIG_FILE_NAME = "config.json";
+    static final String SCENARIO_FILE_NAME = "scenario.json";
+    static final String INPUT_SCENARIO_FILE_NAME = "input.scenario";
+    static final String LOG_FILE_NAME = "run.log";
+    static final String RESULTS_FILE_NAME = "results.json";
+
+    private static final Logger logger = LoggerFactory.getLogger(SimulationArtefactWriter.class);
+
+    private final ObjectMapper objectMapper;
+    private final BatchInputGenerator batchInputGenerator;
+    private final RunLifecycleManager lifecycleManager;
+
+    public SimulationArtefactWriter(ObjectMapper objectMapper,
+                                    BatchInputGenerator batchInputGenerator,
+                                    RunLifecycleManager lifecycleManager) {
+        this.objectMapper = objectMapper;
+        this.batchInputGenerator = batchInputGenerator;
+        this.lifecycleManager = lifecycleManager;
+    }
+
+    public BufferedWriter openLog(Path runDir) throws IOException {
+        return Files.newBufferedWriter(runDir.resolve(LOG_FILE_NAME), StandardCharsets.UTF_8);
+    }
+
+    public void log(BufferedWriter writer, String message) throws IOException {
+        writer.write("[" + OffsetDateTime.now() + "] " + message);
+        writer.newLine();
+        writer.flush();
+    }
+
+    public void appendLog(Path logPath, String message) {
+        try (BufferedWriter logWriter = Files.newBufferedWriter(
+                logPath,
+                StandardCharsets.UTF_8,
+                java.nio.file.StandardOpenOption.APPEND)) {
+            log(logWriter, message);
+        } catch (IOException ex) {
+            logger.warn("Failed to append message to run log at {}", logPath, ex);
+        }
+    }
+
+    public void writeInputFiles(SimulationRunner.RunExecutionRequest request,
+                                Path runDir,
+                                BufferedWriter logWriter) throws IOException {
+        Files.writeString(runDir.resolve(CONFIG_FILE_NAME), request.configJson(), StandardCharsets.UTF_8);
+        log(logWriter, "Wrote config input to " + CONFIG_FILE_NAME);
+
+        if (request.scenarioJson() != null) {
+            Files.writeString(runDir.resolve(SCENARIO_FILE_NAME), request.scenarioJson(), StandardCharsets.UTF_8);
+            log(logWriter, "Wrote scenario input to " + SCENARIO_FILE_NAME);
+
+            ScenarioDefinitionDTO scenarioDefinition = objectMapper.readValue(
+                    request.scenarioJson(), ScenarioDefinitionDTO.class);
+            String name = request.scenarioName() != null ? request.scenarioName() : "run";
+            batchInputGenerator.generateBatchInputFile(
+                    request.configJson(), scenarioDefinition, name, runDir.resolve(INPUT_SCENARIO_FILE_NAME));
+            log(logWriter, "Wrote batch input to " + INPUT_SCENARIO_FILE_NAME);
+        }
+    }
+
+    public void writeResults(Long runId,
+                             Path runDir,
+                             LiftConfigDTO config,
+                             ScenarioDefinitionDTO scenario,
+                             RunMetrics metrics,
+                             String status,
+                             String message) throws IOException {
+        ObjectNode results = objectMapper.createObjectNode();
+        ObjectNode runSummary = results.putObject("runSummary");
+        runSummary.put("runId", runId);
+        runSummary.put("status", status);
+        runSummary.put("generatedAt", OffsetDateTime.now().toString());
+        if (message != null) {
+            runSummary.put("message", message);
+        }
+        if (scenario != null) {
+            runSummary.put("durationTicks", scenario.durationTicks());
+            if (scenario.seed() != null) {
+                runSummary.put("seed", scenario.seed());
+            }
+        }
+        if (metrics != null) {
+            runSummary.put("ticks", metrics.totalTicks());
+        }
+        try {
+            SimulationRun run = lifecycleManager.getByIdWithDetails(runId);
+            runSummary.put("liftSystemId", run.getLiftSystem().getId());
+            runSummary.put("versionNumber", run.getVersion().getVersionNumber());
+        } catch (Exception ex) {
+            logger.warn("Failed to resolve run summary metadata for run {}", runId, ex);
+        }
+
+        if (metrics != null && config != null) {
+            results.set("kpis", metrics.toKpisNode(objectMapper));
+            results.set("perLift", metrics.toPerLiftNode(objectMapper, config));
+            results.set("perFloor", metrics.toPerFloorNode(objectMapper));
+        }
+
+        objectMapper.writerWithDefaultPrettyPrinter()
+            .writeValue(runDir.resolve(RESULTS_FILE_NAME).toFile(), results);
+    }
+}

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -1,32 +1,9 @@
 package com.liftsimulator.admin.service;
 
-import com.liftsimulator.admin.dto.ConfigValidationResponse;
-import com.liftsimulator.admin.dto.LiftConfigDTO;
-import com.liftsimulator.admin.dto.PassengerFlowDTO;
-import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
-import com.liftsimulator.admin.dto.ScenarioValidationResponse;
 import com.liftsimulator.admin.entity.SimulationRun;
-import com.liftsimulator.admin.service.metrics.RunMetrics;
-import com.liftsimulator.domain.Direction;
-import com.liftsimulator.domain.LiftRequest;
-import com.liftsimulator.engine.ControllerFactory;
-import com.liftsimulator.engine.RequestManagingLiftController;
-import com.liftsimulator.engine.SimulationEngine;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RejectedExecutionException;
@@ -34,55 +11,40 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import jakarta.annotation.PreDestroy;
 
 /**
- * Service to run simulations asynchronously and persist run artefacts.
+ * Service to submit simulations asynchronously and manage queued/running tasks.
  */
 @Service
 public class SimulationRunExecutionService {
     private static final Logger logger = LoggerFactory.getLogger(SimulationRunExecutionService.class);
-    private static final int PROGRESS_UPDATE_INTERVAL = 5;
-    private static final String CONFIG_FILE_NAME = "config.json";
-    private static final String SCENARIO_FILE_NAME = "scenario.json";
-    private static final String INPUT_SCENARIO_FILE_NAME = "input.scenario";
-    private static final String LOG_FILE_NAME = "run.log";
-    private static final String RESULTS_FILE_NAME = "results.json";
 
     private final RunLifecycleManager lifecycleManager;
-    private final ConfigValidationService configValidationService;
-    private final ScenarioValidationService scenarioValidationService;
-    private final BatchInputGenerator batchInputGenerator;
-    private final ObjectMapper objectMapper;
+    private final SimulationRunner simulationRunner;
     private final ThreadPoolExecutor executor;
     private final Map<Long, FutureTask<?>> runningTasks = new ConcurrentHashMap<>();
     private final Map<Long, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
 
+    @Autowired
     @SuppressFBWarnings(
         value = "EI_EXPOSE_REP2",
         justification = "Injected dependencies and configuration managed by Spring."
     )
     public SimulationRunExecutionService(
             RunLifecycleManager lifecycleManager,
-            ConfigValidationService configValidationService,
-            ScenarioValidationService scenarioValidationService,
-            BatchInputGenerator batchInputGenerator,
-            ObjectMapper objectMapper,
+            SimulationRunner simulationRunner,
             @Value("${simulation.execution.max-concurrent-runs:4}") int maxConcurrentRuns,
             @Value("${simulation.execution.queue-capacity:20}") int queueCapacity) {
         this.lifecycleManager = lifecycleManager;
-        this.configValidationService = configValidationService;
-        this.scenarioValidationService = scenarioValidationService;
-        this.batchInputGenerator = batchInputGenerator;
-        this.objectMapper = objectMapper;
+        this.simulationRunner = simulationRunner;
         this.executor = new ThreadPoolExecutor(
             maxConcurrentRuns,
             maxConcurrentRuns,
@@ -91,6 +53,28 @@ public class SimulationRunExecutionService {
             new ArrayBlockingQueue<>(queueCapacity),
             new SimulationRunnerThreadFactory(),
             new ThreadPoolExecutor.AbortPolicy()
+        );
+    }
+
+    public SimulationRunExecutionService(
+            RunLifecycleManager lifecycleManager,
+            ConfigValidationService configValidationService,
+            ScenarioValidationService scenarioValidationService,
+            BatchInputGenerator batchInputGenerator,
+            ObjectMapper objectMapper,
+            int maxConcurrentRuns,
+            int queueCapacity) {
+        this(
+            lifecycleManager,
+            new SimulationRunner(
+                lifecycleManager,
+                configValidationService,
+                scenarioValidationService,
+                objectMapper,
+                new SimulationArtefactWriter(objectMapper, batchInputGenerator, lifecycleManager)
+            ),
+            maxConcurrentRuns,
+            queueCapacity
         );
     }
 
@@ -106,7 +90,12 @@ public class SimulationRunExecutionService {
         String scenarioJson = run.getScenario() != null ? run.getScenario().getScenarioJson() : null;
         String scenarioName = run.getScenario() != null ? run.getScenario().getName() : null;
 
-        RunExecutionRequest request = new RunExecutionRequest(run.getId(), configJson, scenarioJson, scenarioName);
+        SimulationRunner.RunExecutionRequest request = new SimulationRunner.RunExecutionRequest(
+            run.getId(),
+            configJson,
+            scenarioJson,
+            scenarioName
+        );
         submitExecution(request);
     }
 
@@ -122,10 +111,6 @@ public class SimulationRunExecutionService {
         token.cancel();
         FutureTask<?> future = runningTasks.get(runId);
         if (future != null && future.cancel(false)) {
-            // future.cancel() marks the FutureTask cancelled but leaves it in the
-            // ArrayBlockingQueue, holding the slot. Remove it explicitly so the slot
-            // is released immediately. executeRun's finally block will never run for
-            // a task that never started, so clean up tracking state here too.
             executor.remove(future);
             runningTasks.remove(runId, future);
             cancellationTokens.remove(runId);
@@ -136,255 +121,43 @@ public class SimulationRunExecutionService {
     /**
      * Indicates whether any simulation run is currently submitted or executing.
      *
-     * <p>Runs are tracked from submission until their asynchronous execution
-     * completes (including artefact writing and lifecycle finalisation). This is
-     * primarily used to let integration tests wait for background executions to
-     * drain before they reset shared database state, preventing a concurrent
-     * {@code UPDATE} from the runner thread from colliding with cleanup deletes.</p>
-     *
      * @return {@code true} if at least one run is in flight
      */
     public boolean hasActiveRuns() {
         return !runningTasks.isEmpty();
     }
 
-    private void executeRun(RunExecutionRequest request) {
-        CancellationToken cancelToken = cancellationTokens.computeIfAbsent(request.runId(), id -> new CancellationToken());
-        boolean started = false;
-
-        SimulationRun runEntity;
-        try {
-            runEntity = getRunById(request.runId());
-        } catch (Exception ex) {
-            logger.error("Failed to load run {} for execution", request.runId(), ex);
-            return;
-        }
-
-        String artefactPath = runEntity.getArtefactBasePath();
-        if (artefactPath == null || artefactPath.isBlank()) {
-            logger.error("Run {} has no artefact path configured; cannot execute", request.runId());
-            failRunWithMessage(request.runId(), "Artefact path not configured for run.", false);
-            return;
-        }
-
-        Path runDir = Paths.get(artefactPath);
-        Path logPath = runDir.resolve(LOG_FILE_NAME);
-        logger.info("Run {} using artefact directory: {}", request.runId(), runDir);
-
-        try (BufferedWriter logWriter = Files.newBufferedWriter(logPath, StandardCharsets.UTF_8)) {
-            log(logWriter, "Run directory: " + runDir.toAbsolutePath());
-
-            if (request.scenarioJson() == null) {
-                log(logWriter, "Missing scenario payload for run " + request.runId());
-                failRunWithMessage(request.runId(), logWriter, "Missing scenario payload for run.", false);
-                writeResults(request.runId(), runDir, null, null, null, "FAILED", "Missing scenario payload for run.");
-                return;
-            }
-
-            ConfigValidationResponse configValidation = configValidationService.validate(request.configJson());
-            if (!configValidation.valid()) {
-                log(logWriter, "Configuration validation failed: " + configValidation.errors());
-                failRunWithMessage(request.runId(), logWriter, "Invalid configuration payload.", false);
-                writeResults(request.runId(), runDir, null, null, null, "FAILED", "Invalid configuration payload.");
-                return;
-            }
-
-            JsonNode scenarioNode = objectMapper.readTree(request.scenarioJson());
-            ScenarioValidationResponse scenarioValidation = scenarioValidationService.validate(scenarioNode);
-            if (!scenarioValidation.valid()) {
-                log(logWriter, "Scenario validation failed: " + scenarioValidation.errors());
-                failRunWithMessage(request.runId(), logWriter, "Invalid scenario payload.", false);
-                writeResults(request.runId(), runDir, null, null, null, "FAILED", "Invalid scenario payload.");
-                return;
-            }
-
-            LiftConfigDTO config = objectMapper.readValue(request.configJson(), LiftConfigDTO.class);
-            ScenarioDefinitionDTO scenario = objectMapper.readerFor(ScenarioDefinitionDTO.class)
-                .readValue(scenarioNode);
-
-            if (scenario.durationTicks() == null) {
-                log(logWriter, "Scenario has null durationTicks");
-                SimulationRun runAtCheck = getRunById(request.runId());
-                boolean runAlreadyStarted = runAtCheck.getStatus() == SimulationRun.RunStatus.RUNNING;
-                failRunWithMessage(request.runId(), logWriter, "Scenario must have a valid durationTicks value.", runAlreadyStarted);
-                writeResults(request.runId(), runDir, null, null, null, "FAILED", "Scenario must have a valid durationTicks value.");
-                return;
-            }
-
-            writeInputFiles(request, runDir, logWriter);
-
-            lifecycleManager.configureRun(
-                request.runId(),
-                scenario.durationTicks().longValue(),
-                scenario.seed() != null ? scenario.seed().longValue() : null,
-                null
-            );
-
-            // Start the run if not already started (it may have been started by createAndStartRun)
-            SimulationRun currentRun = getRunById(request.runId());
-            if (currentRun.getStatus() == SimulationRun.RunStatus.CANCELLED || cancelToken.isCancelled()) {
-                log(logWriter, "Run cancelled before start for run " + request.runId());
-                cancelRunSafely(request.runId(), logWriter, "Run cancelled before start.");
-                writeResults(request.runId(), runDir, config, scenario, null, "CANCELLED", "Run cancelled before start.");
-                return;
-            }
-            if (currentRun.getStatus() != SimulationRun.RunStatus.RUNNING) {
-                lifecycleManager.startRun(request.runId());
-            }
-            started = true;
-            lifecycleManager.updateProgress(request.runId(), 0L);
-            log(logWriter, "Simulation started for run " + request.runId());
-
-            RunMetrics metrics;
-            try {
-                metrics = runSimulation(request.runId(), config, scenario, logWriter, cancelToken);
-            } catch (RunCancelledException ex) {
-                cancelRunSafely(request.runId(), logWriter, ex.getMessage());
-                writeResults(request.runId(), runDir, ex.getConfig(), ex.getScenario(), ex.getMetrics(), "CANCELLED", ex.getMessage());
-                return;
-            }
-
-            if (cancelToken.isCancelled() || getRunById(request.runId()).getStatus() == SimulationRun.RunStatus.CANCELLED) {
-                log(logWriter, "Run cancelled for run " + request.runId());
-                writeResults(request.runId(), runDir, config, scenario, metrics, "CANCELLED", "Run cancelled.");
-                return;
-            }
-            log(logWriter, "Simulation succeeded for run " + request.runId());
-            writeResults(request.runId(), runDir, config, scenario, metrics, "SUCCEEDED", null);
-            lifecycleManager.succeedRun(request.runId());
-        } catch (IOException | RuntimeException ex) {
-            String errorMessage = safeMessage(ex);
-            logger.error("Simulation run {} failed", request.runId(), ex);
-            failRunWithMessage(request.runId(), logPath, errorMessage, started);
-            try {
-                writeResults(request.runId(), runDir, null, null, null, "FAILED", errorMessage);
-            } catch (IOException ioEx) {
-                logger.warn("Failed to write results file for run {}", request.runId(), ioEx);
-            }
-        } finally {
-            runningTasks.remove(request.runId());
-            cancellationTokens.remove(request.runId());
-        }
-    }
-
-    private RunMetrics runSimulation(Long runId,
-                                     LiftConfigDTO config,
-                                     ScenarioDefinitionDTO scenario,
-                                     BufferedWriter logWriter,
-                                     CancellationToken cancelToken) throws IOException {
-        RequestManagingLiftController controller = (RequestManagingLiftController) ControllerFactory.createController(
-            config.controllerStrategy(),
-            config.homeFloor(),
-            config.idleTimeoutTicks(),
-            config.idleParkingMode()
-        );
-
-        SimulationEngine engine = SimulationEngine.builder(controller, config.minFloor(), config.maxFloor())
-            .initialFloor(config.homeFloor())
-            .travelTicksPerFloor(config.travelTicksPerFloor())
-            .doorTransitionTicks(config.doorTransitionTicks())
-            .doorDwellTicks(config.doorDwellTicks())
-            .doorReopenWindowTicks(config.doorReopenWindowTicks())
-            .build();
-
-        Map<Integer, List<PassengerFlowDTO>> flowsByTick = groupFlowsByTick(scenario);
-        RunMetrics metrics = new RunMetrics(config.minFloor(), config.maxFloor());
-
-        log(logWriter, "Starting simulation for " + scenario.durationTicks() + " ticks.");
-        for (int tick = 0; tick < scenario.durationTicks(); tick++) {
-            if (cancelToken.isCancelled() || Thread.currentThread().isInterrupted()) {
-                throw new RunCancelledException("Run cancelled at tick " + engine.getCurrentTick() + ".",
-                    metrics,
-                    config,
-                    scenario);
-            }
-            long currentTick = engine.getCurrentTick();
-            List<PassengerFlowDTO> flows = flowsByTick.getOrDefault((int) currentTick, List.of());
-            for (PassengerFlowDTO flow : flows) {
-                int passengers = flow.passengers() != null ? flow.passengers() : 1;
-
-                // Determine direction based on origin and destination floors
-                Direction direction;
-                if (flow.destinationFloor() > flow.originFloor()) {
-                    direction = Direction.UP;
-                } else if (flow.destinationFloor() < flow.originFloor()) {
-                    direction = Direction.DOWN;
-                } else {
-                    // Same floor - skip this flow as it doesn't require lift movement
-                    continue;
-                }
-
-                metrics.recordPassengerFlow(flow, passengers);
-
-                // One hall call per flow; passenger count is carried on the request for KPI accounting
-                LiftRequest request = LiftRequest.hallCall(flow.originFloor(), direction, passengers);
-                metrics.recordRequestCreation(request, currentTick);
-                controller.addRequest(request);
-            }
-
-            metrics.recordActiveRequests(controller.getRequests(), currentTick);
-            engine.tick();
-            metrics.recordLiftState(engine.getCurrentState());
-            metrics.recordTerminalRequests(engine.getCurrentTick());
-
-            long progressTick = tick + 1L;
-            if (tick % PROGRESS_UPDATE_INTERVAL == 0) {
-                lifecycleManager.updateProgress(runId, progressTick);
-            }
-        }
-
-        lifecycleManager.updateProgress(runId, (long) scenario.durationTicks());
-        log(logWriter, "Simulation completed at tick " + engine.getCurrentTick());
-        metrics.recordTerminalRequests(engine.getCurrentTick());
-        return metrics;
-    }
-
-    private Map<Integer, List<PassengerFlowDTO>> groupFlowsByTick(ScenarioDefinitionDTO scenario) {
-        if (scenario.passengerFlows() == null || scenario.passengerFlows().isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        Map<Integer, List<PassengerFlowDTO>> flowsByTick = new HashMap<>(scenario.passengerFlows().size());
-        for (PassengerFlowDTO flow : scenario.passengerFlows()) {
-            int tick = flow.startTick() != null ? flow.startTick() : 0;
-            flowsByTick.computeIfAbsent(tick, key -> new ArrayList<>()).add(flow);
-        }
-        return flowsByTick;
-    }
-
     private SimulationRun getRunById(Long runId) {
         return lifecycleManager.getByIdWithDetails(runId);
     }
 
-    private void writeInputFiles(RunExecutionRequest request, Path runDir, BufferedWriter logWriter) throws IOException {
-        Files.writeString(runDir.resolve(CONFIG_FILE_NAME), request.configJson(), StandardCharsets.UTF_8);
-        log(logWriter, "Wrote config input to " + CONFIG_FILE_NAME);
-
-        if (request.scenarioJson() != null) {
-            Files.writeString(runDir.resolve(SCENARIO_FILE_NAME), request.scenarioJson(), StandardCharsets.UTF_8);
-            log(logWriter, "Wrote scenario input to " + SCENARIO_FILE_NAME);
-
-            ScenarioDefinitionDTO scenarioDefinition = objectMapper.readValue(
-                    request.scenarioJson(), ScenarioDefinitionDTO.class);
-            String name = request.scenarioName() != null ? request.scenarioName() : "run";
-            batchInputGenerator.generateBatchInputFile(
-                    request.configJson(), scenarioDefinition, name, runDir.resolve(INPUT_SCENARIO_FILE_NAME));
-            log(logWriter, "Wrote batch input to " + INPUT_SCENARIO_FILE_NAME);
-        }
+    @PreDestroy
+    public void shutdownExecutor() {
+        executor.shutdown();
     }
 
-    private void failRunWithMessage(Long runId, BufferedWriter logWriter, String message, boolean started) throws IOException {
-        log(logWriter, "Run failed: " + message);
-        failRunWithMessage(runId, message, started);
-    }
-
-    private void failRunWithMessage(Long runId, Path logPath, String message, boolean started) {
-        try (BufferedWriter logWriter = Files.newBufferedWriter(logPath, StandardCharsets.UTF_8, java.nio.file.StandardOpenOption.APPEND)) {
-            log(logWriter, "Run failed: " + message);
-        } catch (IOException ex) {
-            logger.warn("Failed to append failure message to run log for run {}", runId, ex);
+    private void submitExecution(SimulationRunner.RunExecutionRequest request) {
+        CancellationToken token = cancellationTokens.computeIfAbsent(request.runId(), id -> new CancellationToken());
+        FutureTask<?> task = new FutureTask<>(() -> {
+            try {
+                simulationRunner.executeRun(request, token);
+            } finally {
+                runningTasks.remove(request.runId());
+                cancellationTokens.remove(request.runId());
+            }
+            return null;
+        });
+        try {
+            executor.execute(task);
+            runningTasks.put(request.runId(), task);
+            if (task.isDone()) {
+                runningTasks.remove(request.runId(), task);
+                cancellationTokens.remove(request.runId());
+            }
+        } catch (RejectedExecutionException ex) {
+            logger.warn("Run {} rejected: simulation execution queue is full", request.runId());
+            failRunWithMessage(request.runId(), "Simulation queue is full; run rejected.", false);
         }
-        failRunWithMessage(runId, message, started);
     }
 
     private void failRunWithMessage(Long runId, String message, boolean started) {
@@ -400,133 +173,15 @@ public class SimulationRunExecutionService {
         }
     }
 
-    private void cancelRunSafely(Long runId, BufferedWriter logWriter, String message) throws IOException {
-        log(logWriter, message);
-        cancelRunSafely(runId, message);
-    }
-
-    private void cancelRunSafely(Long runId, String message) {
-        try {
-            SimulationRun run = getRunById(runId);
-            if (run.getStatus() == SimulationRun.RunStatus.CANCELLED) {
-                return;
-            }
-            lifecycleManager.cancelRun(runId);
-        } catch (Exception ex) {
-            logger.error("Failed to mark run {} as cancelled", runId, ex);
-        }
-    }
-
-    private void writeResults(Long runId,
-                              Path runDir,
-                              LiftConfigDTO config,
-                              ScenarioDefinitionDTO scenario,
-                              RunMetrics metrics,
-                              String status,
-                              String message) throws IOException {
-        ObjectNode results = objectMapper.createObjectNode();
-        ObjectNode runSummary = results.putObject("runSummary");
-        runSummary.put("runId", runId);
-        runSummary.put("status", status);
-        runSummary.put("generatedAt", OffsetDateTime.now().toString());
-        if (message != null) {
-            runSummary.put("message", message);
-        }
-        if (scenario != null) {
-            runSummary.put("durationTicks", scenario.durationTicks());
-            if (scenario.seed() != null) {
-                runSummary.put("seed", scenario.seed());
-            }
-        }
-        if (metrics != null) {
-            runSummary.put("ticks", metrics.totalTicks());
-        }
-        try {
-            SimulationRun run = getRunById(runId);
-            runSummary.put("liftSystemId", run.getLiftSystem().getId());
-            runSummary.put("versionNumber", run.getVersion().getVersionNumber());
-        } catch (Exception ex) {
-            logger.warn("Failed to resolve run summary metadata for run {}", runId, ex);
-        }
-
-        if (metrics != null && config != null) {
-            results.set("kpis", metrics.toKpisNode(objectMapper));
-            results.set("perLift", metrics.toPerLiftNode(objectMapper, config));
-            results.set("perFloor", metrics.toPerFloorNode(objectMapper));
-        }
-
-        objectMapper.writerWithDefaultPrettyPrinter()
-            .writeValue(runDir.resolve(RESULTS_FILE_NAME).toFile(), results);
-    }
-
-    private void log(BufferedWriter writer, String message) throws IOException {
-        writer.write("[" + OffsetDateTime.now() + "] " + message);
-        writer.newLine();
-        writer.flush();
-    }
-
-    private String safeMessage(Exception ex) {
-        return ex.getMessage() != null ? ex.getMessage() : "Unexpected simulation failure";
-    }
-
-    @PreDestroy
-    public void shutdownExecutor() {
-        executor.shutdown();
-    }
-
-    private record RunExecutionRequest(Long runId, String configJson, String scenarioJson, String scenarioName) {
-    }
-
-    private void submitExecution(RunExecutionRequest request) {
-        FutureTask<?> task = new FutureTask<>(() -> { executeRun(request); return null; });
-        try {
-            executor.execute(task);
-            runningTasks.put(request.runId(), task);
-            if (task.isDone()) {
-                runningTasks.remove(request.runId(), task);
-                cancellationTokens.remove(request.runId());
-            }
-        } catch (RejectedExecutionException ex) {
-            logger.warn("Run {} rejected: simulation execution queue is full", request.runId());
-            failRunWithMessage(request.runId(), "Simulation queue is full; run rejected.", false);
-        }
-    }
-
-    private static final class CancellationToken {
+    static final class CancellationToken {
         private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
-        private void cancel() {
+        void cancel() {
             cancelled.set(true);
         }
 
-        private boolean isCancelled() {
+        boolean isCancelled() {
             return cancelled.get();
-        }
-    }
-
-    private static final class RunCancelledException extends CancellationException {
-        private static final long serialVersionUID = 1L;
-        private final transient RunMetrics metrics;
-        private final transient LiftConfigDTO config;
-        private final transient ScenarioDefinitionDTO scenario;
-
-        private RunCancelledException(String message, RunMetrics metrics, LiftConfigDTO config, ScenarioDefinitionDTO scenario) {
-            super(message);
-            this.metrics = metrics;
-            this.config = config;
-            this.scenario = scenario;
-        }
-
-        private RunMetrics getMetrics() {
-            return metrics;
-        }
-
-        private LiftConfigDTO getConfig() {
-            return config;
-        }
-
-        private ScenarioDefinitionDTO getScenario() {
-            return scenario;
         }
     }
 
@@ -540,5 +195,4 @@ public class SimulationRunExecutionService {
             return thread;
         }
     }
-
 }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -156,6 +156,7 @@ public class SimulationRunExecutionService {
             }
         } catch (RejectedExecutionException ex) {
             logger.warn("Run {} rejected: simulation execution queue is full", request.runId());
+            cancellationTokens.remove(request.runId(), token);
             failRunWithMessage(request.runId(), "Simulation queue is full; run rejected.", false);
         }
     }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java
@@ -1,7 +1,6 @@
 package com.liftsimulator.admin.service;
 
 import com.liftsimulator.admin.entity.SimulationRun;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,10 +33,6 @@ public class SimulationRunExecutionService {
     private final Map<Long, CancellationToken> cancellationTokens = new ConcurrentHashMap<>();
 
     @Autowired
-    @SuppressFBWarnings(
-        value = "EI_EXPOSE_REP2",
-        justification = "Injected dependencies and configuration managed by Spring."
-    )
     public SimulationRunExecutionService(
             RunLifecycleManager lifecycleManager,
             SimulationRunner simulationRunner,

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunner.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunner.java
@@ -302,6 +302,35 @@ public class SimulationRunner {
         return ex.getMessage() != null ? ex.getMessage() : "Unexpected simulation failure";
     }
 
+    private static final class RunCancelledException extends CancellationException {
+        private static final long serialVersionUID = 1L;
+        private final transient RunMetrics metrics;
+        private final transient LiftConfigDTO config;
+        private final transient ScenarioDefinitionDTO scenario;
+
+        private RunCancelledException(String message,
+                                      RunMetrics metrics,
+                                      LiftConfigDTO config,
+                                      ScenarioDefinitionDTO scenario) {
+            super(message);
+            this.metrics = metrics;
+            this.config = config;
+            this.scenario = scenario;
+        }
+
+        private RunMetrics getMetrics() {
+            return metrics;
+        }
+
+        private LiftConfigDTO getConfig() {
+            return config;
+        }
+
+        private ScenarioDefinitionDTO getScenario() {
+            return scenario;
+        }
+    }
+
     public record RunExecutionRequest(Long runId, String configJson, String scenarioJson, String scenarioName) {
     }
 }

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunner.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunner.java
@@ -12,6 +12,7 @@ import com.liftsimulator.domain.LiftRequest;
 import com.liftsimulator.engine.ControllerFactory;
 import com.liftsimulator.engine.RequestManagingLiftController;
 import com.liftsimulator.engine.SimulationEngine;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -42,6 +43,10 @@ public class SimulationRunner {
     private final ObjectMapper objectMapper;
     private final SimulationArtefactWriter artefactWriter;
 
+    @SuppressFBWarnings(
+        value = "EI_EXPOSE_REP2",
+        justification = "Injected collaborators are Spring-managed singleton services/configuration objects."
+    )
     public SimulationRunner(RunLifecycleManager lifecycleManager,
                             ConfigValidationService configValidationService,
                             ScenarioValidationService scenarioValidationService,

--- a/src/main/java/com/liftsimulator/admin/service/SimulationRunner.java
+++ b/src/main/java/com/liftsimulator/admin/service/SimulationRunner.java
@@ -1,0 +1,307 @@
+package com.liftsimulator.admin.service;
+
+import com.liftsimulator.admin.dto.ConfigValidationResponse;
+import com.liftsimulator.admin.dto.LiftConfigDTO;
+import com.liftsimulator.admin.dto.PassengerFlowDTO;
+import com.liftsimulator.admin.dto.ScenarioDefinitionDTO;
+import com.liftsimulator.admin.dto.ScenarioValidationResponse;
+import com.liftsimulator.admin.entity.SimulationRun;
+import com.liftsimulator.admin.service.metrics.RunMetrics;
+import com.liftsimulator.domain.Direction;
+import com.liftsimulator.domain.LiftRequest;
+import com.liftsimulator.engine.ControllerFactory;
+import com.liftsimulator.engine.RequestManagingLiftController;
+import com.liftsimulator.engine.SimulationEngine;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Runs a validated simulation request and coordinates lifecycle state transitions.
+ */
+@Service
+public class SimulationRunner {
+    private static final Logger logger = LoggerFactory.getLogger(SimulationRunner.class);
+    private static final int PROGRESS_UPDATE_INTERVAL = 5;
+
+    private final RunLifecycleManager lifecycleManager;
+    private final ConfigValidationService configValidationService;
+    private final ScenarioValidationService scenarioValidationService;
+    private final ObjectMapper objectMapper;
+    private final SimulationArtefactWriter artefactWriter;
+
+    public SimulationRunner(RunLifecycleManager lifecycleManager,
+                            ConfigValidationService configValidationService,
+                            ScenarioValidationService scenarioValidationService,
+                            ObjectMapper objectMapper,
+                            SimulationArtefactWriter artefactWriter) {
+        this.lifecycleManager = lifecycleManager;
+        this.configValidationService = configValidationService;
+        this.scenarioValidationService = scenarioValidationService;
+        this.objectMapper = objectMapper;
+        this.artefactWriter = artefactWriter;
+    }
+    public void executeRun(RunExecutionRequest request, SimulationRunExecutionService.CancellationToken cancelToken) {
+        boolean started = false;
+
+        SimulationRun runEntity;
+        try {
+            runEntity = getRunById(request.runId());
+        } catch (Exception ex) {
+            logger.error("Failed to load run {} for execution", request.runId(), ex);
+            return;
+        }
+
+        String artefactPath = runEntity.getArtefactBasePath();
+        if (artefactPath == null || artefactPath.isBlank()) {
+            logger.error("Run {} has no artefact path configured; cannot execute", request.runId());
+            failRunWithMessage(request.runId(), "Artefact path not configured for run.", false);
+            return;
+        }
+
+        Path runDir = Paths.get(artefactPath);
+        Path logPath = runDir.resolve(SimulationArtefactWriter.LOG_FILE_NAME);
+        logger.info("Run {} using artefact directory: {}", request.runId(), runDir);
+
+        try (BufferedWriter logWriter = artefactWriter.openLog(runDir)) {
+            artefactWriter.log(logWriter, "Run directory: " + runDir.toAbsolutePath());
+
+            if (request.scenarioJson() == null) {
+                artefactWriter.log(logWriter, "Missing scenario payload for run " + request.runId());
+                failRunWithMessage(request.runId(), logWriter, "Missing scenario payload for run.", false);
+                artefactWriter.writeResults(request.runId(), runDir, null, null, null, "FAILED", "Missing scenario payload for run.");
+                return;
+            }
+
+            ConfigValidationResponse configValidation = configValidationService.validate(request.configJson());
+            if (!configValidation.valid()) {
+                artefactWriter.log(logWriter, "Configuration validation failed: " + configValidation.errors());
+                failRunWithMessage(request.runId(), logWriter, "Invalid configuration payload.", false);
+                artefactWriter.writeResults(request.runId(), runDir, null, null, null, "FAILED", "Invalid configuration payload.");
+                return;
+            }
+
+            JsonNode scenarioNode = objectMapper.readTree(request.scenarioJson());
+            ScenarioValidationResponse scenarioValidation = scenarioValidationService.validate(scenarioNode);
+            if (!scenarioValidation.valid()) {
+                artefactWriter.log(logWriter, "Scenario validation failed: " + scenarioValidation.errors());
+                failRunWithMessage(request.runId(), logWriter, "Invalid scenario payload.", false);
+                artefactWriter.writeResults(request.runId(), runDir, null, null, null, "FAILED", "Invalid scenario payload.");
+                return;
+            }
+
+            LiftConfigDTO config = objectMapper.readValue(request.configJson(), LiftConfigDTO.class);
+            ScenarioDefinitionDTO scenario = objectMapper.readerFor(ScenarioDefinitionDTO.class)
+                .readValue(scenarioNode);
+
+            if (scenario.durationTicks() == null) {
+                artefactWriter.log(logWriter, "Scenario has null durationTicks");
+                SimulationRun runAtCheck = getRunById(request.runId());
+                boolean runAlreadyStarted = runAtCheck.getStatus() == SimulationRun.RunStatus.RUNNING;
+                failRunWithMessage(request.runId(), logWriter, "Scenario must have a valid durationTicks value.", runAlreadyStarted);
+                artefactWriter.writeResults(request.runId(), runDir, null, null, null, "FAILED", "Scenario must have a valid durationTicks value.");
+                return;
+            }
+
+            artefactWriter.writeInputFiles(request, runDir, logWriter);
+
+            lifecycleManager.configureRun(
+                request.runId(),
+                scenario.durationTicks().longValue(),
+                scenario.seed() != null ? scenario.seed().longValue() : null,
+                null
+            );
+
+            // Start the run if not already started (it may have been started by createAndStartRun)
+            SimulationRun currentRun = getRunById(request.runId());
+            if (currentRun.getStatus() == SimulationRun.RunStatus.CANCELLED || cancelToken.isCancelled()) {
+                artefactWriter.log(logWriter, "Run cancelled before start for run " + request.runId());
+                cancelRunSafely(request.runId(), logWriter, "Run cancelled before start.");
+                artefactWriter.writeResults(request.runId(), runDir, config, scenario, null, "CANCELLED", "Run cancelled before start.");
+                return;
+            }
+            if (currentRun.getStatus() != SimulationRun.RunStatus.RUNNING) {
+                lifecycleManager.startRun(request.runId());
+            }
+            started = true;
+            lifecycleManager.updateProgress(request.runId(), 0L);
+            artefactWriter.log(logWriter, "Simulation started for run " + request.runId());
+
+            RunMetrics metrics;
+            try {
+                metrics = runSimulation(request.runId(), config, scenario, logWriter, cancelToken);
+            } catch (RunCancelledException ex) {
+                cancelRunSafely(request.runId(), logWriter, ex.getMessage());
+                artefactWriter.writeResults(request.runId(), runDir, ex.getConfig(), ex.getScenario(), ex.getMetrics(), "CANCELLED", ex.getMessage());
+                return;
+            }
+
+            if (cancelToken.isCancelled() || getRunById(request.runId()).getStatus() == SimulationRun.RunStatus.CANCELLED) {
+                artefactWriter.log(logWriter, "Run cancelled for run " + request.runId());
+                artefactWriter.writeResults(request.runId(), runDir, config, scenario, metrics, "CANCELLED", "Run cancelled.");
+                return;
+            }
+            artefactWriter.log(logWriter, "Simulation succeeded for run " + request.runId());
+            artefactWriter.writeResults(request.runId(), runDir, config, scenario, metrics, "SUCCEEDED", null);
+            lifecycleManager.succeedRun(request.runId());
+        } catch (IOException | RuntimeException ex) {
+            String errorMessage = safeMessage(ex);
+            logger.error("Simulation run {} failed", request.runId(), ex);
+            failRunWithMessage(request.runId(), logPath, errorMessage, started);
+            try {
+                artefactWriter.writeResults(request.runId(), runDir, null, null, null, "FAILED", errorMessage);
+            } catch (IOException ioEx) {
+                logger.warn("Failed to write results file for run {}", request.runId(), ioEx);
+            }
+        }
+    }
+
+    private RunMetrics runSimulation(Long runId,
+                                     LiftConfigDTO config,
+                                     ScenarioDefinitionDTO scenario,
+                                     BufferedWriter logWriter,
+                                     SimulationRunExecutionService.CancellationToken cancelToken) throws IOException {
+        RequestManagingLiftController controller = (RequestManagingLiftController) ControllerFactory.createController(
+            config.controllerStrategy(),
+            config.homeFloor(),
+            config.idleTimeoutTicks(),
+            config.idleParkingMode()
+        );
+
+        SimulationEngine engine = SimulationEngine.builder(controller, config.minFloor(), config.maxFloor())
+            .initialFloor(config.homeFloor())
+            .travelTicksPerFloor(config.travelTicksPerFloor())
+            .doorTransitionTicks(config.doorTransitionTicks())
+            .doorDwellTicks(config.doorDwellTicks())
+            .doorReopenWindowTicks(config.doorReopenWindowTicks())
+            .build();
+
+        Map<Integer, List<PassengerFlowDTO>> flowsByTick = groupFlowsByTick(scenario);
+        RunMetrics metrics = new RunMetrics(config.minFloor(), config.maxFloor());
+
+        artefactWriter.log(logWriter, "Starting simulation for " + scenario.durationTicks() + " ticks.");
+        for (int tick = 0; tick < scenario.durationTicks(); tick++) {
+            if (cancelToken.isCancelled() || Thread.currentThread().isInterrupted()) {
+                throw new RunCancelledException("Run cancelled at tick " + engine.getCurrentTick() + ".",
+                    metrics,
+                    config,
+                    scenario);
+            }
+            long currentTick = engine.getCurrentTick();
+            List<PassengerFlowDTO> flows = flowsByTick.getOrDefault((int) currentTick, List.of());
+            for (PassengerFlowDTO flow : flows) {
+                int passengers = flow.passengers() != null ? flow.passengers() : 1;
+
+                // Determine direction based on origin and destination floors
+                Direction direction;
+                if (flow.destinationFloor() > flow.originFloor()) {
+                    direction = Direction.UP;
+                } else if (flow.destinationFloor() < flow.originFloor()) {
+                    direction = Direction.DOWN;
+                } else {
+                    // Same floor - skip this flow as it doesn't require lift movement
+                    continue;
+                }
+
+                metrics.recordPassengerFlow(flow, passengers);
+
+                // One hall call per flow; passenger count is carried on the request for KPI accounting
+                LiftRequest request = LiftRequest.hallCall(flow.originFloor(), direction, passengers);
+                metrics.recordRequestCreation(request, currentTick);
+                controller.addRequest(request);
+            }
+
+            metrics.recordActiveRequests(controller.getRequests(), currentTick);
+            engine.tick();
+            metrics.recordLiftState(engine.getCurrentState());
+            metrics.recordTerminalRequests(engine.getCurrentTick());
+
+            long progressTick = tick + 1L;
+            if (tick % PROGRESS_UPDATE_INTERVAL == 0) {
+                lifecycleManager.updateProgress(runId, progressTick);
+            }
+        }
+
+        lifecycleManager.updateProgress(runId, (long) scenario.durationTicks());
+        artefactWriter.log(logWriter, "Simulation completed at tick " + engine.getCurrentTick());
+        metrics.recordTerminalRequests(engine.getCurrentTick());
+        return metrics;
+    }
+
+    private Map<Integer, List<PassengerFlowDTO>> groupFlowsByTick(ScenarioDefinitionDTO scenario) {
+        if (scenario.passengerFlows() == null || scenario.passengerFlows().isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<Integer, List<PassengerFlowDTO>> flowsByTick = new HashMap<>(scenario.passengerFlows().size());
+        for (PassengerFlowDTO flow : scenario.passengerFlows()) {
+            int tick = flow.startTick() != null ? flow.startTick() : 0;
+            flowsByTick.computeIfAbsent(tick, key -> new ArrayList<>()).add(flow);
+        }
+        return flowsByTick;
+    }
+
+    private SimulationRun getRunById(Long runId) {
+        return lifecycleManager.getByIdWithDetails(runId);
+    }
+
+
+    private void failRunWithMessage(Long runId, BufferedWriter logWriter, String message, boolean started) throws IOException {
+        artefactWriter.log(logWriter, "Run failed: " + message);
+        failRunWithMessage(runId, message, started);
+    }
+
+    private void failRunWithMessage(Long runId, Path logPath, String message, boolean started) {
+        artefactWriter.appendLog(logPath, "Run failed: " + message);
+        failRunWithMessage(runId, message, started);
+    }
+
+    private void failRunWithMessage(Long runId, String message, boolean started) {
+        try {
+            if (!started) {
+                lifecycleManager.startRun(runId);
+            }
+            lifecycleManager.failRun(runId, message);
+        } catch (IllegalStateException ex) {
+            lifecycleManager.markRunningRunFailedSafely(runId, message, ex);
+        } catch (Exception ex) {
+            logger.error("Failed to mark run {} as failed", runId, ex);
+        }
+    }
+
+    private void cancelRunSafely(Long runId, BufferedWriter logWriter, String message) throws IOException {
+        artefactWriter.log(logWriter, message);
+        cancelRunSafely(runId, message);
+    }
+
+    private void cancelRunSafely(Long runId, String message) {
+        try {
+            SimulationRun run = getRunById(runId);
+            if (run.getStatus() == SimulationRun.RunStatus.CANCELLED) {
+                return;
+            }
+            lifecycleManager.cancelRun(runId);
+        } catch (Exception ex) {
+            logger.error("Failed to mark run {} as cancelled", runId, ex);
+        }
+    }
+
+    private String safeMessage(Exception ex) {
+        return ex.getMessage() != null ? ex.getMessage() : "Unexpected simulation failure";
+    }
+
+    public record RunExecutionRequest(Long runId, String configJson, String scenarioJson, String scenarioName) {
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce coupling and surface area of the async execution path by separating executor/queue/cancellation concerns from simulation validation, ticking, and filesystem artefact writes.
- Make the runner logic and filesystem interactions easier to reason about and test by giving them single responsibilities.
- Keep the public simulation-run API unchanged while enabling safer lifecycle handling and clearer failure paths.

### Description
- Extracted a new `SimulationRunner` service that performs validation, lifecycle transitions, per-tick simulation (`runSimulation`), progress updates, and cancellation-safe completion (`src/main/java/com/liftsimulator/admin/service/SimulationRunner.java`).
- Added `SimulationArtefactWriter` to centralise log/open/write helpers, input snapshots, batch input generation, and `results.json` writing (`src/main/java/com/liftsimulator/admin/service/SimulationArtefactWriter.java`).
- Refactored `SimulationRunExecutionService` to focus on asynchronous submission, executor lifecycle, cancellation-token management, and in-flight task tracking while delegating execution to `SimulationRunner` (`src/main/java/com/liftsimulator/admin/service/SimulationRunExecutionService.java`).
- Updated documentation and packaging metadata: bumped project version to `0.57.8` (`pom.xml`, `README.md`, frontend `package.json`/`package-lock.json`), added a changelog entry, and revised architecture diagrams and prose to describe the new responsibilities (`CHANGELOG.md`, `docs/architecture.md`, `docs/architecture-diagram.mermaid`, `docs/Workflows-and-Troubleshooting.md`).

### Testing
- Ran `./scripts/sync-versions.sh --check` to verify version references, which completed successfully.
- Ran `git diff --check` to ensure no whitespace or obvious diff issues, which completed successfully.
- Attempted a compile with `mvn -q -DskipTests compile`, which was blocked by Maven failing to resolve the Spring Boot parent POM due to an external HTTP 403 error when contacting Maven Central.
- Attempted offline compile with `mvn -o -q -DskipTests compile`, which failed because the parent POM is not present in the local Maven cache.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5269e0e3a883258f85b18d6867a653)