### PR TITLE
refactor(frontend): push state down in ScenarioForm, LiftSystemDetail, and Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.17] - 2026-07-14
+
+- **Frontend state ownership refactor**: Pushed simulator run setup selection state into `SimulatorRunSetup`, moved scenario template selection state into `ScenarioTemplateSection`, and extracted lift-system version filtering/sorting/pagination state into `useVersionListControls` so the decomposed components own more local UI state without visual or behavioural changes. Updated README and frontend documentation for the 0.57.17 pre-MVP patch release.
+
 ## [0.57.16] - 2026-07-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.16**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.17**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.16.jar
+java -jar target/lift-simulator-0.57.17.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.16.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.17.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.16.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.16.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.16.jar com.liftsimulator.Main --strategy=dir
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.16.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -180,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.16.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.17.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.16.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.17.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -48,7 +48,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.16.jar \
+java -cp target/lift-simulator-0.57.17.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -62,12 +62,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.16.jar \
+java -cp target/lift-simulator-0.57.17.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.16.jar \
+java -cp target/lift-simulator-0.57.17.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -111,7 +111,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.16.jar \
+java -cp target/lift-simulator-0.57.17.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -389,7 +389,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.16.jar \
+   java -cp target/lift-simulator-0.57.17.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -434,7 +434,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.16.jar \
+java -cp target/lift-simulator-0.57.17.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -526,7 +526,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.16.jar \
+java -cp target/lift-simulator-0.57.17.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,7 +17,7 @@ This is the frontend admin application for the Lift Simulator system. It provide
 - Managing simulation runs through decomposed filter, table, pagination, and action-modal components, including multi-select bulk cancellation for active runs and bulk deletion for completed runs
 - Monitoring system health
 - Running simulations through decomposed setup, run-status, and results panels shared with run detail views
-- Maintaining scenarios and lift-system versions through decomposed page sections for easier UI maintenance
+- Maintaining scenarios and lift-system versions through decomposed page sections whose local UI state stays with the owning component or hook for easier maintenance
 
 For the overall project setup (backend, database, and Quick Start), see the [root README](../README.md). Backend REST API conventions (auth, RBAC, rate limits, error shape) live in [docs/API.md](../docs/API.md), and the always-current endpoint reference is the generated Swagger UI at `/api/v1/swagger-ui.html`.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.16",
+  "version": "0.57.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.16",
+      "version": "0.57.17",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.16",
+  "version": "0.57.17",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/frontend/src/components/scenarios/ScenarioTemplateSection.jsx
+++ b/frontend/src/components/scenarios/ScenarioTemplateSection.jsx
@@ -1,6 +1,13 @@
 // @ts-check
+import { useState } from 'react';
 
-function ScenarioTemplateSection({ floorRange, selectedVersionId, templates, selectedTemplateKey, onApplyTemplate }) {
+function ScenarioTemplateSection({ floorRange, selectedVersionId, templates, onApplyTemplate }) {
+  const [selectedTemplateKey, setSelectedTemplateKey] = useState('');
+
+  const handleApplyTemplate = (templateKey) => {
+    setSelectedTemplateKey(templateKey);
+    onApplyTemplate(templateKey);
+  };
   return (
     <div className="form-section">
       <h3>Quick Start Templates</h3>
@@ -8,7 +15,7 @@ function ScenarioTemplateSection({ floorRange, selectedVersionId, templates, sel
       {!selectedVersionId && <p className="help-text" style={{ marginBottom: '1rem', color: '#e67e22' }}>Select a lift system and version above to ensure templates use valid floor ranges.</p>}
       <div className="template-grid">
         {Object.entries(templates).map(([key, template]) => (
-          <button key={key} type="button" className={`template-card${selectedTemplateKey === key ? ' is-selected' : ''}`} onClick={() => onApplyTemplate(key)} aria-pressed={selectedTemplateKey === key}>
+          <button key={key} type="button" className={`template-card${selectedTemplateKey === key ? ' is-selected' : ''}`} onClick={() => handleApplyTemplate(key)} aria-pressed={selectedTemplateKey === key}>
             <div className="template-name">{template.name}</div>
             <div className="template-description">{template.description}</div>
           </button>

--- a/frontend/src/components/simulation-runs/SimulatorRunSetup.jsx
+++ b/frontend/src/components/simulation-runs/SimulatorRunSetup.jsx
@@ -1,67 +1,102 @@
-function SimulatorRunSetup({
-  loading,
-  formError,
-  systems,
-  publishedVersions,
-  filteredScenarios,
-  selectedSystemId,
-  selectedVersionNumber,
-  selectedScenarioId,
-  seed,
-  isStarting,
-  isRunActive,
-  selectedSystem,
-  selectedVersion,
-  selectedScenario,
-  onSystemChange,
-  onVersionChange,
-  onScenarioChange,
-  onSeedChange,
-  onStartRun,
-}) {
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { liftSystemsApi } from '../../api/liftSystemsApi';
+import { handleApiError } from '../../utils/errorHandlers';
+
+function SimulatorRunSetup({ loading, formError, setFormError, systems, scenarios, isStarting, isRunActive, onStartRun }) {
+  const [searchParams] = useSearchParams();
+  const [versions, setVersions] = useState([]);
+  const [selectedSystemId, setSelectedSystemId] = useState(searchParams.get('systemId') || '');
+  const [selectedVersionNumber, setSelectedVersionNumber] = useState(searchParams.get('versionNumber') || '');
+  const [selectedScenarioId, setSelectedScenarioId] = useState('');
+  const [seed, setSeed] = useState('');
+  const hasSyncedFromParams = useRef(false);
+
+  useEffect(() => {
+    if (hasSyncedFromParams.current) return;
+    const incomingSystemId = searchParams.get('systemId');
+    const incomingVersionNumber = searchParams.get('versionNumber');
+    if (incomingSystemId) setSelectedSystemId(incomingSystemId);
+    if (incomingVersionNumber) setSelectedVersionNumber(incomingVersionNumber);
+    hasSyncedFromParams.current = true;
+  }, [searchParams]);
+
+  const loadVersions = useCallback(async () => {
+    if (!selectedSystemId) {
+      setVersions([]);
+      setSelectedVersionNumber('');
+      return;
+    }
+    try {
+      const response = await liftSystemsApi.getVersions(selectedSystemId);
+      setVersions(response.data);
+      setFormError(null);
+    } catch (err) {
+      handleApiError(err, setFormError, 'Failed to load versions');
+    }
+  }, [selectedSystemId, setFormError]);
+
+  useEffect(() => { loadVersions(); }, [loadVersions]);
+
+  const publishedVersions = useMemo(() => versions.filter((version) => version.status === 'PUBLISHED'), [versions]);
+
+  useEffect(() => {
+    if (!publishedVersions.length) {
+      setSelectedVersionNumber('');
+      return;
+    }
+    if (selectedVersionNumber) {
+      const match = publishedVersions.find((version) => String(version.versionNumber) === String(selectedVersionNumber));
+      if (!match) setSelectedVersionNumber('');
+      return;
+    }
+    const querySystemId = searchParams.get('systemId');
+    const preferredVersionNumber = searchParams.get('versionNumber');
+    const queryMatchesSelectedSystem = querySystemId && String(querySystemId) === String(selectedSystemId);
+    const resolvedVersion = queryMatchesSelectedSystem && preferredVersionNumber
+      ? publishedVersions.find((version) => String(version.versionNumber) === String(preferredVersionNumber))
+      : null;
+    if (resolvedVersion) setSelectedVersionNumber(String(resolvedVersion.versionNumber));
+  }, [publishedVersions, searchParams, selectedSystemId, selectedVersionNumber]);
+
+  const selectedSystem = systems.find((system) => String(system.id) === String(selectedSystemId));
+  const selectedVersion = publishedVersions.find((version) => String(version.versionNumber) === String(selectedVersionNumber));
+  const filteredScenarios = useMemo(() => {
+    if (!selectedVersionNumber) return [];
+    return scenarios.filter((scenario) => selectedVersion && String(scenario.liftSystemVersionId) === String(selectedVersion.id));
+  }, [scenarios, selectedVersion, selectedVersionNumber]);
+  const selectedScenario = scenarios.find((scenario) => String(scenario.id) === String(selectedScenarioId));
+
+  useEffect(() => {
+    if (selectedScenarioId && selectedVersionNumber) {
+      const isScenarioCompatible = filteredScenarios.some((scenario) => String(scenario.id) === String(selectedScenarioId));
+      if (!isScenarioCompatible) setSelectedScenarioId('');
+    }
+  }, [selectedScenarioId, selectedVersionNumber, filteredScenarios]);
+
+  const handleStart = () => {
+    if (!selectedSystemId || !selectedVersionNumber || !selectedScenarioId) {
+      setFormError('Select a lift system, published version, and scenario to continue.');
+      return;
+    }
+    onStartRun({
+      liftSystemId: Number(selectedSystemId),
+      versionNumber: Number(selectedVersionNumber),
+      scenarioId: Number(selectedScenarioId),
+      seed: seed ? Number(seed) : null,
+    }, { selectedSystem, selectedVersion, selectedScenario });
+  };
+
   return (
     <section className="simulator-card">
       <h3>Run Setup</h3>
       {loading ? <p>Loading options...</p> : formError ? <p className="error">{formError}</p> : (
         <div className="run-setup-grid">
-          <label className="field">
-            <span>Lift System</span>
-            <select value={selectedSystemId} onChange={(event) => onSystemChange(event.target.value)}>
-              <option value="">Select a lift system</option>
-              {systems.map((system) => <option key={system.id} value={system.id}>{system.displayName}</option>)}
-            </select>
-          </label>
-          <label className="field">
-            <span>Published Version</span>
-            <select value={selectedVersionNumber} onChange={(event) => onVersionChange(event.target.value)} disabled={!selectedSystemId || publishedVersions.length === 0}>
-              <option value="">Select a published version</option>
-              {publishedVersions.map((version) => <option key={version.id} value={version.versionNumber}>Version {version.versionNumber}</option>)}
-            </select>
-            {!selectedSystemId && <small>Select a system to view published versions.</small>}
-            {selectedSystemId && publishedVersions.length === 0 && <small className="warning">No published versions available for this system.</small>}
-          </label>
-          <label className="field">
-            <span>Scenario</span>
-            <select value={selectedScenarioId} onChange={(event) => onScenarioChange(event.target.value)} disabled={!selectedVersionNumber || filteredScenarios.length === 0}>
-              <option value="">Select a scenario</option>
-              {filteredScenarios.map((scenario) => <option key={scenario.id} value={scenario.id}>{scenario.name}</option>)}
-            </select>
-            {!selectedVersionNumber && <small>Select a version to view compatible scenarios.</small>}
-            {selectedVersionNumber && filteredScenarios.length === 0 && <small className="warning">No scenarios available for this version. Create one from the Scenarios page.</small>}
-          </label>
-          <label className="field">
-            <span>Optional Seed</span>
-            <input type="number" value={seed} onChange={(event) => onSeedChange(event.target.value)} placeholder="Leave blank for random" />
-          </label>
-          <div className="run-setup-actions">
-            <button className="btn-primary" onClick={onStartRun} disabled={isStarting || isRunActive || !selectedSystemId || !selectedVersionNumber || !selectedScenarioId}>
-              {isStarting ? 'Starting...' : isRunActive ? 'Run in Progress' : 'Start Run'}
-            </button>
-            {selectedSystem && selectedVersion && selectedScenario && (
-              <div className="selection-summary"><strong>Selected:</strong> {selectedSystem.displayName} · Version {selectedVersion.versionNumber} · {selectedScenario.name}</div>
-            )}
-            {isRunActive && <small className="run-in-progress-hint">A simulation run is in progress. Wait for it to complete or cancel it to start a new run.</small>}
-          </div>
+          <label className="field"><span>Lift System</span><select value={selectedSystemId} onChange={(event) => { setSelectedSystemId(event.target.value); setSelectedVersionNumber(''); }}><option value="">Select a lift system</option>{systems.map((system) => <option key={system.id} value={system.id}>{system.displayName}</option>)}</select></label>
+          <label className="field"><span>Published Version</span><select value={selectedVersionNumber} onChange={(event) => setSelectedVersionNumber(event.target.value)} disabled={!selectedSystemId || publishedVersions.length === 0}><option value="">Select a published version</option>{publishedVersions.map((version) => <option key={version.id} value={version.versionNumber}>Version {version.versionNumber}</option>)}</select>{!selectedSystemId && <small>Select a system to view published versions.</small>}{selectedSystemId && publishedVersions.length === 0 && <small className="warning">No published versions available for this system.</small>}</label>
+          <label className="field"><span>Scenario</span><select value={selectedScenarioId} onChange={(event) => setSelectedScenarioId(event.target.value)} disabled={!selectedVersionNumber || filteredScenarios.length === 0}><option value="">Select a scenario</option>{filteredScenarios.map((scenario) => <option key={scenario.id} value={scenario.id}>{scenario.name}</option>)}</select>{!selectedVersionNumber && <small>Select a version to view compatible scenarios.</small>}{selectedVersionNumber && filteredScenarios.length === 0 && <small className="warning">No scenarios available for this version. Create one from the Scenarios page.</small>}</label>
+          <label className="field"><span>Optional Seed</span><input type="number" value={seed} onChange={(event) => setSeed(event.target.value)} placeholder="Leave blank for random" /></label>
+          <div className="run-setup-actions"><button className="btn-primary" onClick={handleStart} disabled={isStarting || isRunActive || !selectedSystemId || !selectedVersionNumber || !selectedScenarioId}>{isStarting ? 'Starting...' : isRunActive ? 'Run in Progress' : 'Start Run'}</button>{selectedSystem && selectedVersion && selectedScenario && (<div className="selection-summary"><strong>Selected:</strong> {selectedSystem.displayName} · Version {selectedVersion.versionNumber} · {selectedScenario.name}</div>)}{isRunActive && <small className="run-in-progress-hint">A simulation run is in progress. Wait for it to complete or cancel it to start a new run.</small>}</div>
         </div>
       )}
     </section>

--- a/frontend/src/hooks/useVersionListControls.jsx
+++ b/frontend/src/hooks/useVersionListControls.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function sortVersions(versions, sortBy, sortOrder) {
+  return [...versions].sort((a, b) => {
+    let comparison = 0;
+    if (sortBy === 'versionNumber') comparison = a.versionNumber - b.versionNumber;
+    else if (sortBy === 'createdAt') comparison = new Date(a.createdAt) - new Date(b.createdAt);
+    else if (sortBy === 'status') {
+      const statusOrder = { ARCHIVED: 1, DRAFT: 2, PUBLISHED: 3 };
+      comparison = statusOrder[a.status] - statusOrder[b.status];
+    }
+    return sortOrder === 'asc' ? comparison : -comparison;
+  });
+}
+
+export function useVersionListControls(versions) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
+  const [sortBy, setSortBy] = useState('versionNumber');
+  const [sortOrder, setSortOrder] = useState('desc');
+  const [statusFilter, setStatusFilter] = useState('ALL');
+  const [versionSearch, setVersionSearch] = useState('');
+
+  const filteredVersions = useMemo(() => {
+    let filtered = [...versions];
+    if (statusFilter !== 'ALL') filtered = filtered.filter((v) => v.status === statusFilter);
+    if (versionSearch.trim()) {
+      const searchTerm = versionSearch.trim();
+      filtered = filtered.filter((v) => v.versionNumber.toString() === searchTerm);
+    }
+    return sortVersions(filtered, sortBy, sortOrder);
+  }, [sortBy, sortOrder, statusFilter, versionSearch, versions]);
+
+  const totalPages = Math.ceil(filteredVersions.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const endIndex = startIndex + itemsPerPage;
+  const paginatedVersions = filteredVersions.slice(startIndex, endIndex);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [statusFilter, versionSearch, sortBy, sortOrder, itemsPerPage]);
+
+  const handlePageChange = (newPage) => {
+    if (newPage >= 1 && newPage <= totalPages) setCurrentPage(newPage);
+  };
+
+  const renderPageNumbers = () => {
+    const pages = [];
+    const maxPagesToShow = 5;
+    let startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
+    let endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
+    if (endPage - startPage < maxPagesToShow - 1) startPage = Math.max(1, endPage - maxPagesToShow + 1);
+    for (let i = startPage; i <= endPage; i++) {
+      pages.push(<button key={i} onClick={() => handlePageChange(i)} className={`page-number ${i === currentPage ? 'active' : ''}`}>{i}</button>);
+    }
+    return pages;
+  };
+
+  return {
+    controls: { versionSearch, setVersionSearch, statusFilter, setStatusFilter, sortBy, setSortBy, sortOrder, setSortOrder, itemsPerPage, setItemsPerPage },
+    filteredVersions,
+    paginatedVersions,
+    pagination: { totalPages, currentPage, startIndex, endIndex, handlePageChange, renderPageNumbers },
+  };
+}

--- a/frontend/src/pages/LiftSystemDetail.jsx
+++ b/frontend/src/pages/LiftSystemDetail.jsx
@@ -13,6 +13,7 @@ import PaginationControls from '../components/PaginationControls';
 import VersionCard from '../components/liftSystems/VersionCard';
 import VersionsControls from '../components/liftSystems/VersionsControls';
 import { handleApiError } from '../utils/errorHandlers';
+import { useVersionListControls } from '../hooks/useVersionListControls.jsx';
 import {
   getDefaultVersionFormData,
   configToFormData,
@@ -80,14 +81,6 @@ function LiftSystemDetail() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [alertMessage, setAlertMessage] = useState(null);
-
-  // Pagination, sorting, and filtering states
-  const [currentPage, setCurrentPage] = useState(1);
-  const [itemsPerPage, setItemsPerPage] = useState(10);
-  const [sortBy, setSortBy] = useState('versionNumber');
-  const [sortOrder, setSortOrder] = useState('desc');
-  const [statusFilter, setStatusFilter] = useState('ALL');
-  const [versionSearch, setVersionSearch] = useState('');
 
   /**
    * Loads system metadata and all versions from the API.
@@ -330,100 +323,8 @@ function LiftSystemDetail() {
     }
   };
 
-  /**
-   * Filters and sorts versions based on current filter/sort state.
-   * Applies status filter, version number search, and sorting criteria.
-   *
-   * @returns {Array<Object>} Filtered and sorted array of versions
-   */
-  const getFilteredAndSortedVersions = () => {
-    let filtered = [...versions];
-
-    // Apply status filter
-    if (statusFilter !== 'ALL') {
-      filtered = filtered.filter((v) => v.status === statusFilter);
-    }
-
-    // Apply version number search
-    if (versionSearch.trim()) {
-      const searchTerm = versionSearch.trim();
-      filtered = filtered.filter((v) =>
-        v.versionNumber.toString() === searchTerm
-      );
-    }
-
-    // Apply sorting
-    filtered.sort((a, b) => {
-      let comparison = 0;
-
-      if (sortBy === 'versionNumber') {
-        comparison = a.versionNumber - b.versionNumber;
-      } else if (sortBy === 'createdAt') {
-        comparison = new Date(a.createdAt) - new Date(b.createdAt);
-      } else if (sortBy === 'status') {
-        const statusOrder = { ARCHIVED: 1, DRAFT: 2, PUBLISHED: 3 };
-        comparison = statusOrder[a.status] - statusOrder[b.status];
-      }
-
-      return sortOrder === 'asc' ? comparison : -comparison;
-    });
-
-    return filtered;
-  };
-
-  const filteredVersions = getFilteredAndSortedVersions();
-  const totalPages = Math.ceil(filteredVersions.length / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const endIndex = startIndex + itemsPerPage;
-  const paginatedVersions = filteredVersions.slice(startIndex, endIndex);
-
-  // Reset to page 1 when filters change
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [statusFilter, versionSearch, sortBy, sortOrder, itemsPerPage]);
-
-  /**
-   * Handles pagination page changes.
-   * Only updates if the new page is within valid range.
-   *
-   * @param {number} newPage - Target page number (1-indexed)
-   */
-  const handlePageChange = (newPage) => {
-    if (newPage >= 1 && newPage <= totalPages) {
-      setCurrentPage(newPage);
-    }
-  };
-
-  /**
-   * Renders pagination number buttons with smart windowing.
-   * Shows up to 5 page numbers centered around current page.
-   *
-   * @returns {Array<JSX.Element>} Array of page number button elements
-   */
-  const renderPageNumbers = () => {
-    const pages = [];
-    const maxPagesToShow = 5;
-    let startPage = Math.max(1, currentPage - Math.floor(maxPagesToShow / 2));
-    let endPage = Math.min(totalPages, startPage + maxPagesToShow - 1);
-
-    if (endPage - startPage < maxPagesToShow - 1) {
-      startPage = Math.max(1, endPage - maxPagesToShow + 1);
-    }
-
-    for (let i = startPage; i <= endPage; i++) {
-      pages.push(
-        <button
-          key={i}
-          onClick={() => handlePageChange(i)}
-          className={`page-number ${i === currentPage ? 'active' : ''}`}
-        >
-          {i}
-        </button>
-      );
-    }
-
-    return pages;
-  };
+  const { controls: versionControls, filteredVersions, paginatedVersions, pagination } = useVersionListControls(versions);
+  const { totalPages, currentPage, startIndex, endIndex, handlePageChange, renderPageNumbers } = pagination;
 
   if (loading) {
     return <div className="lift-system-detail"><p>Loading...</p></div>;
@@ -476,18 +377,7 @@ function LiftSystemDetail() {
           <div className="empty-state"><p>No versions yet. Create the first version to get started.</p></div>
         ) : (
           <>
-            <VersionsControls
-              versionSearch={versionSearch}
-              setVersionSearch={setVersionSearch}
-              statusFilter={statusFilter}
-              setStatusFilter={setStatusFilter}
-              sortBy={sortBy}
-              setSortBy={setSortBy}
-              sortOrder={sortOrder}
-              setSortOrder={setSortOrder}
-              itemsPerPage={itemsPerPage}
-              setItemsPerPage={setItemsPerPage}
-            />
+            <VersionsControls {...versionControls} />
 
             {filteredVersions.length === 0 ? (
               <div className="empty-state"><p>No versions match your filters.</p></div>

--- a/frontend/src/pages/ScenarioForm.jsx
+++ b/frontend/src/pages/ScenarioForm.jsx
@@ -102,7 +102,6 @@ function ScenarioForm() {
   const [alertMessage, setAlertMessage] = useState(null);
   const [showAdvancedJson, setShowAdvancedJson] = useState(false);
   const [jsonText, setJsonText] = useState('');
-  const [selectedTemplateKey, setSelectedTemplateKey] = useState('');
 
   /**
    * Parses version config to extract floor range.
@@ -285,7 +284,6 @@ function ScenarioForm() {
     const template = SCENARIO_TEMPLATES[templateKey];
     if (!template) return;
 
-    setSelectedTemplateKey(templateKey);
     const json = template.scenarioJson;
     setDurationTicks(json.durationTicks);
 
@@ -566,7 +564,6 @@ function ScenarioForm() {
             floorRange={floorRange}
             selectedVersionId={selectedVersionId}
             templates={SCENARIO_TEMPLATES}
-            selectedTemplateKey={selectedTemplateKey}
             onApplyTemplate={applyTemplate}
           />
         )}

--- a/frontend/src/pages/Simulator.jsx
+++ b/frontend/src/pages/Simulator.jsx
@@ -1,6 +1,6 @@
 // @ts-check
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { liftSystemsApi } from '../api/liftSystemsApi';
 import { scenariosApi } from '../api/scenariosApi';
 import { authHeaders, normalizedApiBaseUrl } from '../api/client';
@@ -15,24 +15,14 @@ import SimulatorRunSetup from '../components/simulation-runs/SimulatorRunSetup';
 import './Simulator.css';
 
 function Simulator() {
-  const [searchParams] = useSearchParams();
   /** @type {import('../types/models').LiftSystem[]} */
   const [systems, setSystems] = useState([]);
-  const [versions, setVersions] = useState([]);
   const [scenarios, setScenarios] = useState([]);
   const [loading, setLoading] = useState(true);
   const [formError, setFormError] = useState(null);
   const [runError, setRunError] = useState(null);
   const [resultsError, setResultsError] = useState(null);
 
-  const [selectedSystemId, setSelectedSystemId] = useState(
-    searchParams.get('systemId') || ''
-  );
-  const [selectedVersionNumber, setSelectedVersionNumber] = useState(
-    searchParams.get('versionNumber') || ''
-  );
-  const [selectedScenarioId, setSelectedScenarioId] = useState('');
-  const [seed, setSeed] = useState('');
   const [runInfo, setRunInfo] = useState(null);
   const [results, setResults] = useState(null);
   const [artefacts, setArtefacts] = useState([]);
@@ -40,7 +30,7 @@ function Simulator() {
   const [isStarting, setIsStarting] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
-  const hasSyncedFromParams = useRef(false);
+  const [runSelection, setRunSelection] = useState({});
 
   useEffect(() => {
     const loadOptions = async () => {
@@ -63,117 +53,8 @@ function Simulator() {
     loadOptions();
   }, []);
 
-  useEffect(() => {
-    if (hasSyncedFromParams.current) {
-      return;
-    }
-
-    const incomingSystemId = searchParams.get('systemId');
-    const incomingVersionNumber = searchParams.get('versionNumber');
-
-    if (incomingSystemId) {
-      setSelectedSystemId(incomingSystemId);
-    }
-
-    if (incomingVersionNumber) {
-      setSelectedVersionNumber(incomingVersionNumber);
-    }
-
-    hasSyncedFromParams.current = true;
-  }, [searchParams]);
-
-  const loadVersions = useCallback(async () => {
-    if (!selectedSystemId) {
-      setVersions([]);
-      setSelectedVersionNumber('');
-      return;
-    }
-
-    try {
-      const response = await liftSystemsApi.getVersions(selectedSystemId);
-      setVersions(response.data);
-      setFormError(null);
-    } catch (err) {
-      handleApiError(err, setFormError, 'Failed to load versions');
-    }
-  }, [selectedSystemId]);
-
-  useEffect(() => {
-    loadVersions();
-  }, [loadVersions]);
-
-  const publishedVersions = useMemo(
-    () => versions.filter((version) => version.status === 'PUBLISHED'),
-    [versions]
-  );
-
-  useEffect(() => {
-    if (!publishedVersions.length) {
-      setSelectedVersionNumber('');
-      return;
-    }
-
-    if (selectedVersionNumber) {
-      const match = publishedVersions.find(
-        (version) => String(version.versionNumber) === String(selectedVersionNumber)
-      );
-      if (!match) {
-        setSelectedVersionNumber('');
-      }
-      return;
-    }
-
-    const querySystemId = searchParams.get('systemId');
-    const preferredVersionNumber = searchParams.get('versionNumber');
-    const queryMatchesSelectedSystem =
-      querySystemId && String(querySystemId) === String(selectedSystemId);
-    const resolvedVersion = queryMatchesSelectedSystem && preferredVersionNumber
-      ? publishedVersions.find(
-          (version) => String(version.versionNumber) === String(preferredVersionNumber)
-        )
-      : null;
-
-    if (resolvedVersion) {
-      setSelectedVersionNumber(String(resolvedVersion.versionNumber));
-    }
-  }, [publishedVersions, searchParams, selectedSystemId, selectedVersionNumber]);
-
-  const selectedSystem = systems.find(
-    (system) => String(system.id) === String(selectedSystemId)
-  );
-  const selectedVersion = publishedVersions.find(
-    (version) => String(version.versionNumber) === String(selectedVersionNumber)
-  );
-
-  // Filter scenarios to only show those belonging to the selected version
-  const filteredScenarios = useMemo(() => {
-    if (!selectedVersionNumber) {
-      return [];
-    }
-    return scenarios.filter(
-      (scenario) => selectedVersion && String(scenario.liftSystemVersionId) === String(selectedVersion.id)
-    );
-  }, [scenarios, selectedVersion, selectedVersionNumber]);
-
-  const selectedScenario = scenarios.find(
-    (scenario) => String(scenario.id) === String(selectedScenarioId)
-  );
-
   const runStatus = runInfo?.status;
   const isTerminal = isTerminalRunStatus(runStatus);
-
-  // Clear selected scenario when version changes if it's not compatible
-  useEffect(() => {
-    if (selectedScenarioId && selectedVersionNumber) {
-      const isScenarioCompatible = filteredScenarios.some(
-        (scenario) => String(scenario.id) === String(selectedScenarioId)
-      );
-      if (!isScenarioCompatible) {
-        setSelectedScenarioId('');
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedVersionNumber, filteredScenarios]);
 
   useRunPolling(() => setNow(Date.now()), {
     intervalMs: 1000,
@@ -230,21 +111,11 @@ function Simulator() {
     loadArtefacts();
   }, [isTerminal, runInfo?.id, runStatus]);
 
-  const handleStartRun = async () => {
-    if (!selectedSystemId || !selectedVersionNumber || !selectedScenarioId) {
-      setFormError('Select a lift system, published version, and scenario to continue.');
-      return;
-    }
-
+  const handleStartRun = async (payload, selection) => {
     try {
       setIsStarting(true);
-      const payload = {
-        liftSystemId: Number(selectedSystemId),
-        versionNumber: Number(selectedVersionNumber),
-        scenarioId: Number(selectedScenarioId),
-        seed: seed ? Number(seed) : null,
-      };
       const response = await simulationRunsApi.createRun(payload);
+      setRunSelection(selection || {});
       setRunInfo(response.data);
       setResults(null);
       setArtefacts([]);
@@ -368,25 +239,11 @@ function Simulator() {
       <SimulatorRunSetup
         loading={loading}
         formError={formError}
+        setFormError={setFormError}
         systems={systems}
-        publishedVersions={publishedVersions}
-        filteredScenarios={filteredScenarios}
-        selectedSystemId={selectedSystemId}
-        selectedVersionNumber={selectedVersionNumber}
-        selectedScenarioId={selectedScenarioId}
-        seed={seed}
+        scenarios={scenarios}
         isStarting={isStarting}
         isRunActive={Boolean(runInfo && !isTerminal)}
-        selectedSystem={selectedSystem}
-        selectedVersion={selectedVersion}
-        selectedScenario={selectedScenario}
-        onSystemChange={(value) => {
-          setSelectedSystemId(value);
-          setSelectedVersionNumber('');
-        }}
-        onVersionChange={setSelectedVersionNumber}
-        onScenarioChange={setSelectedScenarioId}
-        onSeedChange={setSeed}
         onStartRun={handleStartRun}
       />
 
@@ -403,9 +260,9 @@ function Simulator() {
           isCancelling={isCancelling}
           fields={[
             { label: 'Run ID', value: runInfo.id },
-            { label: 'Lift System', value: selectedSystem?.displayName || runInfo.liftSystemId },
-            { label: 'Version', value: selectedVersion ? `Version ${selectedVersion.versionNumber}` : runInfo.versionNumber },
-            { label: 'Scenario', value: selectedScenario?.name || runInfo.scenarioId || '—' },
+            { label: 'Lift System', value: runSelection.selectedSystem?.displayName || runInfo.liftSystemId },
+            { label: 'Version', value: runSelection.selectedVersion ? `Version ${runSelection.selectedVersion.versionNumber}` : runInfo.versionNumber },
+            { label: 'Scenario', value: runSelection.selectedScenario?.name || runInfo.scenarioId || '—' },
             { label: 'Elapsed Time', value: formatRunDuration(elapsedMs) },
             { label: 'Seed', value: runInfo.seed ?? '—' },
           ]}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.16</version>
+    <version>0.57.17</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>


### PR DESCRIPTION
### Motivation
- Reduce top-level page component state by moving UI selection and list controls into the components that own the UI, continuing the Simulator/LiftSystem/Scenario decomposition work.
- Keep `Simulator` responsible for orchestration (data loading and run lifecycle) while letting `SimulatorRunSetup` own the run selection/seed state and version loading.
- Make version list filtering/sorting/pagination reusable and local by extracting it to a hook so `LiftSystemDetail` consumes a compact API.
- Keep Scenario template UI state local to the template component so `ScenarioForm` only applies templates to the form model.

### Description
- Pushed simulator run setup state into a new/modified `SimulatorRunSetup` component (selection of system/version/scenario, published-version loading, seed, and URL preselection handling) and updated `Simulator` to accept a start payload plus selection metadata instead of owning selection state.
- Extracted version list controls into a new hook `useVersionListControls` that exposes `controls`, `filteredVersions`, `paginatedVersions`, and `pagination` results; `LiftSystemDetail` now consumes this hook and passes `VersionsControls` a compact `versionControls` prop and renders `PaginationControls` with the hook pagination output.
- Moved template selection highlight state into `ScenarioTemplateSection` so template selection is local to that component and `ScenarioForm` only receives `onApplyTemplate` events.
- Updated rendering and wiring to preserve behavior and visual output (no UX changes intended), including carrying selected system/version/scenario metadata through to `SimulationRunStatusCard` via a `runSelection` object set at run creation.
- Bumped project/frontend versions to `0.57.17`, added a `0.57.17` changelog entry, and updated `README.md` / `frontend/README.md` text to reflect the refactor and version bump.
- Files added/modified include `frontend/src/hooks/useVersionListControls.jsx`, `frontend/src/components/simulation-runs/SimulatorRunSetup.jsx`, `frontend/src/pages/Simulator.jsx`, `frontend/src/pages/LiftSystemDetail.jsx`, `frontend/src/pages/ScenarioForm.jsx`, `frontend/src/components/scenarios/ScenarioTemplateSection.jsx`, `frontend/package.json`, `frontend/package-lock.json`, `pom.xml`, and docs (`CHANGELOG.md`, `README.md`, `frontend/README.md`).

### Testing
- Ran frontend lint: `npm run lint --prefix frontend` succeeded with no blocking errors.
- Ran frontend unit tests: `npm run test:unit --prefix frontend` (Vitest) executed; all unit tests passed (14 test files, 119 tests) and returned green.
- Built the frontend bundle: `npm run build --prefix frontend` (Vite) succeeded and produced a production build.
- Attempted full Maven package: `mvn -q -DskipTests package` failed in this environment due to an external Maven Central HTTP 403 when resolving the Spring Boot parent POM (environmental network restriction), so the backend packaging step could not be verified here.
- Playwright end-to-end invocation with an invalid flag was attempted (`npm test --prefix frontend -- --run`) and reported an invalid option; the intended E2E suite was not run in that form but unit and build checks cover the refactor's surface changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55a7df51588325b610c96700cbc90a)