### PR TITLE
docs: split Workflows-and-Troubleshooting into CONFIG-SCHEMA.md and TROUBLESHOOTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.14] - 2026-07-12
+
+### Changed
+- **Workflow documentation split**: Split the oversized Workflows and Troubleshooting guide into focused workflow, configuration/schema, and troubleshooting documents. Added `docs/CONFIG-SCHEMA.md` for lift-configuration, scenario payload, and batch-input-generator reference material; restored `docs/TROUBLESHOOTING.md` as the single home for general setup and database diagnostics; refreshed inbound links in README, API, and frontend docs; and updated package metadata for the 0.57.14 pre-MVP patch release.
+
 ## [0.57.13] - 2026-07-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.13**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.14**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -79,7 +79,7 @@ For a visual overview of the major components (React admin UI, Spring Boot backe
 
 **UAT testing** — follow the 14 detailed scenarios in [docs/UAT-TEST-SCENARIOS.md](docs/UAT-TEST-SCENARIOS.md) (estimated 2–3 hours, with expected results, pass/fail criteria, and a sign-off checklist).
 
-**Quick troubleshooting** — most setup failures are: database not running (check credentials in `application-dev.yml`), a port conflict (8080 and 3000 must be free), the wrong Node version (`node --version`), or a migration failure (requires PostgreSQL 12+). See [docs/Workflows-and-Troubleshooting.md#general-troubleshooting](docs/Workflows-and-Troubleshooting.md#general-troubleshooting) for the full guide.
+**Quick troubleshooting** — most setup failures are: database not running (check credentials in `application-dev.yml`), a port conflict (8080 and 3000 must be free), the wrong Node version (`node --version`), or a migration failure (requires PostgreSQL 12+). See [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) for the full guide.
 
 ## Admin Interface
 
@@ -99,7 +99,7 @@ The **frontend admin UI** provides:
 
 Run the UI in dev mode with `cd frontend && npm install && npm run dev`; it proxies API requests to the backend on port 8080. See [frontend/README.md](frontend/README.md) for setup, environment variables, and the type-definition (JSDoc) workflow.
 
-The **backend REST API** is versioned under `/api/v1` (base URL `http://localhost:8080/api/v1`). The complete, always-current endpoint reference is generated from the code by SpringDoc and served as interactive Swagger UI at `/api/v1/swagger-ui.html` and OpenAPI JSON at `/api/v1/api-docs`. API conventions — authentication, role-based access control, versioning, rate limiting, request-size limits, and the shared error-response shape — are documented in [docs/API.md](docs/API.md). For CLI/UI run workflows, the configuration and scenario schema reference, artefact reproduction, and simulation-run troubleshooting, see [docs/Workflows-and-Troubleshooting.md](docs/Workflows-and-Troubleshooting.md). See [ADR-0020](docs/decisions/0020-url-based-api-versioning.md) for the versioning strategy.
+The **backend REST API** is versioned under `/api/v1` (base URL `http://localhost:8080/api/v1`). The complete, always-current endpoint reference is generated from the code by SpringDoc and served as interactive Swagger UI at `/api/v1/swagger-ui.html` and OpenAPI JSON at `/api/v1/api-docs`. API conventions — authentication, role-based access control, versioning, rate limiting, request-size limits, and the shared error-response shape — are documented in [docs/API.md](docs/API.md). For CLI/UI run workflows and artefact reproduction, see [docs/Workflows-and-Troubleshooting.md](docs/Workflows-and-Troubleshooting.md); for configuration and scenario field constraints, see [docs/CONFIG-SCHEMA.md](docs/CONFIG-SCHEMA.md); for simulation-run troubleshooting, see [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md). See [ADR-0020](docs/decisions/0020-url-based-api-versioning.md) for the versioning strategy.
 
 ## Building the Project
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.13.jar
+java -jar target/lift-simulator-0.57.14.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.13.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.14.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.13.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.13.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.14.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.14.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.13.jar com.liftsimulator.Main --strategy=dir
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.13.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.14.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -180,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.13.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.14.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 
@@ -226,7 +226,7 @@ On startup the application runs Flyway automatically: it creates the `lift_simul
 
 The schema includes `lift_system` and `lift_system_version` (versioned JSONB configurations), `scenario` (reusable test scenarios), and `simulation_run`, which tracks run status (CREATED, RUNNING, SUCCEEDED, FAILED, CANCELLED) with optimistic locking and referential integrity to lift systems and versions. See [ADR-0007](docs/decisions/0007-postgresql-flyway-integration.md) and [ADR-0008](docs/decisions/0008-jpa-entities-and-jsonb-mapping.md) for the persistence design.
 
-For JPA entities, repositories, and verification-runner usage, see [docs/DEVELOPER-GUIDE.md#jpa-entities-and-repositories](docs/DEVELOPER-GUIDE.md#jpa-entities-and-repositories). For connection, permission, and migration errors, see [docs/Workflows-and-Troubleshooting.md#database-troubleshooting](docs/Workflows-and-Troubleshooting.md#database-troubleshooting). For backup and restore procedures, see [docs/DATABASE-BACKUP.md](docs/DATABASE-BACKUP.md).
+For JPA entities, repositories, and verification-runner usage, see [docs/DEVELOPER-GUIDE.md#jpa-entities-and-repositories](docs/DEVELOPER-GUIDE.md#jpa-entities-and-repositories). For connection, permission, and migration errors, see [docs/TROUBLESHOOTING.md#database-troubleshooting](docs/TROUBLESHOOTING.md#database-troubleshooting). For backup and restore procedures, see [docs/DATABASE-BACKUP.md](docs/DATABASE-BACKUP.md).
 
 ## Logging
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -11,7 +11,7 @@ The complete endpoint reference is served by the running backend and is the auth
 
 Access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so both URLs require ADMIN-role HTTP Basic authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 
-For operational guidance that the generated spec does not capture — CLI/UI run workflows, artefact reproduction, the configuration and scenario schema reference, and simulation-run troubleshooting — see [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md).
+For operational guidance that the generated spec does not capture — CLI/UI run workflows and artefact reproduction — see [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md). For field-level configuration and scenario constraints, see [Configuration and Scenario Schema Reference](CONFIG-SCHEMA.md). For setup and runtime diagnostics, see [Troubleshooting](TROUBLESHOOTING.md).
 
 ## Base URL and Versioning
 
@@ -215,4 +215,4 @@ The same `valid` / `errors` / `warnings` shape is returned when validation runs 
 
 ## Schema Reference and Operational Details
 
-The lift-configuration and scenario schemas (field constraints, validation rules, the floor-range migration note, and the batch-input-generator format), the run-artefact directory layout, and the `results.json` schema are documented in [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md#configuration-and-scenario-schema-reference). Step-by-step CLI usage, UI-driven run workflows, artefact reproduction, and troubleshooting live in the same guide.
+The lift-configuration and scenario schemas (field constraints, validation rules, the floor-range migration note, and the batch-input-generator format) are documented in [Configuration and Scenario Schema Reference](CONFIG-SCHEMA.md). The run-artefact directory layout, `results.json` schema, step-by-step CLI usage, UI-driven run workflows, and artefact reproduction live in [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md). Setup and runtime diagnostics live in [Troubleshooting](TROUBLESHOOTING.md).

--- a/docs/CONFIG-SCHEMA.md
+++ b/docs/CONFIG-SCHEMA.md
@@ -1,0 +1,101 @@
+# Configuration and Scenario Schema Reference
+
+This reference documents the payload schemas that clients construct when creating lift-system versions, authoring scenarios, and reproducing runs. The field constraints below are enforced by the backend validation framework and are surfaced in the generated OpenAPI spec; they are collected here as human-readable reference. For the API conventions that govern these payloads (auth, error shape, size limits), see [API Conventions](API.md). For operational run workflows, see [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md).
+
+
+### Lift Configuration Schema
+
+All lift system configurations must conform to the following structure:
+
+```json
+{
+  "minFloor": 0,
+  "maxFloor": 9,
+  "lifts": 1,
+  "travelTicksPerFloor": 1,
+  "doorTransitionTicks": 2,
+  "doorDwellTicks": 3,
+  "doorReopenWindowTicks": 2,
+  "homeFloor": 0,
+  "idleTimeoutTicks": 5,
+  "controllerStrategy": "NEAREST_REQUEST_ROUTING",
+  "idleParkingMode": "PARK_TO_HOME_FLOOR"
+}
+```
+
+**Field constraints:**
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `minFloor` | Integer | Required | Minimum floor in the building (can be negative for basements) |
+| `maxFloor` | Integer | > minFloor | Maximum floor in the building (must be greater than minFloor) |
+| `lifts` | Integer | Exactly `1` | Number of lift cars. Multi-lift simulation is not supported in v1.0.0, so any value other than `1` is rejected with a validation error |
+| `travelTicksPerFloor` | Integer | ≥ 1 | Ticks required to travel one floor |
+| `doorTransitionTicks` | Integer | ≥ 1 | Ticks required for doors to open or close |
+| `doorDwellTicks` | Integer | ≥ 1 | Ticks doors stay open before closing |
+| `doorReopenWindowTicks` | Integer | ≥ 0, ≤ doorTransitionTicks | Window during door closing when doors can reopen |
+| `homeFloor` | Integer | minFloor ≤ homeFloor ≤ maxFloor | Idle parking floor (must be within floor range) |
+| `idleTimeoutTicks` | Integer | ≥ 0 | Ticks before idle parking behavior activates |
+| `controllerStrategy` | Enum | NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN | Controller algorithm |
+| `idleParkingMode` | Enum | STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR | Idle parking behavior |
+
+**Validation features:**
+
+- **Structural validation:** ensures JSON is well-formed and all required fields are present.
+- **Type validation:** validates field types and enum values.
+- **Domain validation:** enforces business rules and cross-field constraints — `doorReopenWindowTicks` must not exceed `doorTransitionTicks`, `maxFloor` must be greater than `minFloor`, and `homeFloor` must be within the floor range.
+- **Warnings** (non-blocking): low `doorDwellTicks`, low `idleTimeoutTicks` with `PARK_TO_HOME_FLOOR` mode, and zero `doorReopenWindowTicks` (which disables door reopening).
+
+Validation runs automatically when creating a new version, updating a version's configuration, or publishing a version. If it fails with errors, the operation is rejected with a `400 Bad Request` using the `valid` / `errors` / `warnings` shape documented in [API Conventions](API.md#error-response-structure). To validate without persisting, `POST` the config to the validation endpoint (see the generated OpenAPI spec).
+
+**Migration note (0.46.0 floor-range update):**
+
+- Replace `floors` with explicit `minFloor` and `maxFloor`. For existing configs, set `minFloor` to `0` and `maxFloor` to `floors - 1`.
+- Ensure `homeFloor` is within the new range (`minFloor` to `maxFloor`).
+- Apply the Flyway migration `V2__migrate_floor_range_config.sql` to update stored configuration payloads.
+
+### Scenario Payload Schema
+
+Scenario payloads define passenger flow for UI-driven simulation runs. The scenario schema is separate from the batch `.scenario` files used by the CLI. A scenario JSON payload has the shape:
+
+```json
+{
+  "durationTicks": 60,
+  "passengerFlows": [
+    {
+      "startTick": 0,
+      "originFloor": 0,
+      "destinationFloor": 5,
+      "passengers": 3
+    }
+  ],
+  "seed": 42
+}
+```
+
+**Field constraints:**
+
+| Field | Type | Constraints | Description |
+|-------|------|-------------|-------------|
+| `durationTicks` | Integer | Required, ≥ 1 | Total number of ticks to simulate |
+| `passengerFlows` | Array | Required, ≥ 1 entry | Passenger flow entries |
+| `passengerFlows[].startTick` | Integer | ≥ 0, < durationTicks | Tick when passengers arrive |
+| `passengerFlows[].originFloor` | Integer | Required | Origin floor for the flow |
+| `passengerFlows[].destinationFloor` | Integer | Required, ≠ origin | Destination floor for the flow |
+| `passengerFlows[].passengers` | Integer | Required, ≥ 1 | Number of passengers in the flow |
+| `seed` | Integer | Optional, ≥ 0 | Random seed for deterministic runs |
+
+Scenario names must be unique within a lift system version; a create or rename that collides returns `409 Conflict`. Deleting a scenario intentionally cascades its associated simulation-run history, and clients should warn users with the run count (available from the run-count endpoint) before deleting.
+
+### Batch Input Generator Format
+
+The batch input generator converts stored scenario definitions and lift configurations into the legacy `.scenario` file format used by the CLI simulator. It exists as a backwards-compatibility bridge so scenarios authored through the UI/API can be replayed by the existing CLI batch infrastructure without manual conversion. It runs internally as part of starting a simulation run; there is no standalone public endpoint.
+
+| Direction | Format |
+|-----------|--------|
+| Input | Lift system version configuration plus scenario JSON (passenger flows) — see [Scenario Payload Schema](#scenario-payload-schema) for field constraints |
+| Output | A `.scenario` file consumed by the CLI runner: a `key: value` configuration header followed by comma-delimited event rows of the form `<tick>, hall_call, <alias>, <originFloor>, <direction>`. See [CLI Usage](Workflows-and-Troubleshooting.md#cli-usage-unchanged) for running the generated file. |
+
+Generated `input.scenario` artefacts skip same-floor passenger flows so CLI reproduction matches the in-process executor.
+
+---

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.13.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.14.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,72 @@
+# Troubleshooting
+
+Use this guide to diagnose setup, frontend/backend startup, validation, and database failures. For CLI/UI simulation run workflows and run-specific diagnostics, see [Workflows and Troubleshooting](Workflows-and-Troubleshooting.md#workflow-troubleshooting).
+
+### Quick Start Troubleshooting
+
+#### Backend won't start
+
+- Verify PostgreSQL is running: `psql -h localhost -U lift_admin -d lift_simulator`
+- Check database credentials in `src/main/resources/application-dev.yml`
+- Check port 8080 isn't already in use: `lsof -i :8080` (macOS/Linux) or `netstat -ano | findstr :8080` (Windows)
+
+#### StackOverflowError in backend logs when loading HTML routes
+
+- Ensure the SPA forwarder does not match `/index.html` (the app now excludes it to prevent recursive forwards)
+- Restart the backend after pulling the latest changes
+
+#### Backend returns 404 for index.html
+
+- Build the frontend assets with `mvn -Pfrontend clean package` or run the frontend dev server at http://localhost:3000
+- Verify `target/classes/static/index.html` exists after building the frontend bundle
+
+#### Frontend won't start
+
+- Verify Node.js version: `node --version` (should be 20.19+ or 22.12+)
+- Delete `node_modules` and reinstall: `rm -rf node_modules && npm install`
+- Check port 3000 isn't already in use
+
+#### Can't connect to backend from frontend
+
+- Verify backend is running at http://localhost:8080/api/v1/health
+- Check browser console for CORS errors
+- Vite dev proxy should handle this automatically
+
+#### Database migrations fail
+
+- Drop and recreate database (see [Database Setup](../README.md#database-setup))
+- Verify PostgreSQL version is 12+
+- Check Flyway migration files in `src/main/resources/db/migration/`
+
+#### Scenario validation fails with "Unable to read scenario payload"
+
+- Confirm the scenario JSON is valid and not empty
+- Retry the request after verifying the payload format
+
+#### Cannot delete a lift system due to scenario dependencies
+
+- Delete scenarios (or the versions that reference them) before deleting the lift system
+- Retry the delete once dependent scenarios are removed
+
+### Database Troubleshooting
+
+#### Connection refused errors
+
+- Ensure PostgreSQL is running: `sudo service postgresql status`
+- Check the connection settings in `application-dev.yml`
+
+#### Permission denied errors
+
+- Verify the database user has proper permissions: `GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;`
+- Ensure schema-level permissions: `GRANT ALL ON SCHEMA lift_simulator TO lift_admin;`
+
+#### Migration errors
+
+- Check Flyway history: `SELECT * FROM flyway_schema_history;`
+- For development, you can reset the database: `DROP DATABASE lift_simulator; CREATE DATABASE lift_simulator;`
+- If `public.flyway_schema_history` exists from earlier runs, drop it and restart the app so Flyway recreates history in `lift_simulator`: `DROP TABLE public.flyway_schema_history;`
+- If a legacy `public.schema_metadata` table exists from older releases, it can be dropped; current migrations do not use it: `DROP TABLE public.schema_metadata;`
+- If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` once to clear stale build artifacts; the build now removes old migration resources automatically.
+- If Flyway reports "No migrations found", rebuild with `mvn clean package` to refresh the packaged `db/migration` resources.
+
+---

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -1,6 +1,6 @@
 # Workflows and Troubleshooting
 
-This guide explains how to run Lift Simulator simulations from the command line and the admin UI, where run artefacts are stored, how to reproduce UI-driven runs locally, and how to diagnose common failures. It complements the API reference by focusing on operational workflows rather than endpoint schemas. For API-level errors, see [docs/API.md](API.md).
+This guide explains how to run Lift Simulator simulations from the command line and the admin UI, where run artefacts are stored, and how to reproduce UI-driven runs locally. It complements the API reference by focusing on operational workflows rather than endpoint schemas. For API-level errors, see [docs/API.md](API.md); for configuration and scenario field constraints, see [CONFIG-SCHEMA.md](CONFIG-SCHEMA.md); for setup and runtime diagnostics, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## Table of Contents
 
@@ -11,14 +11,12 @@ This guide explains how to run Lift Simulator simulations from the command line 
   - [Artefact Storage](#artefact-storage)
   - [Reproducing UI Runs via CLI](#reproducing-ui-runs-via-cli)
   - [Example Scenario Walkthrough: Morning Rush Hour](#example-scenario-walkthrough-morning-rush-hour)
-  - [Troubleshooting](#troubleshooting)
-- [Configuration and Scenario Schema Reference](#configuration-and-scenario-schema-reference)
-  - [Lift Configuration Schema](#lift-configuration-schema)
-  - [Scenario Payload Schema](#scenario-payload-schema)
-  - [Batch Input Generator Format](#batch-input-generator-format)
-- [General Troubleshooting](#general-troubleshooting)
-  - [Quick Start Troubleshooting](#quick-start-troubleshooting)
-  - [Database Troubleshooting](#database-troubleshooting)
+  - [Workflow Troubleshooting](#workflow-troubleshooting)
+
+Related references:
+
+- [Configuration and Scenario Schema Reference](CONFIG-SCHEMA.md)
+- [General Troubleshooting](TROUBLESHOOTING.md)
 
 ## CLI and UI-Run Workflows
 
@@ -50,7 +48,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.13.jar \
+java -cp target/lift-simulator-0.57.14.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -64,12 +62,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.13.jar \
+java -cp target/lift-simulator-0.57.14.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.13.jar \
+java -cp target/lift-simulator-0.57.14.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -113,7 +111,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.13.jar \
+java -cp target/lift-simulator-0.57.14.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -391,7 +389,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.13.jar \
+   java -cp target/lift-simulator-0.57.14.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -436,7 +434,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.13.jar \
+java -cp target/lift-simulator-0.57.14.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -528,7 +526,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.13.jar \
+java -cp target/lift-simulator-0.57.14.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```
@@ -545,7 +543,7 @@ The results are deterministic because we used seed 42 in both runs.
 
 ---
 
-### Troubleshooting
+### Workflow Troubleshooting
 
 #### Run Failed (Status: FAILED)
 
@@ -860,177 +858,5 @@ seed must be a valid integer
 - Use exact same seed from UI run
 - Verify all configuration parameters match
 - Rebuild CLI JAR if versions don't match: `mvn clean package`
-
----
-
-## Configuration and Scenario Schema Reference
-
-This section documents the payload schemas that clients construct when creating lift-system versions, authoring scenarios, and reproducing runs. The field constraints below are enforced by the backend validation framework and are surfaced in the generated OpenAPI spec; they are collected here as human-readable reference. For the API conventions that govern these payloads (auth, error shape, size limits), see [API Conventions](API.md).
-
-### Lift Configuration Schema
-
-All lift system configurations must conform to the following structure:
-
-```json
-{
-  "minFloor": 0,
-  "maxFloor": 9,
-  "lifts": 1,
-  "travelTicksPerFloor": 1,
-  "doorTransitionTicks": 2,
-  "doorDwellTicks": 3,
-  "doorReopenWindowTicks": 2,
-  "homeFloor": 0,
-  "idleTimeoutTicks": 5,
-  "controllerStrategy": "NEAREST_REQUEST_ROUTING",
-  "idleParkingMode": "PARK_TO_HOME_FLOOR"
-}
-```
-
-**Field constraints:**
-
-| Field | Type | Constraints | Description |
-|-------|------|-------------|-------------|
-| `minFloor` | Integer | Required | Minimum floor in the building (can be negative for basements) |
-| `maxFloor` | Integer | > minFloor | Maximum floor in the building (must be greater than minFloor) |
-| `lifts` | Integer | Exactly `1` | Number of lift cars. Multi-lift simulation is not supported in v1.0.0, so any value other than `1` is rejected with a validation error |
-| `travelTicksPerFloor` | Integer | ≥ 1 | Ticks required to travel one floor |
-| `doorTransitionTicks` | Integer | ≥ 1 | Ticks required for doors to open or close |
-| `doorDwellTicks` | Integer | ≥ 1 | Ticks doors stay open before closing |
-| `doorReopenWindowTicks` | Integer | ≥ 0, ≤ doorTransitionTicks | Window during door closing when doors can reopen |
-| `homeFloor` | Integer | minFloor ≤ homeFloor ≤ maxFloor | Idle parking floor (must be within floor range) |
-| `idleTimeoutTicks` | Integer | ≥ 0 | Ticks before idle parking behavior activates |
-| `controllerStrategy` | Enum | NEAREST_REQUEST_ROUTING, DIRECTIONAL_SCAN | Controller algorithm |
-| `idleParkingMode` | Enum | STAY_AT_CURRENT_FLOOR, PARK_TO_HOME_FLOOR | Idle parking behavior |
-
-**Validation features:**
-
-- **Structural validation:** ensures JSON is well-formed and all required fields are present.
-- **Type validation:** validates field types and enum values.
-- **Domain validation:** enforces business rules and cross-field constraints — `doorReopenWindowTicks` must not exceed `doorTransitionTicks`, `maxFloor` must be greater than `minFloor`, and `homeFloor` must be within the floor range.
-- **Warnings** (non-blocking): low `doorDwellTicks`, low `idleTimeoutTicks` with `PARK_TO_HOME_FLOOR` mode, and zero `doorReopenWindowTicks` (which disables door reopening).
-
-Validation runs automatically when creating a new version, updating a version's configuration, or publishing a version. If it fails with errors, the operation is rejected with a `400 Bad Request` using the `valid` / `errors` / `warnings` shape documented in [API Conventions](API.md#error-response-structure). To validate without persisting, `POST` the config to the validation endpoint (see the generated OpenAPI spec).
-
-**Migration note (0.46.0 floor-range update):**
-
-- Replace `floors` with explicit `minFloor` and `maxFloor`. For existing configs, set `minFloor` to `0` and `maxFloor` to `floors - 1`.
-- Ensure `homeFloor` is within the new range (`minFloor` to `maxFloor`).
-- Apply the Flyway migration `V2__migrate_floor_range_config.sql` to update stored configuration payloads.
-
-### Scenario Payload Schema
-
-Scenario payloads define passenger flow for UI-driven simulation runs. The scenario schema is separate from the batch `.scenario` files used by the CLI. A scenario JSON payload has the shape:
-
-```json
-{
-  "durationTicks": 60,
-  "passengerFlows": [
-    {
-      "startTick": 0,
-      "originFloor": 0,
-      "destinationFloor": 5,
-      "passengers": 3
-    }
-  ],
-  "seed": 42
-}
-```
-
-**Field constraints:**
-
-| Field | Type | Constraints | Description |
-|-------|------|-------------|-------------|
-| `durationTicks` | Integer | Required, ≥ 1 | Total number of ticks to simulate |
-| `passengerFlows` | Array | Required, ≥ 1 entry | Passenger flow entries |
-| `passengerFlows[].startTick` | Integer | ≥ 0, < durationTicks | Tick when passengers arrive |
-| `passengerFlows[].originFloor` | Integer | Required | Origin floor for the flow |
-| `passengerFlows[].destinationFloor` | Integer | Required, ≠ origin | Destination floor for the flow |
-| `passengerFlows[].passengers` | Integer | Required, ≥ 1 | Number of passengers in the flow |
-| `seed` | Integer | Optional, ≥ 0 | Random seed for deterministic runs |
-
-Scenario names must be unique within a lift system version; a create or rename that collides returns `409 Conflict`. Deleting a scenario intentionally cascades its associated simulation-run history, and clients should warn users with the run count (available from the run-count endpoint) before deleting.
-
-### Batch Input Generator Format
-
-The batch input generator converts stored scenario definitions and lift configurations into the legacy `.scenario` file format used by the CLI simulator. It exists as a backwards-compatibility bridge so scenarios authored through the UI/API can be replayed by the existing CLI batch infrastructure without manual conversion. It runs internally as part of starting a simulation run; there is no standalone public endpoint.
-
-| Direction | Format |
-|-----------|--------|
-| Input | Lift system version configuration plus scenario JSON (passenger flows) — see [Scenario Payload Schema](#scenario-payload-schema) for field constraints |
-| Output | A `.scenario` file consumed by the CLI runner: a `key: value` configuration header followed by comma-delimited event rows of the form `<tick>, hall_call, <alias>, <originFloor>, <direction>`. See [CLI Usage](#cli-usage-unchanged) for running the generated file. |
-
-Generated `input.scenario` artefacts skip same-floor passenger flows so CLI reproduction matches the in-process executor.
-
----
-
-## General Troubleshooting
-
-### Quick Start Troubleshooting
-
-#### Backend won't start
-
-- Verify PostgreSQL is running: `psql -h localhost -U lift_admin -d lift_simulator`
-- Check database credentials in `src/main/resources/application-dev.yml`
-- Check port 8080 isn't already in use: `lsof -i :8080` (macOS/Linux) or `netstat -ano | findstr :8080` (Windows)
-
-#### StackOverflowError in backend logs when loading HTML routes
-
-- Ensure the SPA forwarder does not match `/index.html` (the app now excludes it to prevent recursive forwards)
-- Restart the backend after pulling the latest changes
-
-#### Backend returns 404 for index.html
-
-- Build the frontend assets with `mvn -Pfrontend clean package` or run the frontend dev server at http://localhost:3000
-- Verify `target/classes/static/index.html` exists after building the frontend bundle
-
-#### Frontend won't start
-
-- Verify Node.js version: `node --version` (should be 20.19+ or 22.12+)
-- Delete `node_modules` and reinstall: `rm -rf node_modules && npm install`
-- Check port 3000 isn't already in use
-
-#### Can't connect to backend from frontend
-
-- Verify backend is running at http://localhost:8080/api/v1/health
-- Check browser console for CORS errors
-- Vite dev proxy should handle this automatically
-
-#### Database migrations fail
-
-- Drop and recreate database (see [Database Setup](../README.md#database-setup))
-- Verify PostgreSQL version is 12+
-- Check Flyway migration files in `src/main/resources/db/migration/`
-
-#### Scenario validation fails with "Unable to read scenario payload"
-
-- Confirm the scenario JSON is valid and not empty
-- Retry the request after verifying the payload format
-
-#### Cannot delete a lift system due to scenario dependencies
-
-- Delete scenarios (or the versions that reference them) before deleting the lift system
-- Retry the delete once dependent scenarios are removed
-
-### Database Troubleshooting
-
-#### Connection refused errors
-
-- Ensure PostgreSQL is running: `sudo service postgresql status`
-- Check the connection settings in `application-dev.yml`
-
-#### Permission denied errors
-
-- Verify the database user has proper permissions: `GRANT ALL PRIVILEGES ON DATABASE lift_simulator TO lift_admin;`
-- Ensure schema-level permissions: `GRANT ALL ON SCHEMA lift_simulator TO lift_admin;`
-
-#### Migration errors
-
-- Check Flyway history: `SELECT * FROM flyway_schema_history;`
-- For development, you can reset the database: `DROP DATABASE lift_simulator; CREATE DATABASE lift_simulator;`
-- If `public.flyway_schema_history` exists from earlier runs, drop it and restart the app so Flyway recreates history in `lift_simulator`: `DROP TABLE public.flyway_schema_history;`
-- If a legacy `public.schema_metadata` table exists from older releases, it can be dropped; current migrations do not use it: `DROP TABLE public.schema_metadata;`
-- If you upgraded from 0.23.0 and see "Found more than one migration with version 1", run `mvn clean` once to clear stale build artifacts; the build now removes old migration resources automatically.
-- If Flyway reports "No migrations found", rebuild with `mvn clean package` to refresh the packaged `db/migration` resources.
 
 ---

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -290,7 +290,7 @@ The frontend integrates with the backend `/api/v1` endpoints (lift systems, vers
 - **Port already in use**: if port 3000 is busy, Vite tries the next available port — check the console output for the actual port.
 - **CORS errors**: the proxy configuration should prevent these locally; verify `vite.config.js` proxy settings, restart `npm run dev`, and clear the browser cache.
 
-For broader setup and database troubleshooting, see [docs/Workflows-and-Troubleshooting.md](../docs/Workflows-and-Troubleshooting.md).
+For broader setup and database troubleshooting, see [docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md).
 
 ## Maintenance
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.13",
+  "version": "0.57.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.13",
+      "version": "0.57.14",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.13",
+  "version": "0.57.14",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.13</version>
+    <version>0.57.14</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- The original 1,036-line `Workflows-and-Troubleshooting.md` combined three distinct concerns (run workflows, schema reference, and general troubleshooting) into a single oversized document that is hard to navigate and maintain. 
- The change follows the chosen `CONFIG-SCHEMA.md` option to extract configuration and scenario field-level constraints into a standalone schema reference for reuse by API and editor documentation. 
- Separating general setup and runtime diagnostics into a dedicated troubleshooting file improves discoverability for developers and operators. 

### Description
- Created `docs/CONFIG-SCHEMA.md` containing the Lift Configuration Schema, Scenario Payload Schema, and Batch Input Generator Format extracted from the former combined guide. 
- Created `docs/TROUBLESHOOTING.md` containing Quick Start and Database troubleshooting content moved from the original guide. 
- Reduced `docs/Workflows-and-Troubleshooting.md` to focus on CLI/UI run workflows and retained run-specific diagnostics under a renamed "Workflow Troubleshooting" section with outbound links to the new references. 
- Updated inbound references across the repository (`README.md`, `docs/API.md`, `frontend/README.md`, `docs/DEVELOPER-GUIDE.md`, `frontend/package.json`, `pom.xml`, and other docs) to point to `docs/CONFIG-SCHEMA.md` and `docs/TROUBLESHOOTING.md`, and bumped the project metadata to `0.57.14`; added a `CHANGELOG.md` entry summarizing the split. 

### Testing
- Ran a repository-wide markdown relative link and anchor checker (`python3` script) which returned: "All markdown relative links and anchors resolved". 
- Ran `git diff --check` and addressed stray duplication in the new schema file; final commit passed `git diff --check`. 
- Attempted `mvn -q -DskipTests validate` to verify build metadata, but the run was blocked by an external dependency resolution error (Maven Central returned `403 Forbidden` while resolving the Spring Boot parent POM), so the full Maven validation could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53d5c0e628832584dc31fa696764c3)