### PR TITLE
refactor(frontend): decompose ScenarioForm and LiftSystemDetail into subcomponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.10] - 2026-07-12
+
+### Changed
+- **Frontend page component decomposition**: Split the large scenario form and lift-system detail pages into focused React subcomponents for scenario basics, templates, JSON editing, simulation settings, validation results, lift-system headers/details, version creation, version filters, version cards, and pagination. Updated frontend documentation and package metadata for the 0.57.10 pre-MVP patch release.
+
 ## [0.57.9] - 2026-07-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.9**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.10**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.9.jar
+java -jar target/lift-simulator-0.57.10.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.9.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.10.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.10.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.10.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.Main --strategy=dire
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.9.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.10.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -180,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.9.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.10.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.9.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.10.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -50,7 +50,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.9.jar \
+java -cp target/lift-simulator-0.57.10.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -64,12 +64,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.9.jar \
+java -cp target/lift-simulator-0.57.10.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.9.jar \
+java -cp target/lift-simulator-0.57.10.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -113,7 +113,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.9.jar \
+java -cp target/lift-simulator-0.57.10.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -391,7 +391,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.9.jar \
+   java -cp target/lift-simulator-0.57.10.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -436,7 +436,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.9.jar \
+java -cp target/lift-simulator-0.57.10.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -528,7 +528,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.9.jar \
+java -cp target/lift-simulator-0.57.10.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,6 +17,7 @@ This is the frontend admin application for the Lift Simulator system. It provide
 - Managing simulation runs, including multi-select bulk cancellation for active runs and bulk deletion for completed runs
 - Monitoring system health
 - Running simulations through decomposed setup, run-status, and results panels shared with run detail views
+- Maintaining scenarios and lift-system versions through decomposed page sections for easier UI maintenance
 
 For the overall project setup (backend, database, and Quick Start), see the [root README](../README.md). Backend REST API conventions (auth, RBAC, rate limits, error shape) live in [docs/API.md](../docs/API.md), and the always-current endpoint reference is the generated Swagger UI at `/api/v1/swagger-ui.html`.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.9",
+  "version": "0.57.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.9",
+      "version": "0.57.10",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.9",
+  "version": "0.57.10",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/components/liftSystems/CreateVersionForm.jsx
+++ b/frontend/src/components/liftSystems/CreateVersionForm.jsx
@@ -1,0 +1,45 @@
+// @ts-check
+import VersionConfigForm from '../VersionConfigForm';
+import { CONFIG_EXAMPLE_JSON, CONFIG_REQUIRED_FIELDS, CONFIG_SCHEMA_DOCS_URL, CONFIG_SCHEMA_HELP_TEXT } from '../../utils/configSchemaHelp';
+
+function CreateVersionForm({ versions, editorMode, switchToGuidedMode, switchToJsonMode, versionFormData, versionFormErrors, handleVersionFormChange, newVersionConfig, handleNewVersionConfigChange, creating, createValidationResult, handleCreateVersion, validatingCreate, handleValidateCreateVersion, handleCancelCreateVersion, createValidationError }) {
+  return (
+    <div className="create-version-form">
+      <div className="version-number-display"><h4>Version {versions.length > 0 ? Math.max(...versions.map(v => v.versionNumber)) + 1 : 1}</h4></div>
+      <div className="editor-mode-toggle" role="group" aria-label="Configuration editor mode">
+        <button type="button" className={editorMode === 'guided' ? 'mode-btn active' : 'mode-btn'} onClick={switchToGuidedMode} aria-pressed={editorMode === 'guided'}>Guided Form</button>
+        <button type="button" className={editorMode === 'json' ? 'mode-btn active' : 'mode-btn'} onClick={switchToJsonMode} aria-pressed={editorMode === 'json'}>Advanced (JSON)</button>
+      </div>
+      {editorMode === 'guided' ? (
+        <>
+          <div className="config-label-row"><label>Version Configuration</label><a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">View schema docs</a></div>
+          <p className="config-help-text">Fill in the parameters below. Switch to Advanced (JSON) to edit the raw configuration directly.</p>
+          <VersionConfigForm value={versionFormData} errors={versionFormErrors} onChange={handleVersionFormChange} />
+        </>
+      ) : (
+        <>
+          <div className="config-label-row"><label htmlFor="config">Configuration JSON</label><a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">View schema docs</a></div>
+          <p id="config-help" className="config-help-text">{CONFIG_SCHEMA_HELP_TEXT}</p>
+          <details className="config-example-help"><summary>Show complete valid example</summary><pre>{CONFIG_EXAMPLE_JSON}</pre></details>
+          <textarea id="config" value={newVersionConfig} onChange={handleNewVersionConfigChange} placeholder={CONFIG_EXAMPLE_JSON} rows="14" required aria-describedby="config-help config-required-fields" />
+          <p id="config-required-fields" className="config-required-fields">Required fields: {CONFIG_REQUIRED_FIELDS.map((field) => `\`${field}\``).join(', ')}.</p>
+        </>
+      )}
+      <div className="form-actions">
+        <button type="button" className="btn-primary" disabled={creating || !createValidationResult?.valid} onClick={handleCreateVersion} title={createValidationResult?.valid ? 'Create a new version with this configuration' : 'Validate the configuration before creating'}>{creating ? 'Creating...' : 'Create Version'}</button>
+        <button type="button" className="btn-secondary" onClick={handleValidateCreateVersion} disabled={validatingCreate}>{validatingCreate ? 'Validating...' : 'Validate'}</button>
+        <button type="button" onClick={handleCancelCreateVersion} className="btn-secondary">Cancel</button>
+      </div>
+      {createValidationError && <div className="validation-error-banner">{createValidationError}</div>}
+      {createValidationResult && (
+        <div className={createValidationResult.valid ? 'validation-success-banner' : 'validation-error-banner'}>
+          <strong>{createValidationResult.valid ? '✓ Configuration is valid' : '✗ Configuration has errors'}</strong>
+          {createValidationResult.errors?.length > 0 && <ul>{createValidationResult.errors.map((err, idx) => <li key={idx}><strong>{err.field}:</strong> {err.message}</li>)}</ul>}
+          {createValidationResult.warnings?.length > 0 && <ul>{createValidationResult.warnings.map((warn, idx) => <li key={idx}><strong>{warn.field}:</strong> {warn.message}</li>)}</ul>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default CreateVersionForm;

--- a/frontend/src/components/liftSystems/LiftSystemHeader.jsx
+++ b/frontend/src/components/liftSystems/LiftSystemHeader.jsx
@@ -1,0 +1,20 @@
+// @ts-check
+import { Link } from 'react-router-dom';
+
+function LiftSystemHeader({ system, onEdit, onDelete }) {
+  return (
+    <div className="detail-header">
+      <div>
+        <Link to="/systems" className="breadcrumb">← Back to Systems</Link>
+        <h2>{system.displayName}</h2>
+        <p className="system-key">{system.systemKey}</p>
+      </div>
+      <div className="header-actions">
+        <button onClick={onEdit} className="btn-secondary">Edit System</button>
+        <button onClick={onDelete} className="btn-danger">Delete System</button>
+      </div>
+    </div>
+  );
+}
+
+export default LiftSystemHeader;

--- a/frontend/src/components/liftSystems/LiftSystemInfoSection.jsx
+++ b/frontend/src/components/liftSystems/LiftSystemInfoSection.jsx
@@ -1,0 +1,18 @@
+// @ts-check
+
+function LiftSystemInfoSection({ system }) {
+  return (
+    <div className="detail-section">
+      <h3>System Information</h3>
+      <div className="info-grid">
+        <div className="info-item"><label>Display Name</label><p>{system.displayName}</p></div>
+        <div className="info-item"><label>System Key</label><p className="monospace">{system.systemKey}</p></div>
+        <div className="info-item"><label>Description</label><p>{system.description || 'No description provided'}</p></div>
+        <div className="info-item"><label>Created</label><p>{new Date(system.createdAt).toLocaleString()}</p></div>
+        <div className="info-item"><label>Last Updated</label><p>{new Date(system.updatedAt).toLocaleString()}</p></div>
+      </div>
+    </div>
+  );
+}
+
+export default LiftSystemInfoSection;

--- a/frontend/src/components/liftSystems/PaginationControls.jsx
+++ b/frontend/src/components/liftSystems/PaginationControls.jsx
@@ -1,0 +1,20 @@
+// @ts-check
+
+function PaginationControls({ totalPages, currentPage, startIndex, endIndex, totalItems, onPageChange, renderPageNumbers }) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="pagination-controls">
+      <div className="pagination-info">Showing {startIndex + 1}-{Math.min(endIndex, totalItems)} of {totalItems} versions</div>
+      <div className="pagination-buttons">
+        <button onClick={() => onPageChange(1)} disabled={currentPage === 1} className="page-btn" title="First page">&laquo;</button>
+        <button onClick={() => onPageChange(currentPage - 1)} disabled={currentPage === 1} className="page-btn" title="Previous page">&lsaquo;</button>
+        {renderPageNumbers()}
+        <button onClick={() => onPageChange(currentPage + 1)} disabled={currentPage === totalPages} className="page-btn" title="Next page">&rsaquo;</button>
+        <button onClick={() => onPageChange(totalPages)} disabled={currentPage === totalPages} className="page-btn" title="Last page">&raquo;</button>
+      </div>
+    </div>
+  );
+}
+
+export default PaginationControls;

--- a/frontend/src/components/liftSystems/VersionCard.jsx
+++ b/frontend/src/components/liftSystems/VersionCard.jsx
@@ -1,0 +1,24 @@
+// @ts-check
+import VersionActions from '../VersionActions';
+import { getStatusBadgeClass } from '../../utils/statusUtils';
+
+function VersionCard({ version, systemId, onPublish, onRunSimulation, formatVersionConfig }) {
+  return (
+    <div className="version-card">
+      <div className="version-header">
+        <div>
+          <h4>Version {version.versionNumber}</h4>
+          <span className={getStatusBadgeClass(version.status)}>{version.status}</span>
+        </div>
+        <VersionActions systemId={systemId} versionNumber={version.versionNumber} status={version.status} onPublish={onPublish} onRunSimulation={onRunSimulation} />
+      </div>
+      <div className="version-info">
+        <div className="info-row"><span className="label">Created:</span><span>{new Date(version.createdAt).toLocaleString()}</span></div>
+        {version.publishedAt && <div className="info-row"><span className="label">Published:</span><span>{new Date(version.publishedAt).toLocaleString()}</span></div>}
+        <details className="config-details"><summary>View Configuration</summary><pre className="config-preview">{formatVersionConfig(version.config)}</pre></details>
+      </div>
+    </div>
+  );
+}
+
+export default VersionCard;

--- a/frontend/src/components/liftSystems/VersionsControls.jsx
+++ b/frontend/src/components/liftSystems/VersionsControls.jsx
@@ -1,0 +1,15 @@
+// @ts-check
+
+function VersionsControls({ versionSearch, setVersionSearch, statusFilter, setStatusFilter, sortBy, setSortBy, sortOrder, setSortOrder, itemsPerPage, setItemsPerPage }) {
+  return (
+    <div className="versions-controls"><div className="controls-row">
+      <div className="control-group"><label htmlFor="versionSearch">Search Version:</label><input id="versionSearch" type="text" placeholder="Search by version number..." value={versionSearch} onChange={(e) => setVersionSearch(e.target.value)} className="search-input" /></div>
+      <div className="control-group"><label htmlFor="statusFilter">Filter by Status:</label><select id="statusFilter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)} className="filter-select"><option value="ALL">All Statuses</option><option value="PUBLISHED">Published</option><option value="DRAFT">Draft</option><option value="ARCHIVED">Archived</option></select></div>
+      <div className="control-group"><label htmlFor="sortBy">Sort by:</label><select id="sortBy" value={sortBy} onChange={(e) => setSortBy(e.target.value)} className="sort-select"><option value="versionNumber">Version Number</option><option value="createdAt">Creation Date</option><option value="status">Status</option></select></div>
+      <div className="control-group"><label htmlFor="sortOrder">Order:</label><select id="sortOrder" value={sortOrder} onChange={(e) => setSortOrder(e.target.value)} className="sort-select"><option value="desc">{sortBy === 'versionNumber' ? 'Descending' : sortBy === 'createdAt' ? 'Newest First' : 'Published First'}</option><option value="asc">{sortBy === 'versionNumber' ? 'Ascending' : sortBy === 'createdAt' ? 'Oldest First' : 'Archived First'}</option></select></div>
+      <div className="control-group"><label htmlFor="itemsPerPage">Items per page:</label><select id="itemsPerPage" value={itemsPerPage} onChange={(e) => setItemsPerPage(Number(e.target.value))} className="items-select"><option value="10">10</option><option value="20">20</option><option value="50">50</option><option value="100">100</option></select></div>
+    </div></div>
+  );
+}
+
+export default VersionsControls;

--- a/frontend/src/components/scenarios/ScenarioBasicsSection.jsx
+++ b/frontend/src/components/scenarios/ScenarioBasicsSection.jsx
@@ -1,0 +1,79 @@
+// @ts-check
+
+function ScenarioBasicsSection({
+  scenarioName, setScenarioName, formErrors, setFormErrors,
+  liftSystems, selectedSystemId, setSelectedSystemId,
+  versions, selectedVersionId, setSelectedVersionId,
+  floorRange, parseVersionConfig
+}) {
+  return (
+    <div className="form-section">
+      <div className="form-group">
+        <label htmlFor="scenarioName">Scenario Name <span className="required">*</span></label>
+        <input
+          type="text"
+          id="scenarioName"
+          value={scenarioName}
+          onChange={(e) => {
+            setScenarioName(e.target.value);
+            if (formErrors.scenarioName) setFormErrors(prev => ({ ...prev, scenarioName: '' }));
+          }}
+          placeholder="e.g., Morning Rush Hour"
+          className={formErrors.scenarioName ? 'error' : ''}
+        />
+        {formErrors.scenarioName && <span className="error-message">{formErrors.scenarioName}</span>}
+      </div>
+
+      <div className="form-group">
+        <label htmlFor="liftSystem">Lift System <span className="required">*</span></label>
+        <select
+          id="liftSystem"
+          value={selectedSystemId}
+          onChange={(e) => {
+            setSelectedSystemId(e.target.value);
+            setSelectedVersionId('');
+            if (formErrors.liftSystem || formErrors.liftSystemVersion) {
+              setFormErrors(prev => ({ ...prev, liftSystem: '', liftSystemVersion: '' }));
+            }
+          }}
+          className={formErrors.liftSystem ? 'error' : ''}
+        >
+          <option value="">-- Select Lift System --</option>
+          {liftSystems.map((system) => <option key={system.id} value={system.id}>{system.displayName}</option>)}
+        </select>
+        {formErrors.liftSystem && <span className="error-message">{formErrors.liftSystem}</span>}
+        <p className="help-text">Select the lift system this scenario will be designed for</p>
+      </div>
+
+      {selectedSystemId && (
+        <div className="form-group">
+          <label htmlFor="liftSystemVersion">Version <span className="required">*</span></label>
+          <select
+            id="liftSystemVersion"
+            value={selectedVersionId}
+            onChange={(e) => {
+              setSelectedVersionId(e.target.value);
+              if (formErrors.liftSystemVersion) setFormErrors(prev => ({ ...prev, liftSystemVersion: '' }));
+            }}
+            className={formErrors.liftSystemVersion ? 'error' : ''}
+          >
+            <option value="">-- Select Version --</option>
+            {versions.map((version) => {
+              const floorInfo = parseVersionConfig(version.config);
+              return (
+                <option key={version.id} value={version.id}>
+                  Version {version.versionNumber}{floorInfo ? ` (Floors ${floorInfo.minFloor} to ${floorInfo.maxFloor})` : ''}
+                </option>
+              );
+            })}
+          </select>
+          <p className="help-text">Select the version to ensure floor ranges are validated correctly</p>
+          {floorRange && <p className="help-text"><strong>Valid floor range: {floorRange.minFloor} to {floorRange.maxFloor}</strong></p>}
+          {formErrors.liftSystemVersion && <span className="error-message">{formErrors.liftSystemVersion}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ScenarioBasicsSection;

--- a/frontend/src/components/scenarios/ScenarioJsonEditor.jsx
+++ b/frontend/src/components/scenarios/ScenarioJsonEditor.jsx
@@ -1,0 +1,25 @@
+// @ts-check
+
+function ScenarioJsonEditor({ jsonText, setJsonText, formErrors, setFormErrors }) {
+  return (
+    <div className="form-section">
+      <h3>Scenario JSON</h3>
+      <div className="form-group">
+        <textarea
+          value={jsonText}
+          onChange={(e) => {
+            setJsonText(e.target.value);
+            if (formErrors.durationTicks) setFormErrors(prev => ({ ...prev, durationTicks: '' }));
+          }}
+          rows={20}
+          className="json-editor"
+          placeholder="Enter scenario JSON..."
+        />
+        <p className="help-text">Edit the scenario JSON directly. Valid fields: durationTicks, passengerFlows, seed (optional)</p>
+        {formErrors.durationTicks && <span className="error-message">{formErrors.durationTicks}</span>}
+      </div>
+    </div>
+  );
+}
+
+export default ScenarioJsonEditor;

--- a/frontend/src/components/scenarios/ScenarioSettingsSection.jsx
+++ b/frontend/src/components/scenarios/ScenarioSettingsSection.jsx
@@ -1,0 +1,48 @@
+// @ts-check
+import PassengerFlowBuilder from '../PassengerFlowBuilder';
+
+function ScenarioSettingsSection({ durationTicks, setDurationTicks, useSeed, setUseSeed, seed, setSeed, passengerFlows, setPassengerFlows, floorRange, formErrors, setFormErrors }) {
+  return (
+    <>
+      <div className="form-section">
+        <h3>Simulation Settings</h3>
+        <div className="form-group">
+          <label htmlFor="durationTicks">Duration (ticks) <span className="required">*</span></label>
+          <input
+            type="number"
+            id="durationTicks"
+            value={durationTicks}
+            onChange={(e) => {
+              setDurationTicks(e.target.value);
+              if (formErrors.durationTicks) setFormErrors(prev => ({ ...prev, durationTicks: '' }));
+            }}
+            className={formErrors.durationTicks ? 'error' : ''}
+            min="1"
+            placeholder="e.g., 100"
+          />
+          {formErrors.durationTicks && <span className="error-message">{formErrors.durationTicks}</span>}
+          <p className="help-text">How long the simulation will run (each tick represents one time unit)</p>
+        </div>
+        <div className="form-group">
+          <label htmlFor="useSeed" className="checkbox-label">
+            <input type="checkbox" id="useSeed" checked={useSeed} onChange={(e) => setUseSeed(e.target.checked)} />
+            Use Random Seed (for reproducibility)
+          </label>
+        </div>
+        {useSeed && (
+          <div className="form-group">
+            <label htmlFor="seed">Random Seed</label>
+            <input type="number" id="seed" value={seed} onChange={(e) => setSeed(e.target.value)} min="0" placeholder="e.g., 42" />
+            <p className="help-text">Optional seed for reproducible random behavior. Same seed = same simulation results.</p>
+          </div>
+        )}
+      </div>
+      <div className="form-section">
+        <h3>Passenger Flows</h3>
+        <PassengerFlowBuilder flows={passengerFlows} onChange={setPassengerFlows} maxTick={parseInt(durationTicks, 10) || 100} floorRange={floorRange} />
+      </div>
+    </>
+  );
+}
+
+export default ScenarioSettingsSection;

--- a/frontend/src/components/scenarios/ScenarioTemplateSection.jsx
+++ b/frontend/src/components/scenarios/ScenarioTemplateSection.jsx
@@ -1,0 +1,21 @@
+// @ts-check
+
+function ScenarioTemplateSection({ floorRange, selectedVersionId, templates, selectedTemplateKey, onApplyTemplate }) {
+  return (
+    <div className="form-section">
+      <h3>Quick Start Templates</h3>
+      {floorRange && <p className="help-text" style={{ marginBottom: '1rem' }}>Templates will be adapted to the selected floor range ({floorRange.minFloor} to {floorRange.maxFloor}).</p>}
+      {!selectedVersionId && <p className="help-text" style={{ marginBottom: '1rem', color: '#e67e22' }}>Select a lift system and version above to ensure templates use valid floor ranges.</p>}
+      <div className="template-grid">
+        {Object.entries(templates).map(([key, template]) => (
+          <button key={key} type="button" className={`template-card${selectedTemplateKey === key ? ' is-selected' : ''}`} onClick={() => onApplyTemplate(key)} aria-pressed={selectedTemplateKey === key}>
+            <div className="template-name">{template.name}</div>
+            <div className="template-description">{template.description}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ScenarioTemplateSection;

--- a/frontend/src/components/scenarios/ScenarioValidationResults.jsx
+++ b/frontend/src/components/scenarios/ScenarioValidationResults.jsx
@@ -1,0 +1,19 @@
+// @ts-check
+
+function ScenarioValidationResults({ validationErrors, validationWarnings }) {
+  if (validationErrors.length === 0 && validationWarnings.length === 0) return null;
+
+  return (
+    <div className="form-section">
+      <h3>Validation Results</h3>
+      {validationErrors.length > 0 && (
+        <div className="validation-errors"><h4>Errors:</h4><ul>{validationErrors.map((error, index) => <li key={index}><strong>{error.field}:</strong> {error.message}</li>)}</ul></div>
+      )}
+      {validationWarnings.length > 0 && (
+        <div className="validation-warnings"><h4>Warnings:</h4><ul>{validationWarnings.map((warning, index) => <li key={index}><strong>{warning.field}:</strong> {warning.message}</li>)}</ul></div>
+      )}
+    </div>
+  );
+}
+
+export default ScenarioValidationResults;

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -1,15 +1,18 @@
 // @ts-check
 import { useEffect, useState, useCallback } from 'react';
-import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
+import { Link, useParams, useNavigate, useLocation } from 'react-router-dom';
+
 import { liftSystemsApi } from '../api/liftSystemsApi';
-import VersionActions from '../components/VersionActions';
 import ConfirmModal from '../components/ConfirmModal';
 import AlertModal from '../components/AlertModal';
 import EditSystemModal from '../components/EditSystemModal';
-import VersionConfigForm from '../components/VersionConfigForm';
+import CreateVersionForm from '../components/liftSystems/CreateVersionForm';
+import LiftSystemHeader from '../components/liftSystems/LiftSystemHeader';
+import LiftSystemInfoSection from '../components/liftSystems/LiftSystemInfoSection';
+import PaginationControls from '../components/liftSystems/PaginationControls';
+import VersionCard from '../components/liftSystems/VersionCard';
+import VersionsControls from '../components/liftSystems/VersionsControls';
 import { handleApiError } from '../utils/errorHandlers';
-import { getStatusBadgeClass } from '../utils/statusUtils';
-import { CONFIG_EXAMPLE_JSON, CONFIG_REQUIRED_FIELDS, CONFIG_SCHEMA_DOCS_URL, CONFIG_SCHEMA_HELP_TEXT } from '../utils/configSchemaHelp';
 import {
   getDefaultVersionFormData,
   configToFormData,
@@ -437,410 +440,90 @@ function LiftSystemDetail() {
 
   return (
     <div className="lift-system-detail">
-      <div className="detail-header">
-        <div>
-          <Link to="/systems" className="breadcrumb">← Back to Systems</Link>
-          <h2>{system.displayName}</h2>
-          <p className="system-key">{system.systemKey}</p>
-        </div>
-        <div className="header-actions">
-          <button onClick={() => setShowEditModal(true)} className="btn-secondary">Edit System</button>
-          <button onClick={handleDeleteSystem} className="btn-danger">Delete System</button>
-        </div>
-      </div>
-
-      <div className="detail-section">
-        <h3>System Information</h3>
-        <div className="info-grid">
-          <div className="info-item">
-            <label>Display Name</label>
-            <p>{system.displayName}</p>
-          </div>
-          <div className="info-item">
-            <label>System Key</label>
-            <p className="monospace">{system.systemKey}</p>
-          </div>
-          <div className="info-item">
-            <label>Description</label>
-            <p>{system.description || 'No description provided'}</p>
-          </div>
-          <div className="info-item">
-            <label>Created</label>
-            <p>{new Date(system.createdAt).toLocaleString()}</p>
-          </div>
-          <div className="info-item">
-            <label>Last Updated</label>
-            <p>{new Date(system.updatedAt).toLocaleString()}</p>
-          </div>
-        </div>
-      </div>
+      <LiftSystemHeader system={system} onEdit={() => setShowEditModal(true)} onDelete={handleDeleteSystem} />
+      <LiftSystemInfoSection system={system} />
 
       <div className="detail-section" id="versions">
         <div className="section-header">
           <h3>Versions ({filteredVersions.length} of {versions.length})</h3>
-          <button
-            onClick={toggleCreateVersion}
-            className="btn-primary"
-          >
+          <button onClick={toggleCreateVersion} className="btn-primary">
             {showCreateVersion ? 'Cancel' : 'Create New Version'}
           </button>
         </div>
 
         {showCreateVersion && (
-          <div className="create-version-form">
-            <div className="version-number-display">
-              <h4>Version {versions.length > 0 ? Math.max(...versions.map(v => v.versionNumber)) + 1 : 1}</h4>
-            </div>
-
-            <div className="editor-mode-toggle" role="group" aria-label="Configuration editor mode">
-              <button
-                type="button"
-                className={editorMode === 'guided' ? 'mode-btn active' : 'mode-btn'}
-                onClick={switchToGuidedMode}
-                aria-pressed={editorMode === 'guided'}
-              >
-                Guided Form
-              </button>
-              <button
-                type="button"
-                className={editorMode === 'json' ? 'mode-btn active' : 'mode-btn'}
-                onClick={switchToJsonMode}
-                aria-pressed={editorMode === 'json'}
-              >
-                Advanced (JSON)
-              </button>
-            </div>
-
-            {editorMode === 'guided' ? (
-              <>
-                <div className="config-label-row">
-                  <label>Version Configuration</label>
-                  <a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
-                    View schema docs
-                  </a>
-                </div>
-                <p className="config-help-text">
-                  Fill in the parameters below. Switch to Advanced (JSON) to edit the raw configuration directly.
-                </p>
-                <VersionConfigForm
-                  value={versionFormData}
-                  errors={versionFormErrors}
-                  onChange={handleVersionFormChange}
-                />
-              </>
-            ) : (
-              <>
-                <div className="config-label-row">
-                  <label htmlFor="config">Configuration JSON</label>
-                  <a href={CONFIG_SCHEMA_DOCS_URL} target="_blank" rel="noreferrer">
-                    View schema docs
-                  </a>
-                </div>
-                <p id="config-help" className="config-help-text">{CONFIG_SCHEMA_HELP_TEXT}</p>
-                <details className="config-example-help">
-                  <summary>Show complete valid example</summary>
-                  <pre>{CONFIG_EXAMPLE_JSON}</pre>
-                </details>
-                <textarea
-                  id="config"
-                  value={newVersionConfig}
-                  onChange={handleNewVersionConfigChange}
-                  placeholder={CONFIG_EXAMPLE_JSON}
-                  rows="14"
-                  required
-                  aria-describedby="config-help config-required-fields"
-                />
-                <p id="config-required-fields" className="config-required-fields">
-                  Required fields: {CONFIG_REQUIRED_FIELDS.map((field) => `\`${field}\``).join(', ')}.
-                </p>
-              </>
-            )}
-            <div className="form-actions">
-              <button
-                type="button"
-                className="btn-primary"
-                disabled={creating || !createValidationResult?.valid}
-                onClick={handleCreateVersion}
-                title={
-                  createValidationResult?.valid
-                    ? 'Create a new version with this configuration'
-                    : 'Validate the configuration before creating'
-                }
-              >
-                {creating ? 'Creating...' : 'Create Version'}
-              </button>
-              <button
-                type="button"
-                className="btn-secondary"
-                onClick={handleValidateCreateVersion}
-                disabled={validatingCreate}
-              >
-                {validatingCreate ? 'Validating...' : 'Validate'}
-              </button>
-              <button
-                type="button"
-                onClick={handleCancelCreateVersion}
-                className="btn-secondary"
-              >
-                Cancel
-              </button>
-            </div>
-
-            {createValidationError && (
-              <div className="validation-error-banner">{createValidationError}</div>
-            )}
-
-            {createValidationResult && (
-              <div
-                className={
-                  createValidationResult.valid
-                    ? 'validation-success-banner'
-                    : 'validation-error-banner'
-                }
-              >
-                <strong>
-                  {createValidationResult.valid
-                    ? '✓ Configuration is valid'
-                    : '✗ Configuration has errors'}
-                </strong>
-
-                {createValidationResult.errors?.length > 0 && (
-                  <ul>
-                    {createValidationResult.errors.map((err, idx) => (
-                      <li key={idx}>
-                        <strong>{err.field}:</strong> {err.message}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-
-                {createValidationResult.warnings?.length > 0 && (
-                  <ul>
-                    {createValidationResult.warnings.map((warn, idx) => (
-                      <li key={idx}>
-                        <strong>{warn.field}:</strong> {warn.message}
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            )}
-          </div>
+          <CreateVersionForm
+            versions={versions}
+            editorMode={editorMode}
+            switchToGuidedMode={switchToGuidedMode}
+            switchToJsonMode={switchToJsonMode}
+            versionFormData={versionFormData}
+            versionFormErrors={versionFormErrors}
+            handleVersionFormChange={handleVersionFormChange}
+            newVersionConfig={newVersionConfig}
+            handleNewVersionConfigChange={handleNewVersionConfigChange}
+            creating={creating}
+            createValidationResult={createValidationResult}
+            handleCreateVersion={handleCreateVersion}
+            validatingCreate={validatingCreate}
+            handleValidateCreateVersion={handleValidateCreateVersion}
+            handleCancelCreateVersion={handleCancelCreateVersion}
+            createValidationError={createValidationError}
+          />
         )}
 
         {versions.length === 0 ? (
-          <div className="empty-state">
-            <p>No versions yet. Create the first version to get started.</p>
-          </div>
+          <div className="empty-state"><p>No versions yet. Create the first version to get started.</p></div>
         ) : (
           <>
-            <div className="versions-controls">
-              <div className="controls-row">
-                <div className="control-group">
-                  <label htmlFor="versionSearch">Search Version:</label>
-                  <input
-                    id="versionSearch"
-                    type="text"
-                    placeholder="Search by version number..."
-                    value={versionSearch}
-                    onChange={(e) => setVersionSearch(e.target.value)}
-                    className="search-input"
-                  />
-                </div>
-
-                <div className="control-group">
-                  <label htmlFor="statusFilter">Filter by Status:</label>
-                  <select
-                    id="statusFilter"
-                    value={statusFilter}
-                    onChange={(e) => setStatusFilter(e.target.value)}
-                    className="filter-select"
-                  >
-                    <option value="ALL">All Statuses</option>
-                    <option value="PUBLISHED">Published</option>
-                    <option value="DRAFT">Draft</option>
-                    <option value="ARCHIVED">Archived</option>
-                  </select>
-                </div>
-
-                <div className="control-group">
-                  <label htmlFor="sortBy">Sort by:</label>
-                  <select
-                    id="sortBy"
-                    value={sortBy}
-                    onChange={(e) => setSortBy(e.target.value)}
-                    className="sort-select"
-                  >
-                    <option value="versionNumber">Version Number</option>
-                    <option value="createdAt">Creation Date</option>
-                    <option value="status">Status</option>
-                  </select>
-                </div>
-
-                <div className="control-group">
-                  <label htmlFor="sortOrder">Order:</label>
-                  <select
-                    id="sortOrder"
-                    value={sortOrder}
-                    onChange={(e) => setSortOrder(e.target.value)}
-                    className="sort-select"
-                  >
-                    <option value="desc">
-                      {sortBy === 'versionNumber' ? 'Descending' :
-                       sortBy === 'createdAt' ? 'Newest First' :
-                       'Published First'}
-                    </option>
-                    <option value="asc">
-                      {sortBy === 'versionNumber' ? 'Ascending' :
-                       sortBy === 'createdAt' ? 'Oldest First' :
-                       'Archived First'}
-                    </option>
-                  </select>
-                </div>
-
-                <div className="control-group">
-                  <label htmlFor="itemsPerPage">Items per page:</label>
-                  <select
-                    id="itemsPerPage"
-                    value={itemsPerPage}
-                    onChange={(e) => setItemsPerPage(Number(e.target.value))}
-                    className="items-select"
-                  >
-                    <option value="10">10</option>
-                    <option value="20">20</option>
-                    <option value="50">50</option>
-                    <option value="100">100</option>
-                  </select>
-                </div>
-              </div>
-            </div>
+            <VersionsControls
+              versionSearch={versionSearch}
+              setVersionSearch={setVersionSearch}
+              statusFilter={statusFilter}
+              setStatusFilter={setStatusFilter}
+              sortBy={sortBy}
+              setSortBy={setSortBy}
+              sortOrder={sortOrder}
+              setSortOrder={setSortOrder}
+              itemsPerPage={itemsPerPage}
+              setItemsPerPage={setItemsPerPage}
+            />
 
             {filteredVersions.length === 0 ? (
-              <div className="empty-state">
-                <p>No versions match your filters.</p>
-              </div>
+              <div className="empty-state"><p>No versions match your filters.</p></div>
             ) : (
               <>
                 <div className="versions-list">
                   {paginatedVersions.map((version) => (
-              <div key={version.id} className="version-card">
-                <div className="version-header">
-                  <div>
-                    <h4>Version {version.versionNumber}</h4>
-                    <span className={getStatusBadgeClass(version.status)}>
-                      {version.status}
-                    </span>
-                  </div>
-                  <VersionActions
-                    systemId={id}
-                    versionNumber={version.versionNumber}
-                    status={version.status}
-                    onPublish={handlePublishVersion}
-                    onRunSimulation={handleRunSimulation}
-                  />
+                    <VersionCard
+                      key={version.id}
+                      version={version}
+                      systemId={id}
+                      onPublish={handlePublishVersion}
+                      onRunSimulation={handleRunSimulation}
+                      formatVersionConfig={formatVersionConfig}
+                    />
+                  ))}
                 </div>
-                <div className="version-info">
-                  <div className="info-row">
-                    <span className="label">Created:</span>
-                    <span>{new Date(version.createdAt).toLocaleString()}</span>
-                  </div>
-                  {version.publishedAt && (
-                    <div className="info-row">
-                      <span className="label">Published:</span>
-                      <span>{new Date(version.publishedAt).toLocaleString()}</span>
-                    </div>
-                  )}
-                  <details className="config-details">
-                    <summary>View Configuration</summary>
-                    <pre className="config-preview">{formatVersionConfig(version.config)}</pre>
-                  </details>
-                </div>
-              </div>
-            ))}
-          </div>
-
-          {totalPages > 1 && (
-            <div className="pagination-controls">
-              <div className="pagination-info">
-                Showing {startIndex + 1}-{Math.min(endIndex, filteredVersions.length)} of {filteredVersions.length} versions
-              </div>
-              <div className="pagination-buttons">
-                <button
-                  onClick={() => handlePageChange(1)}
-                  disabled={currentPage === 1}
-                  className="page-btn"
-                  title="First page"
-                >
-                  &laquo;
-                </button>
-                <button
-                  onClick={() => handlePageChange(currentPage - 1)}
-                  disabled={currentPage === 1}
-                  className="page-btn"
-                  title="Previous page"
-                >
-                  &lsaquo;
-                </button>
-                {renderPageNumbers()}
-                <button
-                  onClick={() => handlePageChange(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                  className="page-btn"
-                  title="Next page"
-                >
-                  &rsaquo;
-                </button>
-                <button
-                  onClick={() => handlePageChange(totalPages)}
-                  disabled={currentPage === totalPages}
-                  className="page-btn"
-                  title="Last page"
-                >
-                  &raquo;
-                </button>
-              </div>
-            </div>
-          )}
-        </>
+                <PaginationControls
+                  totalPages={totalPages}
+                  currentPage={currentPage}
+                  startIndex={startIndex}
+                  endIndex={endIndex}
+                  totalItems={filteredVersions.length}
+                  onPageChange={handlePageChange}
+                  renderPageNumbers={renderPageNumbers}
+                />
+              </>
             )}
           </>
         )}
       </div>
 
-      <ConfirmModal
-        isOpen={showPublishConfirm}
-        onClose={() => setShowPublishConfirm(false)}
-        onConfirm={confirmPublish}
-        title="Publish Version"
-        message={`Are you sure you want to publish version ${versionToPublish}?`}
-        confirmText="Publish"
-        confirmStyle="primary"
-      />
-
-      <ConfirmModal
-        isOpen={showDeleteConfirm}
-        onClose={() => setShowDeleteConfirm(false)}
-        onConfirm={confirmDelete}
-        title="Delete System"
-        message={`Are you sure you want to delete "${system?.displayName}"? This will delete all versions as well.`}
-        confirmText="Delete"
-        confirmStyle="danger"
-      />
-
-      <AlertModal
-        isOpen={!!alertMessage}
-        onClose={() => setAlertMessage(null)}
-        title="Error"
-        message={alertMessage}
-        type="error"
-      />
-
-      <EditSystemModal
-        isOpen={showEditModal}
-        onClose={() => setShowEditModal(false)}
-        onSubmit={handleEditSystem}
-        system={system}
-      />
+      <ConfirmModal isOpen={showPublishConfirm} onClose={() => setShowPublishConfirm(false)} onConfirm={confirmPublish} title="Publish Version" message={`Are you sure you want to publish version ${versionToPublish}?`} confirmText="Publish" confirmStyle="primary" />
+      <ConfirmModal isOpen={showDeleteConfirm} onClose={() => setShowDeleteConfirm(false)} onConfirm={confirmDelete} title="Delete System" message={`Are you sure you want to delete "${system?.displayName}"? This will delete all versions as well.`} confirmText="Delete" confirmStyle="danger" />
+      <AlertModal isOpen={!!alertMessage} onClose={() => setAlertMessage(null)} title="Error" message={alertMessage} type="error" />
+      <EditSystemModal isOpen={showEditModal} onClose={() => setShowEditModal(false)} onSubmit={handleEditSystem} system={system} />
     </div>
   );
 }

--- a/frontend/src/pages/ScenarioForm.jsx
+++ b/frontend/src/pages/ScenarioForm.jsx
@@ -4,7 +4,11 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { scenariosApi } from '../api/scenariosApi';
 import { liftSystemsApi } from '../api/liftSystemsApi';
 import AlertModal from '../components/AlertModal';
-import PassengerFlowBuilder from '../components/PassengerFlowBuilder';
+import ScenarioBasicsSection from '../components/scenarios/ScenarioBasicsSection';
+import ScenarioJsonEditor from '../components/scenarios/ScenarioJsonEditor';
+import ScenarioSettingsSection from '../components/scenarios/ScenarioSettingsSection';
+import ScenarioTemplateSection from '../components/scenarios/ScenarioTemplateSection';
+import ScenarioValidationResults from '../components/scenarios/ScenarioValidationResults';
 import { handleApiError } from '../utils/errorHandlers';
 import './ScenarioForm.css';
 
@@ -542,304 +546,68 @@ function ScenarioForm() {
       </div>
 
       <form onSubmit={handleSubmit}>
-        {/* Scenario Name */}
-        <div className="form-section">
-          <div className="form-group">
-            <label htmlFor="scenarioName">
-              Scenario Name <span className="required">*</span>
-            </label>
-            <input
-              type="text"
-              id="scenarioName"
-              value={scenarioName}
-              onChange={(e) => {
-                setScenarioName(e.target.value);
-                if (formErrors.scenarioName) {
-                  setFormErrors(prev => ({ ...prev, scenarioName: '' }));
-                }
-              }}
-              placeholder="e.g., Morning Rush Hour"
-              className={formErrors.scenarioName ? 'error' : ''}
-            />
-            {formErrors.scenarioName && (
-              <span className="error-message">{formErrors.scenarioName}</span>
-            )}
-          </div>
+        <ScenarioBasicsSection
+          scenarioName={scenarioName}
+          setScenarioName={setScenarioName}
+          formErrors={formErrors}
+          setFormErrors={setFormErrors}
+          liftSystems={liftSystems}
+          selectedSystemId={selectedSystemId}
+          setSelectedSystemId={setSelectedSystemId}
+          versions={versions}
+          selectedVersionId={selectedVersionId}
+          setSelectedVersionId={setSelectedVersionId}
+          floorRange={floorRange}
+          parseVersionConfig={parseVersionConfig}
+        />
 
-          {/* Lift System Selection */}
-          <div className="form-group">
-            <label htmlFor="liftSystem">
-              Lift System <span className="required">*</span>
-            </label>
-            <select
-              id="liftSystem"
-              value={selectedSystemId}
-              onChange={(e) => {
-                setSelectedSystemId(e.target.value);
-                setSelectedVersionId('');
-                if (formErrors.liftSystem || formErrors.liftSystemVersion) {
-                  setFormErrors(prev => ({ ...prev, liftSystem: '', liftSystemVersion: '' }));
-                }
-              }}
-              className={formErrors.liftSystem ? 'error' : ''}
-            >
-              <option value="">-- Select Lift System --</option>
-              {liftSystems.map((system) => (
-                <option key={system.id} value={system.id}>
-                  {system.displayName}
-                </option>
-              ))}
-            </select>
-            {formErrors.liftSystem && (
-              <span className="error-message">{formErrors.liftSystem}</span>
-            )}
-            <p className="help-text">
-              Select the lift system this scenario will be designed for
-            </p>
-          </div>
-
-          {/* Version Selection */}
-          {selectedSystemId && (
-            <div className="form-group">
-              <label htmlFor="liftSystemVersion">
-                Version <span className="required">*</span>
-              </label>
-              <select
-                id="liftSystemVersion"
-                value={selectedVersionId}
-                onChange={(e) => {
-                  setSelectedVersionId(e.target.value);
-                  if (formErrors.liftSystemVersion) {
-                    setFormErrors(prev => ({ ...prev, liftSystemVersion: '' }));
-                  }
-                }}
-                className={formErrors.liftSystemVersion ? 'error' : ''}
-              >
-                <option value="">-- Select Version --</option>
-                {versions.map((version) => {
-                  const floorInfo = parseVersionConfig(version.config);
-                  return (
-                    <option key={version.id} value={version.id}>
-                      Version {version.versionNumber}
-                      {floorInfo ?
-                        ` (Floors ${floorInfo.minFloor} to ${floorInfo.maxFloor})` :
-                        ''
-                      }
-                    </option>
-                  );
-                })}
-              </select>
-              <p className="help-text">
-                Select the version to ensure floor ranges are validated correctly
-              </p>
-              {floorRange && (
-                <p className="help-text">
-                  <strong>Valid floor range: {floorRange.minFloor} to {floorRange.maxFloor}</strong>
-                </p>
-              )}
-              {formErrors.liftSystemVersion && (
-                <span className="error-message">{formErrors.liftSystemVersion}</span>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Template Selection */}
         {!isEditMode && (
-          <div className="form-section">
-            <h3>Quick Start Templates</h3>
-            {floorRange && (
-              <p className="help-text" style={{ marginBottom: '1rem' }}>
-                Templates will be adapted to the selected floor range ({floorRange.minFloor} to {floorRange.maxFloor}).
-              </p>
-            )}
-            {!selectedVersionId && (
-              <p className="help-text" style={{ marginBottom: '1rem', color: '#e67e22' }}>
-                Select a lift system and version above to ensure templates use valid floor ranges.
-              </p>
-            )}
-            <div className="template-grid">
-              {Object.entries(SCENARIO_TEMPLATES).map(([key, template]) => (
-                <button
-                  key={key}
-                  type="button"
-                  className={`template-card${selectedTemplateKey === key ? ' is-selected' : ''}`}
-                  onClick={() => applyTemplate(key)}
-                  aria-pressed={selectedTemplateKey === key}
-                >
-                  <div className="template-name">{template.name}</div>
-                  <div className="template-description">{template.description}</div>
-                </button>
-              ))}
-            </div>
-          </div>
+          <ScenarioTemplateSection
+            floorRange={floorRange}
+            selectedVersionId={selectedVersionId}
+            templates={SCENARIO_TEMPLATES}
+            selectedTemplateKey={selectedTemplateKey}
+            onApplyTemplate={applyTemplate}
+          />
         )}
 
-        {/* Advanced JSON Toggle */}
         <div className="form-section">
-          <button
-            type="button"
-            className="btn-secondary"
-            onClick={handleToggleAdvancedJson}
-          >
+          <button type="button" className="btn-secondary" onClick={handleToggleAdvancedJson}>
             {showAdvancedJson ? 'Switch to Form Mode' : 'Switch to Advanced JSON Mode'}
           </button>
         </div>
 
         {showAdvancedJson ? (
-          /* Advanced JSON Editor */
-          <div className="form-section">
-            <h3>Scenario JSON</h3>
-            <div className="form-group">
-              <textarea
-                value={jsonText}
-                onChange={(e) => {
-                  setJsonText(e.target.value);
-                  if (formErrors.durationTicks) {
-                    setFormErrors(prev => ({ ...prev, durationTicks: '' }));
-                  }
-                }}
-                rows={20}
-                className="json-editor"
-                placeholder="Enter scenario JSON..."
-              />
-              <p className="help-text">
-                Edit the scenario JSON directly. Valid fields: durationTicks, passengerFlows, seed (optional)
-              </p>
-              {formErrors.durationTicks && (
-                <span className="error-message">{formErrors.durationTicks}</span>
-              )}
-            </div>
-          </div>
+          <ScenarioJsonEditor
+            jsonText={jsonText}
+            setJsonText={setJsonText}
+            formErrors={formErrors}
+            setFormErrors={setFormErrors}
+          />
         ) : (
-          /* Form Mode */
-          <>
-            {/* Duration */}
-            <div className="form-section">
-              <h3>Simulation Settings</h3>
-              <div className="form-group">
-                <label htmlFor="durationTicks">
-                  Duration (ticks) <span className="required">*</span>
-                </label>
-                <input
-                  type="number"
-                  id="durationTicks"
-                  value={durationTicks}
-                  onChange={(e) => {
-                    setDurationTicks(e.target.value);
-                    if (formErrors.durationTicks) {
-                      setFormErrors(prev => ({ ...prev, durationTicks: '' }));
-                    }
-                  }}
-                  className={formErrors.durationTicks ? 'error' : ''}
-                  min="1"
-                  placeholder="e.g., 100"
-                />
-                {formErrors.durationTicks && (
-                  <span className="error-message">{formErrors.durationTicks}</span>
-                )}
-                <p className="help-text">
-                  How long the simulation will run (each tick represents one time unit)
-                </p>
-              </div>
-
-              {/* Seed */}
-              <div className="form-group">
-                <label htmlFor="useSeed" className="checkbox-label">
-                  <input
-                    type="checkbox"
-                    id="useSeed"
-                    checked={useSeed}
-                    onChange={(e) => setUseSeed(e.target.checked)}
-                  />
-                  Use Random Seed (for reproducibility)
-                </label>
-              </div>
-
-              {useSeed && (
-                <div className="form-group">
-                  <label htmlFor="seed">Random Seed</label>
-                  <input
-                    type="number"
-                    id="seed"
-                    value={seed}
-                    onChange={(e) => setSeed(e.target.value)}
-                    min="0"
-                    placeholder="e.g., 42"
-                  />
-                  <p className="help-text">
-                    Optional seed for reproducible random behavior. Same seed = same simulation results.
-                  </p>
-                </div>
-              )}
-            </div>
-
-            {/* Passenger Flows */}
-            <div className="form-section">
-              <h3>Passenger Flows</h3>
-              <PassengerFlowBuilder
-                flows={passengerFlows}
-                onChange={setPassengerFlows}
-                maxTick={parseInt(durationTicks, 10) || 100}
-                floorRange={floorRange}
-              />
-            </div>
-          </>
+          <ScenarioSettingsSection
+            durationTicks={durationTicks}
+            setDurationTicks={setDurationTicks}
+            useSeed={useSeed}
+            setUseSeed={setUseSeed}
+            seed={seed}
+            setSeed={setSeed}
+            passengerFlows={passengerFlows}
+            setPassengerFlows={setPassengerFlows}
+            floorRange={floorRange}
+            formErrors={formErrors}
+            setFormErrors={setFormErrors}
+          />
         )}
 
-        {/* Validation Results */}
-        {(validationErrors.length > 0 || validationWarnings.length > 0) && (
-          <div className="form-section">
-            <h3>Validation Results</h3>
-            {validationErrors.length > 0 && (
-              <div className="validation-errors">
-                <h4>Errors:</h4>
-                <ul>
-                  {validationErrors.map((error, index) => (
-                    <li key={index}>
-                      <strong>{error.field}:</strong> {error.message}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {validationWarnings.length > 0 && (
-              <div className="validation-warnings">
-                <h4>Warnings:</h4>
-                <ul>
-                  {validationWarnings.map((warning, index) => (
-                    <li key={index}>
-                      <strong>{warning.field}:</strong> {warning.message}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </div>
-        )}
+        <ScenarioValidationResults validationErrors={validationErrors} validationWarnings={validationWarnings} />
 
-        {/* Actions */}
         <div className="form-actions">
-          <button
-            type="button"
-            className="btn-secondary"
-            onClick={() => navigate('/scenarios')}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="btn-secondary"
-            onClick={handleValidate}
-            disabled={validating}
-          >
+          <button type="button" className="btn-secondary" onClick={() => navigate('/scenarios')}>Cancel</button>
+          <button type="button" className="btn-secondary" onClick={handleValidate} disabled={validating}>
             {validating ? 'Validating...' : 'Validate'}
           </button>
-          <button
-            type="submit"
-            className="btn-primary"
-            disabled={saving || validating}
-          >
+          <button type="submit" className="btn-primary" disabled={saving || validating}>
             {saving ? 'Saving...' : (isEditMode ? 'Update Scenario' : 'Create Scenario')}
           </button>
         </div>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.9</version>
+    <version>0.57.10</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Reduce the size and complexity of two very large page components to improve readability and maintainability.
- Make scenario and lift-system UI concerns more modular so pieces (templates, JSON editor, settings, version cards, pagination) can be reused and tested independently.
- Keep the visible UI and behavior unchanged while moving markup and render logic into focused subcomponents.

### Description
- Replaced large inline render trees in `frontend/src/pages/ScenarioForm.jsx` and `frontend/src/pages/LiftSystemDetail.jsx` with imports of new subcomponents and smaller page-level scaffolding.
- Added scenario subcomponents under `frontend/src/components/scenarios/`: `ScenarioBasicsSection.jsx`, `ScenarioTemplateSection.jsx`, `ScenarioJsonEditor.jsx`, `ScenarioSettingsSection.jsx`, and `ScenarioValidationResults.jsx` to own the form sections and JSON editor.
- Added lift-system/version subcomponents under `frontend/src/components/liftSystems/`: `LiftSystemHeader.jsx`, `LiftSystemInfoSection.jsx`, `CreateVersionForm.jsx`, `VersionCard.jsx`, `VersionsControls.jsx`, and `PaginationControls.jsx` to own header, info, create-version, cards, filters, and pagination.
- Updated imports and wiring in the two page files to use the new components and preserved existing behavior (validation, API calls, modals, and actions).
- Bumped repository and frontend UI version from `0.57.9` to `0.57.10`, updated `CHANGELOG.md`, `README.md`, `frontend/README.md`, `pom.xml`, `frontend/package.json`, and `frontend/package-lock.json` to reflect the change.
- Commit message follows commitizen style: `refactor(frontend): decompose large page components`.

### Testing
- Ran `npm --prefix frontend run lint` and ESLint completed successfully after fixing an import/format issue. (passed)
- Ran `npm --prefix frontend run build` and the Vite production build completed successfully producing `dist/` assets. (passed)
- Ran `./scripts/sync-versions.sh --check` to verify version consistency across `pom.xml`, frontend package files, and README references and it reported consistency. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a533e24e9748325bf9dafedb4d578e2)