### PR TITLE
test: tighten JaCoCo coverage gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ summary is kept under [Earlier history](#earlier-history).
 
 ## [Unreleased]
 
+## [0.57.18] - 2026-07-16
+
+### Changed
+- **JaCoCo package coverage gates**: Replaced the single bundle-only coverage guard with package-level JaCoCo line coverage rules for `engine`, `domain`, `admin.service`, and `scenario`, while retaining the 50% bundle backstop for overall production business logic. Documented the gate design and synchronized package metadata for the 0.57.18 pre-MVP patch release.
+
+
 ## [0.57.17] - 2026-07-14
 
 - **Frontend state ownership refactor**: Pushed simulator run setup selection state into `SimulatorRunSetup`, moved scenario template selection state into `ScenarioTemplateSection`, and extracted lift-system version filtering/sorting/pagination state into `useVersionListControls` so the decomposed components own more local UI state without visual or behavioural changes. Updated README and frontend documentation for the 0.57.17 pre-MVP patch release.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java-based simulation of lift (elevator) controllers with a focus on correctness and design clarity.
 
-Current version: **0.57.17**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
+Current version: **0.57.18**. This project follows [Semantic Versioning](https://semver.org/); see [CHANGELOG.md](CHANGELOG.md) for version history.
 
 ## What is this?
 
@@ -116,12 +116,12 @@ mvn clean package
 Build a deployable Spring Boot JAR that also serves the React admin UI from `/` (activates the Maven `frontend` profile):
 ```bash
 mvn -Pfrontend clean package
-java -jar target/lift-simulator-0.57.17.jar
+java -jar target/lift-simulator-0.57.18.jar
 ```
 
 The `frontend` profile installs Node.js 20.19.0 (for Vite 7 compatibility), runs `npm ci`, builds the Vite bundle, and packages it under `BOOT-INF/classes/static/`. CI uses this profile so downloaded JAR artifacts include the frontend assets. Verify the packaged UI with:
 ```bash
-jar tf target/lift-simulator-0.57.17.jar | grep '^BOOT-INF/classes/static/'
+jar tf target/lift-simulator-0.57.18.jar | grep '^BOOT-INF/classes/static/'
 ```
 
 ## Running the Application
@@ -133,8 +133,8 @@ mvn exec:java -Dexec.mainClass="com.liftsimulator.Main"
 
 Or run the built JAR. The demo selects a controller strategy via command-line arguments:
 ```bash
-java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.Main --help
-java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.Main --strategy=directional-scan
+java -cp target/lift-simulator-0.57.18.jar com.liftsimulator.Main --help
+java -cp target/lift-simulator-0.57.18.jar com.liftsimulator.Main --strategy=directional-scan
 ```
 `--strategy` accepts `nearest-request` (default) or `directional-scan`. The demo runs a pre-configured scenario and prints the simulation state at each tick.
 
@@ -142,7 +142,7 @@ java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.Main --strategy=dir
 Run scripted scenarios with the scenario runner — either the bundled demo or a custom file:
 ```bash
 mvn exec:java -Dexec.mainClass="com.liftsimulator.scenario.ScenarioRunnerMain"
-java -cp target/lift-simulator-0.57.17.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
+java -cp target/lift-simulator-0.57.18.jar com.liftsimulator.scenario.ScenarioRunnerMain path/to/scenario.scenario
 ```
 
 Scenario files are plain text with metadata and tick-based event lines (parsing enforces limits of 1,000,000 ticks and 10,000 events per file); the controller strategy and idle-parking mode are taken from the scenario file. For the scenario file format and metadata keys, see the [CLI run workflows guide](docs/Workflows-and-Troubleshooting.md#cli-usage-unchanged). For simulation engine internals, controller strategy behaviour, out-of-service handling, request modelling, and the lift state machine, see [docs/DEVELOPER-GUIDE.md](docs/DEVELOPER-GUIDE.md).
@@ -159,7 +159,7 @@ mvn test     # tests only
 > [Testcontainers](https://java.testcontainers.org/) and run the real Flyway migrations against it; the only
 > requirement is a running **Docker** daemon. (CI uses its own PostgreSQL service container.)
 
-The suite spans backend unit tests, Spring-context integration tests for the REST APIs and repositories, deterministic controller scenario tests, and Playwright browser E2E tests under `frontend/e2e` (see [ADR-0014](docs/decisions/0014-playwright-e2e-testing.md)). `mvn verify` enforces a minimum **50% line coverage baseline** through JaCoCo for production business logic (report at `target/site/jacoco/index.html`); CI runs the same phase so pull requests fail if the scoped baseline drops. For the full setup — test database, categories, environment variables, and IDE integration — see [docs/TESTING-SETUP.md](docs/TESTING-SETUP.md) and [docs/TESTING-ARCHITECTURE-GUIDE.md](docs/TESTING-ARCHITECTURE-GUIDE.md). For local frontend E2E runs and the Playwright configuration, see [frontend/README.md](frontend/README.md#testing).
+The suite spans backend unit tests, Spring-context integration tests for the REST APIs and repositories, deterministic controller scenario tests, and Playwright browser E2E tests under `frontend/e2e` (see [ADR-0014](docs/decisions/0014-playwright-e2e-testing.md)). `mvn verify` enforces JaCoCo line coverage gates for production business logic: package-level floors for the engine, domain, admin service, and scenario packages, plus a 50% bundle backstop (report at `target/site/jacoco/index.html`); CI runs the same phase so pull requests fail if a scoped baseline drops. For the full setup — test database, categories, environment variables, and IDE integration — see [docs/TESTING-SETUP.md](docs/TESTING-SETUP.md) and [docs/TESTING-ARCHITECTURE-GUIDE.md](docs/TESTING-ARCHITECTURE-GUIDE.md). For local frontend E2E runs and the Playwright configuration, see [frontend/README.md](frontend/README.md#testing).
 
 ## Quality Checks
 
@@ -180,7 +180,7 @@ The backend is configured via YAML files under `src/main/resources/`:
 - `application-dev.yml` — development secrets and database settings (copy from `application-dev.yml.template`)
 - `application-local.yml` — optional local-only overrides such as log paths or ports (copy from `application-local.yml.template`)
 
-No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.17.jar` for production. This prevents a development profile from masking production configuration mistakes.
+No profile is active in the checked-in base configuration, so launches must set `SPRING_PROFILES_ACTIVE` explicitly — for example `SPRING_PROFILES_ACTIVE=dev mvn spring-boot:run` for development, `SPRING_PROFILES_ACTIVE=dev,local` to add local overrides (your `application-local.yml` is git-ignored, so `git pull` will not overwrite it), or `SPRING_PROFILES_ACTIVE=prod java -jar target/lift-simulator-0.57.18.jar` for production. This prevents a development profile from masking production configuration mistakes.
 
 OpenAPI/Swagger access is controlled by `security.openapi.public-access` (`SECURITY_OPENAPI_PUBLIC_ACCESS`). The checked-in base configuration and the code fallback both default to `false`, so `/api/v1/api-docs` and `/api/v1/swagger-ui.html` require ADMIN-role authentication unless an environment or profile override explicitly enables public access. The development template keeps `${SECURITY_OPENAPI_PUBLIC_ACCESS:true}` for local convenience; set `SECURITY_OPENAPI_PUBLIC_ACCESS=false` in any shared or production environment.
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -396,7 +396,7 @@ mvn spring-boot:run -Dspring-boot.run.arguments="--spring.jpa.verify=true"
 Or with the JAR:
 
 ```bash
-java -jar target/lift-simulator-0.57.17.jar --spring.jpa.verify=true
+java -jar target/lift-simulator-0.57.18.jar --spring.jpa.verify=true
 ```
 
 The verification runner will:

--- a/docs/TESTING-ARCHITECTURE-GUIDE.md
+++ b/docs/TESTING-ARCHITECTURE-GUIDE.md
@@ -126,6 +126,23 @@ mvn clean test -Dtest="LiftSystemControllerTest"
     SPRING_DATASOURCE_PASSWORD: liftpassword
 ```
 
+
+## JaCoCo Coverage Gate
+
+`mvn verify` runs the JaCoCo `check` goal after the test suite and fails the build when production business-logic coverage drops below the configured line-coverage floors. Generated or low-signal wiring packages remain excluded from the gate (`Application`/`Main` entry points, Spring `config`, DTOs, entities, repositories, and `package-info`).
+
+The gate intentionally combines focused package rules with a bundle backstop:
+
+| Scope | Line coverage floor | Why it is gated |
+| --- | ---: | --- |
+| `com.liftsimulator.engine` | 75% | Core lift simulation state transitions and controller behaviour should not be masked by unrelated package coverage. |
+| `com.liftsimulator.domain` | 80% | Domain objects encode request and lift invariants that are cheap and valuable to test directly. |
+| `com.liftsimulator.admin.service` | 55% | Admin orchestration, artefact handling, and simulation-run services contain most backend business workflows. |
+| `com.liftsimulator.scenario` | 60% | Scenario parsing and execution support deterministic regression coverage for CLI and simulation flows. |
+| Bundle | 50% | Backstop to prevent overall production business-logic coverage from drifting down outside the named package floors. |
+
+When the check fails, Maven reports the violated JaCoCo rule and package. Open `target/site/jacoco/index.html`, drill into the package named in the failure, and prefer adding focused tests for uncovered branches or edge cases over lowering the threshold. Thresholds should move upward only after measuring a green `mvn verify` run and leaving a small buffer below the measured baseline.
+
 ## Property Resolution Order (Spring Boot)
 
 1. **Environment Variables** (Highest priority in CI/CD)

--- a/docs/Workflows-and-Troubleshooting.md
+++ b/docs/Workflows-and-Troubleshooting.md
@@ -48,7 +48,7 @@ The command-line interface remains **fully backward compatible** with previous v
 Run a simulation using a `.scenario` file:
 
 ```bash
-java -cp target/lift-simulator-0.57.17.jar \
+java -cp target/lift-simulator-0.57.18.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   path/to/scenario.scenario
 ```
@@ -62,12 +62,12 @@ If no scenario file is provided, uses `demo.scenario` from the classpath.
 **Example:**
 ```bash
 # Run with a specific scenario file
-java -cp target/lift-simulator-0.57.17.jar \
+java -cp target/lift-simulator-0.57.18.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   my-test-scenario.scenario
 
 # Run with default demo scenario
-java -cp target/lift-simulator-0.57.17.jar \
+java -cp target/lift-simulator-0.57.18.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain
 ```
 
@@ -111,7 +111,7 @@ Event rows are comma-delimited, and each request carries a unique alias (`p1`, `
 Run a quick demo simulation with built-in configuration:
 
 ```bash
-java -cp target/lift-simulator-0.57.17.jar \
+java -cp target/lift-simulator-0.57.18.jar \
   com.liftsimulator.Main \
   --strategy=directional-scan
 ```
@@ -389,7 +389,7 @@ You can reproduce any UI-driven run using the CLI by downloading the generated i
 
 4. **Run via CLI**
    ```bash
-   java -cp target/lift-simulator-0.57.17.jar \
+   java -cp target/lift-simulator-0.57.18.jar \
      com.liftsimulator.scenario.ScenarioRunnerMain \
      run-42-reproduction.scenario
    ```
@@ -434,7 +434,7 @@ curl -X POST http://localhost:8080/api/batch/generate-input \
 **3. Run the scenario:**
 
 ```bash
-java -cp target/lift-simulator-0.57.17.jar \
+java -cp target/lift-simulator-0.57.18.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   run-42-reproduction.scenario
 ```
@@ -526,7 +526,7 @@ Where `run-123-inputs.json` contains:
 **2. Run via CLI:**
 
 ```bash
-java -cp target/lift-simulator-0.57.17.jar \
+java -cp target/lift-simulator-0.57.18.jar \
   com.liftsimulator.scenario.ScenarioRunnerMain \
   morning-rush-reproduction.scenario
 ```

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lift-simulator-admin",
-  "version": "0.57.17",
+  "version": "0.57.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lift-simulator-admin",
-      "version": "0.57.17",
+      "version": "0.57.18",
       "dependencies": {
         "axios": "^1.18.1",
         "react": "^19.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lift-simulator-admin",
   "private": true,
-  "version": "0.57.17",
+  "version": "0.57.18",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
                                 <rule>
                                     <element>PACKAGE</element>
                                     <includes>
-                                        <include>com/liftsimulator/engine</include>
+                                        <include>com.liftsimulator.engine</include>
                                     </includes>
                                     <limits>
                                         <limit>
@@ -252,7 +252,7 @@
                                 <rule>
                                     <element>PACKAGE</element>
                                     <includes>
-                                        <include>com/liftsimulator/domain</include>
+                                        <include>com.liftsimulator.domain</include>
                                     </includes>
                                     <limits>
                                         <limit>
@@ -265,7 +265,7 @@
                                 <rule>
                                     <element>PACKAGE</element>
                                     <includes>
-                                        <include>com/liftsimulator/admin/service</include>
+                                        <include>com.liftsimulator.admin.service</include>
                                     </includes>
                                     <limits>
                                         <limit>
@@ -278,7 +278,7 @@
                                 <rule>
                                     <element>PACKAGE</element>
                                     <includes>
-                                        <include>com/liftsimulator/scenario</include>
+                                        <include>com.liftsimulator.scenario</include>
                                     </includes>
                                     <limits>
                                         <limit>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.liftsimulator</groupId>
     <artifactId>lift-simulator</artifactId>
-    <version>0.57.17</version>
+    <version>0.57.18</version>
     <packaging>jar</packaging>
 
     <name>Lift Simulator</name>
@@ -236,6 +236,58 @@
                                 <exclude>com/liftsimulator/**/package-info.class</exclude>
                             </excludes>
                             <rules>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <includes>
+                                        <include>com/liftsimulator/engine</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <includes>
+                                        <include>com/liftsimulator/domain</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <includes>
+                                        <include>com/liftsimulator/admin/service</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.55</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                                <rule>
+                                    <element>PACKAGE</element>
+                                    <includes>
+                                        <include>com/liftsimulator/scenario</include>
+                                    </includes>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
                                 <rule>
                                     <element>BUNDLE</element>
                                     <limits>


### PR DESCRIPTION
### Motivation

- Reduce risk of regressions by replacing a coarse bundle-wide 50% JaCoCo gate with focused per-package coverage floors for core backend packages.
- Keep a 50% bundle backstop so overall production-business-logic coverage cannot drift below an acceptable minimum.

### Description

- Replaced the single `BUNDLE`-only JaCoCo `check` rule in `pom.xml` with package-level `PACKAGE` rules for `com/liftsimulator/engine`, `com/liftsimulator/domain`, `com/liftsimulator/admin/service`, and `com/liftsimulator/scenario`, and retained the `BUNDLE` backstop.
- Set the package floors to: `engine` 75%, `domain` 80%, `admin.service` 55%, `scenario` 60%, and `bundle` 50%.
- Bumped project version from `0.57.17` to `0.57.18` and synchronized `README.md`, `frontend/package.json`, and `frontend/package-lock.json` references.
- Documented the new gate and failure-investigation guidance in `docs/TESTING-ARCHITECTURE-GUIDE.md` and added an entry to `CHANGELOG.md`; updated a few CLI/docs jar-version references in `docs/Workflows-and-Troubleshooting.md` and `docs/DEVELOPER-GUIDE.md`.

### Testing

- Verified `pom.xml` parses with `python3` (`xml.etree.ElementTree.parse`) successfully.
- Ran `./scripts/sync-versions.sh --check` to confirm version references were consistent, which passed.
- Attempted `mvn verify` to produce a fresh JaCoCo report, but the build was blocked by an external Maven Central resolution error (HTTP 403 resolving `org.springframework.boot:spring-boot-starter-parent:4.1.0`), so a `target/site/jacoco/` report could not be generated locally.
- Committed changes with commit message `test: tighten jacoco coverage gates`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a583c574ac88325a21def269405961b)