### PR TITLE
refactor(frontend): decompose Simulator and SimulationRunDetail into subcomponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.9] - 2026-07-11
+
+### Changed
+- **Frontend simulation page decomposition**: Split the simulator setup, run-status, and results rendering out of the large `Simulator.jsx` and `SimulationRunDetail.jsx` pages into reusable simulation-run components, with shared result-formatting helpers for KPIs, artefact sizes, and per-lift metrics. Updated frontend documentation and package metadata for the 0.57.9 pre-MVP patch release.
+
 ## [0.57.8] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.8**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.9**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.8.jar
+java -jar target/lift-simulator-0.57.9.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.8.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.9.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.8.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -180,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.8.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.9.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.8.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.9.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -50,7 +50,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.8.jar \
+java -cp target/lift-simulator-0.57.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -64,12 +64,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.8.jar \
+java -cp target/lift-simulator-0.57.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.8.jar \
+java -cp target/lift-simulator-0.57.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -113,7 +113,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.8.jar \
+java -cp target/lift-simulator-0.57.9.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -391,7 +391,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.8.jar \
+   java -cp target/lift-simulator-0.57.9.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -436,7 +436,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.8.jar \
+java -cp target/lift-simulator-0.57.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -528,7 +528,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.8.jar \
+java -cp target/lift-simulator-0.57.9.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,6 +16,7 @@ This is the frontend admin application for the Lift Simulator system. It provide
 - Validating configuration JSON and displaying detailed validation errors
 - Managing simulation runs, including multi-select bulk cancellation for active runs and bulk deletion for completed runs
 - Monitoring system health
+- Running simulations through decomposed setup, run-status, and results panels shared with run detail views
 
 For the overall project setup (backend, database, and Quick Start), see the [root README](../README.md). Backend REST API conventions (auth, RBAC, rate limits, error shape) live in [docs/API.md](../docs/API.md), and the always-current endpoint reference is the generated Swagger UI at `/api/v1/swagger-ui.html`.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.8",
+  "version": "0.57.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.8",
+      "version": "0.57.9",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.8",
+  "version": "0.57.9",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/components/simulation-runs/SimulationResultsPanel.jsx
+++ b/frontend/src/components/simulation-runs/SimulationResultsPanel.jsx
@@ -1,0 +1,129 @@
+import { Link } from 'react-router-dom';
+import {
+  formatBytes,
+  formatKpiValue,
+  formatNumber,
+  getPickupLegUtilisation,
+  kpiLabels,
+} from '../../utils/simulationResultsUtils';
+
+function SimulationResultsPanel({
+  cardClassName = 'detail-card',
+  runInfo,
+  runStatus,
+  results,
+  artefacts,
+  resultsError,
+  artefactDownloadUrl,
+  onArtefactDownload,
+  showFullDetailsLink = false,
+  showMissingInputMessage = false,
+  onlyShowReproduceOnSuccess = true,
+}) {
+  const runSummary = results?.results?.runSummary;
+  const kpis = results?.results?.kpis;
+  const perLift = results?.results?.perLift || [];
+  const perFloor = results?.results?.perFloor || [];
+  const inputArtefact = artefacts.find((item) => item.name === 'input.scenario');
+  const showReproduce = inputArtefact && (!onlyShowReproduceOnSuccess || runStatus === 'SUCCEEDED');
+
+  return (
+    <section className={cardClassName}>
+      <div className="results-header">
+        <h3>Results</h3>
+        {showFullDetailsLink && (
+          <Link to={`/simulation-runs/${runInfo.id}`} className="btn-secondary btn-small">
+            View Full Details
+          </Link>
+        )}
+      </div>
+      {resultsError && <p className="error">{resultsError}</p>}
+
+      {runStatus === 'FAILED' && (
+        <div className="result-banner error">
+          <strong>Simulation failed.</strong>
+          <p>{results?.errorMessage || runInfo.errorMessage || 'Unknown error.'}</p>
+        </div>
+      )}
+
+      {runStatus === 'CANCELLED' && (
+        <div className="result-banner warning">
+          <strong>Simulation was cancelled.</strong>
+        </div>
+      )}
+
+      {runStatus === 'SUCCEEDED' && results?.results && (
+        <>
+          <div className="result-banner success">
+            <strong>Simulation completed successfully.</strong>
+            {results.errorMessage && <p>{results.errorMessage}</p>}
+          </div>
+          <div className="kpi-grid">
+            {kpis && Object.entries(kpis).map(([key, value]) => (
+              <div key={key} className="kpi-card">
+                <span>{kpiLabels[key] || key}</span>
+                <strong>{formatKpiValue(key, value)}</strong>
+              </div>
+            ))}
+          </div>
+          <div className="results-section">
+            <h4>Run Summary</h4>
+            <div className="summary-grid">
+              <div><span className="label">Generated</span><p>{runSummary?.generatedAt ? new Date(runSummary.generatedAt).toLocaleString() : '—'}</p></div>
+              <div><span className="label">Ticks</span><p>{runSummary?.ticks ?? '—'}</p></div>
+              <div><span className="label">Duration</span><p>{runSummary?.durationTicks ?? '—'} ticks</p></div>
+              <div><span className="label">Seed</span><p>{runSummary?.seed ?? runInfo.seed ?? '—'}</p></div>
+            </div>
+          </div>
+          <div className="results-section">
+            <h4>Per Lift</h4>
+            {perLift.length === 0 ? <p>No lift metrics available.</p> : (
+              <div className="table-wrapper"><table><thead><tr><th>Lift</th><th>Controller</th><th>Parking</th><th>Pickup-leg Utilisation</th><th>Idle</th><th>Moving</th><th>Door</th><th>Status Counts</th></tr></thead><tbody>
+                {perLift.map((lift) => <tr key={lift.liftId}><td>{lift.liftId}</td><td>{lift.controllerStrategy || '—'}</td><td>{lift.idleParkingMode || '—'}</td><td>{formatKpiValue('pickupLegUtilisation', getPickupLegUtilisation(lift))}</td><td>{formatNumber(lift.idleTicks)}</td><td>{formatNumber(lift.movingTicks)}</td><td>{formatNumber(lift.doorTicks)}</td><td>{lift.statusCounts ? Object.entries(lift.statusCounts).map(([status, count]) => `${status}: ${count}`).join(', ') : '—'}</td></tr>)}
+              </tbody></table></div>
+            )}
+          </div>
+          <div className="results-section">
+            <h4>Per Floor</h4>
+            {perFloor.length === 0 ? <p>No floor metrics available.</p> : (
+              <div className="table-wrapper"><table><thead><tr><th>Floor</th><th>Origin Passengers</th><th>Destination Passengers</th><th>Lift Visits</th></tr></thead><tbody>
+                {perFloor.map((floor) => <tr key={floor.floor}><td>{floor.floor}</td><td>{formatNumber(floor.originPassengers)}</td><td>{formatNumber(floor.destinationPassengers)}</td><td>{formatNumber(floor.liftVisits)}</td></tr>)}
+              </tbody></table></div>
+            )}
+          </div>
+        </>
+      )}
+
+      {runStatus === 'SUCCEEDED' && !results?.results && (
+        <div className="result-banner warning">
+          <strong>Simulation completed, but results were unavailable.</strong>
+          <p>{results?.errorMessage || 'Results file could not be read.'}</p>
+        </div>
+      )}
+
+      <div className="results-section">
+        <h4>Artefacts</h4>
+        {artefacts.length === 0 ? <p>No artefacts available.</p> : (
+          <div className="table-wrapper"><table><thead><tr><th>Name</th><th>Size</th><th>Type</th><th>Download</th></tr></thead><tbody>
+            {artefacts.map((artefact) => <tr key={`${artefact.name}-${artefact.path}`}><td>{artefact.name}</td><td>{formatBytes(artefact.size)}</td><td>{artefact.mimeType}</td><td><a className="link" href={artefactDownloadUrl(artefact.path)} onClick={(event) => onArtefactDownload(event, artefact)}>Download</a></td></tr>)}
+          </tbody></table></div>
+        )}
+      </div>
+
+      {(showReproduce || showMissingInputMessage) && (
+        <div className="results-section reproduce-section">
+          <h4>Reproduce via CLI</h4>
+          <p>Use the generated batch input file to reproduce this run with the CLI simulator.</p>
+          {inputArtefact ? (
+            <div className="reproduce-actions">
+              <a className="btn-secondary" href={artefactDownloadUrl(inputArtefact.path)} onClick={(event) => onArtefactDownload(event, inputArtefact)}>Download input.scenario</a>
+              <code>lift-simulator --input {inputArtefact.path}</code>
+            </div>
+          ) : <p className="warning">Input file not available for this run.</p>}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default SimulationResultsPanel;

--- a/frontend/src/components/simulation-runs/SimulationRunStatusCard.jsx
+++ b/frontend/src/components/simulation-runs/SimulationRunStatusCard.jsx
@@ -1,0 +1,80 @@
+import { formatDate, formatRunDuration, getRunStatusPillClass } from '../../utils/statusUtils';
+
+function SimulationRunStatusCard({
+  cardClassName = 'detail-card',
+  title = 'Run Status',
+  runInfo,
+  runStatus,
+  isTerminal = false,
+  elapsedMs,
+  progressPercentage,
+  runError = null,
+  onCancel,
+  isCancelling = false,
+  onDelete,
+  isDeleting = false,
+  showDeleteButton = false,
+  hideProgressWhenTerminal = false,
+  fields,
+}) {
+  const defaultFields = [
+    { label: 'Run ID', value: runInfo.id },
+    { label: 'Lift System', value: runInfo.liftSystemId },
+    { label: 'Version', value: runInfo.versionNumber },
+    { label: 'Scenario', value: runInfo.scenarioId || '—' },
+    { label: 'Created', value: formatDate(runInfo.createdAt) },
+    { label: 'Started', value: formatDate(runInfo.startedAt) },
+    { label: 'Ended', value: formatDate(runInfo.endedAt) },
+    { label: 'Duration', value: formatRunDuration(elapsedMs) },
+    { label: 'Seed', value: runInfo.seed ?? '—' },
+  ];
+  const visibleFields = fields || defaultFields;
+  const canCancel = runStatus === 'RUNNING' || runStatus === 'CREATED';
+  const shouldShowProgress = progressPercentage != null && (!hideProgressWhenTerminal || !isTerminal);
+
+  return (
+    <section className={cardClassName}>
+      <div className="status-header">
+        <h3>{title}</h3>
+        <div className="status-actions">
+          <span className={getRunStatusPillClass(runStatus)}>{runStatus}</span>
+          {canCancel && onCancel && (
+            <button className="btn-danger" type="button" onClick={onCancel} disabled={isCancelling}>
+              {isCancelling ? 'Cancelling...' : 'Cancel Run'}
+            </button>
+          )}
+          {showDeleteButton && isTerminal && onDelete && (
+            <button className="btn-danger" type="button" onClick={onDelete} disabled={isDeleting}>
+              {isDeleting ? 'Deleting...' : 'Delete Run'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="status-grid">
+        {visibleFields.map((field) => (
+          <div key={field.label}>
+            <span className="label">{field.label}</span>
+            <p>{field.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {shouldShowProgress && (
+        <div className="progress-section">
+          <div className="progress-meta">
+            <span>{runInfo.currentTick ?? 0} / {runInfo.totalTicks} ticks</span>
+            <span>{progressPercentage.toFixed(1)}%</span>
+          </div>
+          <div className="progress-bar">
+            <div className="progress-fill" style={{ width: `${progressPercentage}%` }} />
+          </div>
+        </div>
+      )}
+
+      {runError && <p className="error">{runError}</p>}
+    </section>
+  );
+}
+
+export default SimulationRunStatusCard;

--- a/frontend/src/components/simulation-runs/SimulatorRunSetup.jsx
+++ b/frontend/src/components/simulation-runs/SimulatorRunSetup.jsx
@@ -1,0 +1,71 @@
+function SimulatorRunSetup({
+  loading,
+  formError,
+  systems,
+  publishedVersions,
+  filteredScenarios,
+  selectedSystemId,
+  selectedVersionNumber,
+  selectedScenarioId,
+  seed,
+  isStarting,
+  isRunActive,
+  selectedSystem,
+  selectedVersion,
+  selectedScenario,
+  onSystemChange,
+  onVersionChange,
+  onScenarioChange,
+  onSeedChange,
+  onStartRun,
+}) {
+  return (
+    <section className="simulator-card">
+      <h3>Run Setup</h3>
+      {loading ? <p>Loading options...</p> : formError ? <p className="error">{formError}</p> : (
+        <div className="run-setup-grid">
+          <label className="field">
+            <span>Lift System</span>
+            <select value={selectedSystemId} onChange={(event) => onSystemChange(event.target.value)}>
+              <option value="">Select a lift system</option>
+              {systems.map((system) => <option key={system.id} value={system.id}>{system.displayName}</option>)}
+            </select>
+          </label>
+          <label className="field">
+            <span>Published Version</span>
+            <select value={selectedVersionNumber} onChange={(event) => onVersionChange(event.target.value)} disabled={!selectedSystemId || publishedVersions.length === 0}>
+              <option value="">Select a published version</option>
+              {publishedVersions.map((version) => <option key={version.id} value={version.versionNumber}>Version {version.versionNumber}</option>)}
+            </select>
+            {!selectedSystemId && <small>Select a system to view published versions.</small>}
+            {selectedSystemId && publishedVersions.length === 0 && <small className="warning">No published versions available for this system.</small>}
+          </label>
+          <label className="field">
+            <span>Scenario</span>
+            <select value={selectedScenarioId} onChange={(event) => onScenarioChange(event.target.value)} disabled={!selectedVersionNumber || filteredScenarios.length === 0}>
+              <option value="">Select a scenario</option>
+              {filteredScenarios.map((scenario) => <option key={scenario.id} value={scenario.id}>{scenario.name}</option>)}
+            </select>
+            {!selectedVersionNumber && <small>Select a version to view compatible scenarios.</small>}
+            {selectedVersionNumber && filteredScenarios.length === 0 && <small className="warning">No scenarios available for this version. Create one from the Scenarios page.</small>}
+          </label>
+          <label className="field">
+            <span>Optional Seed</span>
+            <input type="number" value={seed} onChange={(event) => onSeedChange(event.target.value)} placeholder="Leave blank for random" />
+          </label>
+          <div className="run-setup-actions">
+            <button className="btn-primary" onClick={onStartRun} disabled={isStarting || isRunActive || !selectedSystemId || !selectedVersionNumber || !selectedScenarioId}>
+              {isStarting ? 'Starting...' : isRunActive ? 'Run in Progress' : 'Start Run'}
+            </button>
+            {selectedSystem && selectedVersion && selectedScenario && (
+              <div className="selection-summary"><strong>Selected:</strong> {selectedSystem.displayName} · Version {selectedVersion.versionNumber} · {selectedScenario.name}</div>
+            )}
+            {isRunActive && <small className="run-in-progress-hint">A simulation run is in progress. Wait for it to complete or cancel it to start a new run.</small>}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default SimulatorRunSetup;

--- a/frontend/src/pages/SimulationRunDetail.jsx
+++ b/frontend/src/pages/SimulationRunDetail.jsx
@@ -7,23 +7,9 @@ import AlertModal from '../components/AlertModal';
 import ConfirmModal from '../components/ConfirmModal';
 import { getApiErrorMessage, handleApiError, logApiError } from '../utils/errorHandlers';
 import { isTerminalRunStatus, useRunPolling } from '../hooks/useRunPolling';
-import { formatDate, formatRunDuration, getRunStatusPillClass } from '../utils/statusUtils';
+import SimulationRunStatusCard from '../components/simulation-runs/SimulationRunStatusCard';
+import SimulationResultsPanel from '../components/simulation-runs/SimulationResultsPanel';
 import './SimulationRunDetail.css';
-
-const kpiLabels = {
-  requestsTotal: 'Requests',
-  pickupRequestsServed: 'Pickup Requests Served',
-  pickupRequestsCancelled: 'Pickup Requests Cancelled',
-  passengersServed: 'Passengers Served',
-  passengersCancelled: 'Passengers Cancelled',
-  avgPickupWaitTicks: 'Avg Wait to Pickup (ticks)',
-  maxPickupWaitTicks: 'Max Wait to Pickup (ticks)',
-  idleTicks: 'Idle Ticks',
-  movingTicks: 'Moving Ticks',
-  doorTicks: 'Door Ticks',
-  pickupLegUtilisation: 'Pickup-leg Utilisation',
-  utilisation: 'Pickup-leg Utilisation',
-};
 
 /**
  * Simulation run detail page component.
@@ -214,41 +200,6 @@ function SimulationRunDetail() {
     [runInfo?.id, artefactDownloadUrl]
   );
 
-  const formatNumber = (value) => {
-    if (value == null || Number.isNaN(value)) return '—';
-    if (typeof value === 'number') {
-      return Number.isInteger(value) ? value.toString() : value.toFixed(2);
-    }
-    return String(value);
-  };
-
-  const formatKpiValue = (key, value) => {
-    if ((key === 'pickupLegUtilisation' || key === 'utilisation') && typeof value === 'number') {
-      return `${(value * 100).toFixed(1)}%`;
-    }
-    return formatNumber(value);
-  };
-
-  const getPickupLegUtilisation = (lift) => lift?.pickupLegUtilisation ?? lift?.utilisation;
-
-  const formatBytes = (bytes) => {
-    if (!bytes && bytes !== 0) return '—';
-    const units = ['B', 'KB', 'MB', 'GB'];
-    let size = bytes;
-    let index = 0;
-    while (size >= 1024 && index < units.length - 1) {
-      size /= 1024;
-      index += 1;
-    }
-    return `${size.toFixed(1)} ${units[index]}`;
-  };
-
-  const runSummary = results?.results?.runSummary;
-  const kpis = results?.results?.kpis;
-  const perLift = results?.results?.perLift || [];
-  const perFloor = results?.results?.perFloor || [];
-  const inputArtefact = artefacts.find((item) => item.name === 'input.scenario');
-
   if (loading) {
     return (
       <div className="simulation-run-detail">
@@ -294,293 +245,33 @@ function SimulationRunDetail() {
         </div>
       </div>
 
-      <section className="detail-card">
-        <div className="status-header">
-          <h3>Run Status</h3>
-          <div className="status-actions">
-            <span className={getRunStatusPillClass(runStatus)}>
-              {runStatus}
-            </span>
-            {(runStatus === 'RUNNING' || runStatus === 'CREATED') && (
-              <button
-                className="btn-danger"
-                type="button"
-                onClick={() => setShowCancelModal(true)}
-                disabled={isCancelling}
-              >
-                {isCancelling ? 'Cancelling...' : 'Cancel Run'}
-              </button>
-            )}
-            {isTerminal && (
-              <button
-                className="btn-danger"
-                type="button"
-                onClick={() => {
-                  setDeleteError(null);
-                  setShowDeleteModal(true);
-                }}
-                disabled={isDeleting}
-              >
-                {isDeleting ? 'Deleting...' : 'Delete Run'}
-              </button>
-            )}
-          </div>
-        </div>
-
-        <div className="status-grid">
-          <div>
-            <span className="label">Run ID</span>
-            <p>{runInfo.id}</p>
-          </div>
-          <div>
-            <span className="label">Lift System</span>
-            <p>{runInfo.liftSystemId}</p>
-          </div>
-          <div>
-            <span className="label">Version</span>
-            <p>{runInfo.versionNumber}</p>
-          </div>
-          <div>
-            <span className="label">Scenario</span>
-            <p>{runInfo.scenarioId || '—'}</p>
-          </div>
-          <div>
-            <span className="label">Created</span>
-            <p>{formatDate(runInfo.createdAt)}</p>
-          </div>
-          <div>
-            <span className="label">Started</span>
-            <p>{formatDate(runInfo.startedAt)}</p>
-          </div>
-          <div>
-            <span className="label">Ended</span>
-            <p>{formatDate(runInfo.endedAt)}</p>
-          </div>
-          <div>
-            <span className="label">Duration</span>
-            <p>{formatRunDuration(elapsedMs)}</p>
-          </div>
-          <div>
-            <span className="label">Seed</span>
-            <p>{runInfo.seed ?? '—'}</p>
-          </div>
-        </div>
-
-        {progressPercentage != null && !isTerminal && (
-          <div className="progress-section">
-            <div className="progress-meta">
-              <span>
-                {runInfo.currentTick ?? 0} / {runInfo.totalTicks} ticks
-              </span>
-              <span>{progressPercentage.toFixed(1)}%</span>
-            </div>
-            <div className="progress-bar">
-              <div
-                className="progress-fill"
-                style={{ width: `${progressPercentage}%` }}
-              />
-            </div>
-          </div>
-        )}
-      </section>
+      <SimulationRunStatusCard
+        runInfo={runInfo}
+        runStatus={runStatus}
+        isTerminal={isTerminal}
+        elapsedMs={elapsedMs}
+        progressPercentage={progressPercentage}
+        onCancel={() => setShowCancelModal(true)}
+        isCancelling={isCancelling}
+        onDelete={() => {
+          setDeleteError(null);
+          setShowDeleteModal(true);
+        }}
+        isDeleting={isDeleting}
+        showDeleteButton
+        hideProgressWhenTerminal
+      />
 
       {isTerminal && (
-        <section className="detail-card">
-          <h3>Results</h3>
-          {resultsError && <p className="error">{resultsError}</p>}
-
-          {runStatus === 'FAILED' && (
-            <div className="result-banner error">
-              <strong>Simulation failed.</strong>
-              <p>{results?.errorMessage || runInfo.errorMessage || 'Unknown error.'}</p>
-            </div>
-          )}
-
-          {runStatus === 'CANCELLED' && (
-            <div className="result-banner warning">
-              <strong>Simulation was cancelled.</strong>
-            </div>
-          )}
-
-          {runStatus === 'SUCCEEDED' && results?.results && (
-            <>
-              <div className="result-banner success">
-                <strong>Simulation completed successfully.</strong>
-              </div>
-
-              <div className="kpi-grid">
-                {kpis &&
-                  Object.entries(kpis).map(([key, value]) => (
-                    <div key={key} className="kpi-card">
-                      <span>{kpiLabels[key] || key}</span>
-                      <strong>{formatKpiValue(key, value)}</strong>
-                    </div>
-                  ))}
-              </div>
-
-              <div className="results-section">
-                <h4>Run Summary</h4>
-                <div className="summary-grid">
-                  <div>
-                    <span className="label">Generated</span>
-                    <p>{runSummary?.generatedAt ? new Date(runSummary.generatedAt).toLocaleString() : '—'}</p>
-                  </div>
-                  <div>
-                    <span className="label">Ticks</span>
-                    <p>{runSummary?.ticks ?? '—'}</p>
-                  </div>
-                  <div>
-                    <span className="label">Duration</span>
-                    <p>{runSummary?.durationTicks ?? '—'} ticks</p>
-                  </div>
-                  <div>
-                    <span className="label">Seed</span>
-                    <p>{runSummary?.seed ?? runInfo.seed ?? '—'}</p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="results-section">
-                <h4>Per Lift</h4>
-                {perLift.length === 0 ? (
-                  <p>No lift metrics available.</p>
-                ) : (
-                  <div className="table-wrapper">
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Lift</th>
-                          <th>Controller</th>
-                          <th>Parking</th>
-                          <th>Pickup-leg Utilisation</th>
-                          <th>Idle</th>
-                          <th>Moving</th>
-                          <th>Door</th>
-                          <th>Status Counts</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {perLift.map((lift) => (
-                          <tr key={lift.liftId}>
-                            <td>{lift.liftId}</td>
-                            <td>{lift.controllerStrategy || '—'}</td>
-                            <td>{lift.idleParkingMode || '—'}</td>
-                            <td>{formatKpiValue('pickupLegUtilisation', getPickupLegUtilisation(lift))}</td>
-                            <td>{formatNumber(lift.idleTicks)}</td>
-                            <td>{formatNumber(lift.movingTicks)}</td>
-                            <td>{formatNumber(lift.doorTicks)}</td>
-                            <td>
-                              {lift.statusCounts
-                                ? Object.entries(lift.statusCounts)
-                                    .map(([status, count]) => `${status}: ${count}`)
-                                    .join(', ')
-                                : '—'}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-
-              <div className="results-section">
-                <h4>Per Floor</h4>
-                {perFloor.length === 0 ? (
-                  <p>No floor metrics available.</p>
-                ) : (
-                  <div className="table-wrapper">
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Floor</th>
-                          <th>Origin Passengers</th>
-                          <th>Destination Passengers</th>
-                          <th>Lift Visits</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {perFloor.map((floor) => (
-                          <tr key={floor.floor}>
-                            <td>{floor.floor}</td>
-                            <td>{formatNumber(floor.originPassengers)}</td>
-                            <td>{formatNumber(floor.destinationPassengers)}</td>
-                            <td>{formatNumber(floor.liftVisits)}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-
-          {runStatus === 'SUCCEEDED' && !results?.results && (
-            <div className="result-banner warning">
-              <strong>Simulation completed, but results were unavailable.</strong>
-              <p>{results?.errorMessage || 'Results file could not be read.'}</p>
-            </div>
-          )}
-
-          <div className="results-section">
-            <h4>Artefacts</h4>
-            {artefacts.length === 0 ? (
-              <p>No artefacts available.</p>
-            ) : (
-              <div className="table-wrapper">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Size</th>
-                      <th>Type</th>
-                      <th>Download</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {artefacts.map((artefact) => (
-                      <tr key={`${artefact.name}-${artefact.path}`}>
-                        <td>{artefact.name}</td>
-                        <td>{formatBytes(artefact.size)}</td>
-                        <td>{artefact.mimeType}</td>
-                        <td>
-                          <a
-                            className="link"
-                            href={artefactDownloadUrl(artefact.path)}
-                            onClick={(event) => handleArtefactDownload(event, artefact)}
-                          >
-                            Download
-                          </a>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-
-          {runStatus === 'SUCCEEDED' && inputArtefact && (
-            <div className="results-section reproduce-section">
-              <h4>Reproduce via CLI</h4>
-              <p>
-                Use the generated batch input file to reproduce this run with the
-                CLI simulator.
-              </p>
-              <div className="reproduce-actions">
-                <a
-                  className="btn-secondary"
-                  href={artefactDownloadUrl(inputArtefact.path)}
-                  onClick={(event) => handleArtefactDownload(event, inputArtefact)}
-                >
-                  Download input.scenario
-                </a>
-                <code>lift-simulator --input {inputArtefact.path}</code>
-              </div>
-            </div>
-          )}
-        </section>
+        <SimulationResultsPanel
+          runInfo={runInfo}
+          runStatus={runStatus}
+          results={results}
+          artefacts={artefacts}
+          resultsError={resultsError}
+          artefactDownloadUrl={artefactDownloadUrl}
+          onArtefactDownload={handleArtefactDownload}
+        />
       )}
 
       <ConfirmModal

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -8,23 +8,11 @@ import { simulationRunsApi } from '../api/simulationRunsApi';
 import ConfirmModal from '../components/ConfirmModal';
 import { handleApiError } from '../utils/errorHandlers';
 import { isTerminalRunStatus, useRunPolling } from '../hooks/useRunPolling';
-import { formatRunDuration, getRunStatusPillClass } from '../utils/statusUtils';
+import { formatRunDuration } from '../utils/statusUtils';
+import SimulationRunStatusCard from '../components/simulation-runs/SimulationRunStatusCard';
+import SimulationResultsPanel from '../components/simulation-runs/SimulationResultsPanel';
+import SimulatorRunSetup from '../components/simulation-runs/SimulatorRunSetup';
 import './Simulator.css';
-
-const kpiLabels = {
-  requestsTotal: 'Requests',
-  pickupRequestsServed: 'Pickup Requests Served',
-  pickupRequestsCancelled: 'Pickup Requests Cancelled',
-  passengersServed: 'Passengers Served',
-  passengersCancelled: 'Passengers Cancelled',
-  avgPickupWaitTicks: 'Avg Wait to Pickup (ticks)',
-  maxPickupWaitTicks: 'Max Wait to Pickup (ticks)',
-  idleTicks: 'Idle Ticks',
-  movingTicks: 'Moving Ticks',
-  doorTicks: 'Door Ticks',
-  pickupLegUtilisation: 'Pickup-leg Utilisation',
-  utilisation: 'Pickup-leg Utilisation',
-};
 
 function Simulator() {
   const [searchParams] = useSearchParams();
@@ -358,45 +346,6 @@ function Simulator() {
     [runInfo?.id, artefactDownloadUrl]
   );
 
-  const formatNumber = (value) => {
-    if (value == null || Number.isNaN(value)) {
-      return '—';
-    }
-    if (typeof value === 'number') {
-      return Number.isInteger(value) ? value.toString() : value.toFixed(2);
-    }
-    return String(value);
-  };
-
-  const formatKpiValue = (key, value) => {
-    if ((key === 'pickupLegUtilisation' || key === 'utilisation') && typeof value === 'number') {
-      return `${(value * 100).toFixed(1)}%`;
-    }
-    return formatNumber(value);
-  };
-
-  const getPickupLegUtilisation = (lift) => lift?.pickupLegUtilisation ?? lift?.utilisation;
-
-  const formatBytes = (bytes) => {
-    if (!bytes && bytes !== 0) {
-      return '—';
-    }
-    const units = ['B', 'KB', 'MB', 'GB'];
-    let size = bytes;
-    let index = 0;
-    while (size >= 1024 && index < units.length - 1) {
-      size /= 1024;
-      index += 1;
-    }
-    return `${size.toFixed(1)} ${units[index]}`;
-  };
-
-  const runSummary = results?.results?.runSummary;
-  const kpis = results?.results?.kpis;
-  const perLift = results?.results?.perLift || [];
-  const perFloor = results?.results?.perFloor || [];
-  const inputArtefact = artefacts.find((item) => item.name === 'input.scenario');
-
   return (
     <div className="simulator">
       <div className="page-header">
@@ -416,187 +365,51 @@ function Simulator() {
         </div>
       </div>
 
-      <section className="simulator-card">
-        <h3>Run Setup</h3>
-        {loading ? (
-          <p>Loading options...</p>
-        ) : formError ? (
-          <p className="error">{formError}</p>
-        ) : (
-          <div className="run-setup-grid">
-            <label className="field">
-              <span>Lift System</span>
-              <select
-                value={selectedSystemId}
-                onChange={(event) => {
-                  setSelectedSystemId(event.target.value);
-                  setSelectedVersionNumber('');
-                }}
-              >
-                <option value="">Select a lift system</option>
-                {systems.map((system) => (
-                  <option key={system.id} value={system.id}>
-                    {system.displayName}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="field">
-              <span>Published Version</span>
-              <select
-                value={selectedVersionNumber}
-                onChange={(event) => setSelectedVersionNumber(event.target.value)}
-                disabled={!selectedSystemId || publishedVersions.length === 0}
-              >
-                <option value="">Select a published version</option>
-                {publishedVersions.map((version) => (
-                  <option key={version.id} value={version.versionNumber}>
-                    Version {version.versionNumber}
-                  </option>
-                ))}
-              </select>
-              {!selectedSystemId && (
-                <small>Select a system to view published versions.</small>
-              )}
-              {selectedSystemId && publishedVersions.length === 0 && (
-                <small className="warning">
-                  No published versions available for this system.
-                </small>
-              )}
-            </label>
-
-            <label className="field">
-              <span>Scenario</span>
-              <select
-                value={selectedScenarioId}
-                onChange={(event) => setSelectedScenarioId(event.target.value)}
-                disabled={!selectedVersionNumber || filteredScenarios.length === 0}
-              >
-                <option value="">Select a scenario</option>
-                {filteredScenarios.map((scenario) => (
-                  <option key={scenario.id} value={scenario.id}>
-                    {scenario.name}
-                  </option>
-                ))}
-              </select>
-              {!selectedVersionNumber && (
-                <small>Select a version to view compatible scenarios.</small>
-              )}
-              {selectedVersionNumber && filteredScenarios.length === 0 && (
-                <small className="warning">
-                  No scenarios available for this version. Create one from the Scenarios page.
-                </small>
-              )}
-            </label>
-
-            <label className="field">
-              <span>Optional Seed</span>
-              <input
-                type="number"
-                value={seed}
-                onChange={(event) => setSeed(event.target.value)}
-                placeholder="Leave blank for random"
-              />
-            </label>
-
-            <div className="run-setup-actions">
-              <button
-                className="btn-primary"
-                onClick={handleStartRun}
-                disabled={
-                  isStarting ||
-                  (runInfo && !isTerminal) ||
-                  !selectedSystemId ||
-                  !selectedVersionNumber ||
-                  !selectedScenarioId
-                }
-              >
-                {isStarting ? 'Starting...' : (runInfo && !isTerminal) ? 'Run in Progress' : 'Start Run'}
-              </button>
-              {selectedSystem && selectedVersion && selectedScenario && (
-                <div className="selection-summary">
-                  <strong>Selected:</strong> {selectedSystem.displayName} · Version{' '}
-                  {selectedVersion.versionNumber} · {selectedScenario.name}
-                </div>
-              )}
-              {runInfo && !isTerminal && (
-                <small className="run-in-progress-hint">
-                  A simulation run is in progress. Wait for it to complete or cancel it to start a new run.
-                </small>
-              )}
-            </div>
-          </div>
-        )}
-      </section>
+      <SimulatorRunSetup
+        loading={loading}
+        formError={formError}
+        systems={systems}
+        publishedVersions={publishedVersions}
+        filteredScenarios={filteredScenarios}
+        selectedSystemId={selectedSystemId}
+        selectedVersionNumber={selectedVersionNumber}
+        selectedScenarioId={selectedScenarioId}
+        seed={seed}
+        isStarting={isStarting}
+        isRunActive={Boolean(runInfo && !isTerminal)}
+        selectedSystem={selectedSystem}
+        selectedVersion={selectedVersion}
+        selectedScenario={selectedScenario}
+        onSystemChange={(value) => {
+          setSelectedSystemId(value);
+          setSelectedVersionNumber('');
+        }}
+        onVersionChange={setSelectedVersionNumber}
+        onScenarioChange={setSelectedScenarioId}
+        onSeedChange={setSeed}
+        onStartRun={handleStartRun}
+      />
 
       {runInfo && (
-        <section className="simulator-card">
-          <div className="status-header">
-            <h3>Run Status</h3>
-            <div className="status-actions">
-              <span className={getRunStatusPillClass(runStatus)}>
-                {runStatus}
-              </span>
-              {(runStatus === 'RUNNING' || runStatus === 'CREATED') && (
-                <button
-                  className="btn-danger"
-                  type="button"
-                  onClick={() => setShowCancelModal(true)}
-                  disabled={isCancelling}
-                >
-                  {isCancelling ? 'Cancelling...' : 'Cancel Run'}
-                </button>
-              )}
-            </div>
-          </div>
-
-          <div className="status-grid">
-            <div>
-              <span className="label">Run ID</span>
-              <p>{runInfo.id}</p>
-            </div>
-            <div>
-              <span className="label">Lift System</span>
-              <p>{selectedSystem?.displayName || runInfo.liftSystemId}</p>
-            </div>
-            <div>
-              <span className="label">Version</span>
-              <p>{selectedVersion ? `Version ${selectedVersion.versionNumber}` : runInfo.versionNumber}</p>
-            </div>
-            <div>
-              <span className="label">Scenario</span>
-              <p>{selectedScenario?.name || runInfo.scenarioId || '—'}</p>
-            </div>
-            <div>
-              <span className="label">Elapsed Time</span>
-              <p>{formatRunDuration(elapsedMs)}</p>
-            </div>
-            <div>
-              <span className="label">Seed</span>
-              <p>{runInfo.seed ?? '—'}</p>
-            </div>
-          </div>
-
-          {progressPercentage != null && (
-            <div className="progress-section">
-              <div className="progress-meta">
-                <span>
-                  {runInfo.currentTick ?? 0} / {runInfo.totalTicks} ticks
-                </span>
-                <span>{progressPercentage.toFixed(1)}%</span>
-              </div>
-              <div className="progress-bar">
-                <div
-                  className="progress-fill"
-                  style={{ width: `${progressPercentage}%` }}
-                />
-              </div>
-            </div>
-          )}
-
-          {runError && <p className="error">{runError}</p>}
-        </section>
+        <SimulationRunStatusCard
+          cardClassName="simulator-card"
+          runInfo={runInfo}
+          runStatus={runStatus}
+          isTerminal={isTerminal}
+          elapsedMs={elapsedMs}
+          progressPercentage={progressPercentage}
+          runError={runError}
+          onCancel={() => setShowCancelModal(true)}
+          isCancelling={isCancelling}
+          fields={[
+            { label: 'Run ID', value: runInfo.id },
+            { label: 'Lift System', value: selectedSystem?.displayName || runInfo.liftSystemId },
+            { label: 'Version', value: selectedVersion ? `Version ${selectedVersion.versionNumber}` : runInfo.versionNumber },
+            { label: 'Scenario', value: selectedScenario?.name || runInfo.scenarioId || '—' },
+            { label: 'Elapsed Time', value: formatRunDuration(elapsedMs) },
+            { label: 'Seed', value: runInfo.seed ?? '—' },
+          ]}
+        />
       )}
 
       <ConfirmModal
@@ -611,210 +424,19 @@ function Simulator() {
       />
 
       {isTerminal && runInfo && (
-        <section className="simulator-card">
-          <div className="results-header">
-            <h3>Results</h3>
-            <Link to={`/simulation-runs/${runInfo.id}`} className="btn-secondary btn-small">
-              View Full Details
-            </Link>
-          </div>
-          {resultsError && <p className="error">{resultsError}</p>}
-
-          {runStatus === 'FAILED' && (
-            <div className="result-banner error">
-              <strong>Simulation failed.</strong>
-              <p>{results?.errorMessage || runInfo.errorMessage || 'Unknown error.'}</p>
-            </div>
-          )}
-
-          {runStatus === 'CANCELLED' && (
-            <div className="result-banner warning">
-              <strong>Simulation was cancelled.</strong>
-            </div>
-          )}
-
-          {runStatus === 'SUCCEEDED' && results?.results && (
-            <>
-              <div className="result-banner success">
-                <strong>Simulation completed successfully.</strong>
-                {results.errorMessage && <p>{results.errorMessage}</p>}
-              </div>
-
-              <div className="kpi-grid">
-                {kpis &&
-                  Object.entries(kpis).map(([key, value]) => (
-                    <div key={key} className="kpi-card">
-                      <span>{kpiLabels[key] || key}</span>
-                      <strong>{formatKpiValue(key, value)}</strong>
-                    </div>
-                  ))}
-              </div>
-
-              <div className="results-section">
-                <h4>Run Summary</h4>
-                <div className="summary-grid">
-                  <div>
-                    <span className="label">Generated</span>
-                    <p>{runSummary?.generatedAt ? new Date(runSummary.generatedAt).toLocaleString() : '—'}</p>
-                  </div>
-                  <div>
-                    <span className="label">Ticks</span>
-                    <p>{runSummary?.ticks ?? '—'}</p>
-                  </div>
-                  <div>
-                    <span className="label">Duration</span>
-                    <p>{runSummary?.durationTicks ?? '—'} ticks</p>
-                  </div>
-                  <div>
-                    <span className="label">Seed</span>
-                    <p>{runSummary?.seed ?? runInfo.seed ?? '—'}</p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="results-section">
-                <h4>Per Lift</h4>
-                {perLift.length === 0 ? (
-                  <p>No lift metrics available.</p>
-                ) : (
-                  <div className="table-wrapper">
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Lift</th>
-                          <th>Controller</th>
-                          <th>Parking</th>
-                          <th>Pickup-leg Utilisation</th>
-                          <th>Idle</th>
-                          <th>Moving</th>
-                          <th>Door</th>
-                          <th>Status Counts</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {perLift.map((lift) => (
-                          <tr key={lift.liftId}>
-                            <td>{lift.liftId}</td>
-                            <td>{lift.controllerStrategy || '—'}</td>
-                            <td>{lift.idleParkingMode || '—'}</td>
-                            <td>{formatKpiValue('pickupLegUtilisation', getPickupLegUtilisation(lift))}</td>
-                            <td>{formatNumber(lift.idleTicks)}</td>
-                            <td>{formatNumber(lift.movingTicks)}</td>
-                            <td>{formatNumber(lift.doorTicks)}</td>
-                            <td>
-                              {lift.statusCounts
-                                ? Object.entries(lift.statusCounts)
-                                    .map(([status, count]) => `${status}: ${count}`)
-                                    .join(', ')
-                                : '—'}
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-
-              <div className="results-section">
-                <h4>Per Floor</h4>
-                {perFloor.length === 0 ? (
-                  <p>No floor metrics available.</p>
-                ) : (
-                  <div className="table-wrapper">
-                    <table>
-                      <thead>
-                        <tr>
-                          <th>Floor</th>
-                          <th>Origin Passengers</th>
-                          <th>Destination Passengers</th>
-                          <th>Lift Visits</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {perFloor.map((floor) => (
-                          <tr key={floor.floor}>
-                            <td>{floor.floor}</td>
-                            <td>{formatNumber(floor.originPassengers)}</td>
-                            <td>{formatNumber(floor.destinationPassengers)}</td>
-                            <td>{formatNumber(floor.liftVisits)}</td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-
-          {runStatus === 'SUCCEEDED' && !results?.results && (
-            <div className="result-banner warning">
-              <strong>Simulation completed, but results were unavailable.</strong>
-              <p>{results?.errorMessage || 'Results file could not be read.'}</p>
-            </div>
-          )}
-
-          <div className="results-section">
-            <h4>Artefacts</h4>
-            {artefacts.length === 0 ? (
-              <p>No artefacts available.</p>
-            ) : (
-              <div className="table-wrapper">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Size</th>
-                      <th>Type</th>
-                      <th>Download</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {artefacts.map((artefact) => (
-                      <tr key={`${artefact.name}-${artefact.path}`}>
-                        <td>{artefact.name}</td>
-                        <td>{formatBytes(artefact.size)}</td>
-                        <td>{artefact.mimeType}</td>
-                        <td>
-                          <a
-                            className="link"
-                            href={artefactDownloadUrl(artefact.path)}
-                            onClick={(event) => handleArtefactDownload(event, artefact)}
-                          >
-                            Download
-                          </a>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </div>
-
-          <div className="results-section reproduce-section">
-            <h4>Reproduce via CLI</h4>
-            <p>
-              Use the generated batch input file to reproduce this run with the
-              CLI simulator.
-            </p>
-            {inputArtefact ? (
-              <div className="reproduce-actions">
-                <a
-                  className="btn-secondary"
-                  href={artefactDownloadUrl(inputArtefact.path)}
-                  onClick={(event) => handleArtefactDownload(event, inputArtefact)}
-                >
-                  Download input.scenario
-                </a>
-                <code>lift-simulator --input {inputArtefact.path}</code>
-              </div>
-            ) : (
-              <p className="warning">Input file not available for this run.</p>
-            )}
-          </div>
-        </section>
+        <SimulationResultsPanel
+          cardClassName="simulator-card"
+          runInfo={runInfo}
+          runStatus={runStatus}
+          results={results}
+          artefacts={artefacts}
+          resultsError={resultsError}
+          artefactDownloadUrl={artefactDownloadUrl}
+          onArtefactDownload={handleArtefactDownload}
+          showFullDetailsLink
+          showMissingInputMessage
+          onlyShowReproduceOnSuccess={false}
+        />
       )}
     </div>
   );

--- a/frontend/src/utils/simulationResultsUtils.js
+++ b/frontend/src/utils/simulationResultsUtils.js
@@ -1,0 +1,43 @@
+export const kpiLabels = {
+  requestsTotal: 'Requests',
+  pickupRequestsServed: 'Pickup Requests Served',
+  pickupRequestsCancelled: 'Pickup Requests Cancelled',
+  passengersServed: 'Passengers Served',
+  passengersCancelled: 'Passengers Cancelled',
+  avgPickupWaitTicks: 'Avg Wait to Pickup (ticks)',
+  maxPickupWaitTicks: 'Max Wait to Pickup (ticks)',
+  idleTicks: 'Idle Ticks',
+  movingTicks: 'Moving Ticks',
+  doorTicks: 'Door Ticks',
+  pickupLegUtilisation: 'Pickup-leg Utilisation',
+  utilisation: 'Pickup-leg Utilisation',
+};
+
+export const formatNumber = (value) => {
+  if (value == null || Number.isNaN(value)) return '—';
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? value.toString() : value.toFixed(2);
+  }
+  return String(value);
+};
+
+export const formatKpiValue = (key, value) => {
+  if ((key === 'pickupLegUtilisation' || key === 'utilisation') && typeof value === 'number') {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return formatNumber(value);
+};
+
+export const getPickupLegUtilisation = (lift) => lift?.pickupLegUtilisation ?? lift?.utilisation;
+
+export const formatBytes = (bytes) => {
+  if (!bytes && bytes !== 0) return '—';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let size = bytes;
+  let index = 0;
+  while (size >= 1024 && index < units.length - 1) {
+    size /= 1024;
+    index += 1;
+  }
+  return `${size.toFixed(1)} ${units[index]}`;
+};

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.8</version>
+    <version>0.57.9</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation

- Reduce the size and complexity of the very large `Simulator.jsx` and `SimulationRunDetail.jsx` pages by extracting reusable pieces and removing duplicated formatting helpers.
- Make run setup, status rendering, and terminal results easier to maintain and reuse across pages.
- Keep behaviour and public APIs unchanged while improving code organisation and testability.

### Description

- Extracted simulation UI subcomponents: `SimulatorRunSetup`, `SimulationRunStatusCard`, and `SimulationResultsPanel` under `frontend/src/components/simulation-runs/` and wired them into `Simulator.jsx` and `SimulationRunDetail.jsx`.
- Centralised result formatting and labels into a new helper module `frontend/src/utils/simulationResultsUtils.js` and removed duplicated local helpers from the pages.
- Updated pages to import and use the new components, preserving existing behaviours for polling, run creation/cancellation, artefact download, and deletion flows.
- Bumped project/frontend version references to `0.57.9` and updated `CHANGELOG.md`, `README.md`, `frontend/README.md`, `pom.xml`, and `frontend/package.json` to record the change.

### Testing

- Ran `./scripts/sync-versions.sh --check` to verify version references and it passed.
- Ran frontend linting with `npm run lint` (in `frontend/`) and no lint errors were reported.
- Built the frontend bundle with `npm run build` (in `frontend/`) and the Vite production build completed successfully, producing `dist/` assets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52793858f483259b8764d3a87d883a)